### PR TITLE
3D-Graph, Härtung, 4K-Layout, System-Schutz & Logging

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write|NotebookEdit|Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"$CLAUDE_PROJECT_DIR/scripts/protect-guard.mjs\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,9 @@
 # database backups (local snapshots — see npm run backup)
 /backups
 
+# appearance/config protection lock (local toggle — see npm run protect)
+/.mc-protect
+
 # misc
 .DS_Store
 *.pem

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,9 @@
 # database backups (local snapshots — see npm run backup)
 /backups
 
+# readable log exports (generated — see npm run export-log)
+/exports
+
 # appearance/config protection lock (local toggle — see npm run protect)
 /.mc-protect
 

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -14,6 +14,25 @@ Format pro Eintrag: **Was** · **Warum** · **Dateien**. Neueste oben.
 
 ## 2026-05-22
 
+### Graph: Prompts, echte Farben, isolierte Knoten weg, gedeckelte Detailkarte
+- **Was:** Prompt-Knoten (deine UserPromptSubmit + Claude→Agent-Task-Prompts) mit eigener
+  Farbe/Legende; echtes 3D ohne künstliches Licht (flaches Ambient + Bloom, höhere Auflösung,
+  durchdachte Palette); isolierte Knoten werden entfernt + Zoom-to-fit; Detailkarte mit
+  Maximalhöhe + scrollbaren Lang-Feldern; Befehle nach echtem Programm gruppiert (cd-Präfix
+  übersprungen); Legende aus dem Header nach unten-links verschoben.
+- **Warum:** Nutzer wollte Prompts im Graph (seine + Claudes), schönere/echte 3D-Optik, und
+  der einzelne fremde Session-Knoten („Schreibtisch", 0 Tools/Prompts) trieb die Kamera weit
+  weg. Lange Befehle bliesen die Detailkarte auf. 7 Legenden-Einträge überfüllten den Header.
+- **Dateien:** `src/app/api/graph/route.ts`, `plugins/tool-graph/widget.tsx`.
+- **Ehrliche Grenze:** Claudes *freie* Antworten erfassen die Hooks nicht (kein Hook dafür) —
+  nur Prompts + Aktionen. Visueller Pixel-Test nicht möglich (kein Headless-Browser hier).
+
+### Export-Log + Entscheidungs-Journal
+- **Was:** `npm run export-log` (Prompts/Tools → lesbares Markdown), `DECISIONS.md` (dieses Journal).
+- **Warum:** Nutzer wollte „alle Gedanken/Prompts speichern". Prompts/Tools liegen ohnehin in
+  SQLite; das *Warum* fehlte → Journal. Reasoning kann nicht 1:1 auto-persistiert werden.
+- **Dateien:** `scripts/export-log.mjs`, `DECISIONS.md`, `package.json`.
+
 ### System-Schutz gegen versehentliches Kaputtmachen (Guard-Hook)
 - **Was:** PreToolUse-Hook (`.claude/settings.json` → `scripts/protect-guard.mjs`), der
   Edit/Write/NotebookEdit/Bash-Schreibzugriffe auf Aussehen/Config-Dateien blockt, wenn

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -1,0 +1,89 @@
+# Entscheidungs-Journal · Decision Log
+
+Zweck: festhalten **was** geändert wurde und **warum** — menschenlesbar und für Claude
+schnell parsebar. Ergänzt (nicht ersetzt) die maschinellen Daten:
+
+- **Prompts & Tool-Aufrufe** werden bereits automatisch in `data/mission-control.db`
+  (`events`, `tool_calls`) gespeichert — das ist die Kernfunktion des Dashboards.
+- **Persistentes Claude-Wissen** liegt in `~/.claude/projects/<projekt>/memory/`.
+- Dieses Journal trägt das **Warum** hinter Entscheidungen nach.
+
+Format pro Eintrag: **Was** · **Warum** · **Dateien**. Neueste oben.
+
+---
+
+## 2026-05-22
+
+### System-Schutz gegen versehentliches Kaputtmachen (Guard-Hook)
+- **Was:** PreToolUse-Hook (`.claude/settings.json` → `scripts/protect-guard.mjs`), der
+  Edit/Write/NotebookEdit/Bash-Schreibzugriffe auf Aussehen/Config-Dateien blockt, wenn
+  `.mc-protect` existiert. Toggle: `npm run protect` / `npm run unprotect` (PIN 0000).
+  Standard: AUS.
+- **Warum:** Nutzer wollte verhindern, dass das System (v.a. Farben/Config) — besonders
+  durch Claude in anderen Runs — kaputtgeht. Ein Browser-PIN kann das nicht; Schutz muss
+  auf Claude-Code-Ebene (Hook) sitzen. Lesen bleibt frei, damit normale Arbeit weiterläuft.
+- **Dateien:** `scripts/protect-guard.mjs`, `scripts/protect.mjs`, `.claude/settings.json`,
+  `package.json`, `.gitignore`.
+
+### PIN-View-Lock — gebaut und wieder verworfen
+- **Was:** Erst einen PIN-Lock gebaut, der die *Bedienelemente* (Filter, Vollbild,
+  Graph-Klicks) sperrt; dann komplett entfernt.
+- **Warum:** Missverständnis. Nutzer wollte das *System* vor Änderungen schützen, nicht die
+  *Ansicht* sperren. Die View-Sperre behinderte nur (Vollbild/Klicks gingen nicht mehr) →
+  ersetzt durch den Guard-Hook oben.
+- **Dateien:** (entfernt) `src/components/lock-provider.tsx`, `lock-controls.tsx`.
+
+### Info-Hinweise überall
+- **Was:** Dezente ℹ️ (Hover/Fokus) an jedem Panel + Header; `InfoHint`-Komponente,
+  `Panel` bekam `info`-Prop.
+- **Warum:** Nutzer wünschte kleine, professionelle Erklärungen, was was ist.
+- **Dateien:** `src/components/info-hint.tsx`, `panel.tsx`, alle vier Widgets, `dashboard.tsx`.
+
+### Großbild-/4K-Skalierung, randlos
+- **Was:** Ab 2560px kein Breitenlimit (`max-w-none`), Root-Schrift 20px (QHD) / 24px (4K),
+  größere Panels/Abstände. HD (≤1920px) unverändert.
+- **Warum:** Auf dem 4K-Schirm wirkte alles klein und als Insel mittig; Nutzer musste manuell
+  zoomen. Erst zu zaghaft gedeckelt → dann randlos + kräftiger.
+- **Dateien:** `src/app/globals.css`, `dashboard.tsx`, `plugins/registry.ts`.
+
+### Graph-Labels Claude-first optimiert
+- **Was:** Ziel-Knoten mit explizitem `kind` (file/command/url/pattern), kompakte Labels
+  (Bash nach Programm gruppiert, Dateien als kurzer Pfad, URLs als Host), Farbe/Substantiv/
+  dynamische Legende.
+- **Warum:** Lange, einmalige Kommandozeilen als „Datei"-Knoten waren unleserlich; Labels
+  sollten für Claude schnell parsebar und für Menschen verständlich sein.
+- **Dateien:** `src/app/api/graph/route.ts`, `plugins/tool-graph/widget.tsx`.
+
+### Härtung (Stabilität)
+- **Was:** Error-Boundary pro Widget + `app/error.tsx`/`global-error.tsx`; API-Routen
+  (sessions/graph/events) mit try/catch + sicherem Fallback; SSE-Reconnect mit Backoff +
+  Backlog; Ingest-Body-Limit (413); diverse Guards (NaN, ResizeObserver).
+- **Warum:** Nutzer wollte, dass nichts durch andere Runs kaputtgeht — ein Fehler darf nicht
+  das ganze Dashboard reißen, DB-Hänger nur ein Widget degradieren.
+- **Dateien:** `src/components/error-boundary.tsx`, `app/error.tsx`, `app/global-error.tsx`,
+  `live-provider.tsx`, API-Routen, `lib/format.ts`.
+
+### DB-Backup
+- **Was:** `npm run backup` → konsistenter SQLite-Snapshot nach `backups/` (neueste 14).
+- **Warum:** „Alles speichern" — sichere, wiederherstellbare Kopien, auch bei laufendem Server.
+- **Dateien:** `scripts/backup.mjs`, `package.json`, `.gitignore`.
+
+### 3D-Graph interaktiv + Glühen
+- **Was:** Knoten anklickbar (Kamera-Fokus + Detailkarte), Vollbild-Button, aktive Sessions
+  glühen sanft (UnrealBloom + dezenter Puls), aktive Linien leuchten, inaktive sichtbar gedimmt.
+- **Warum:** Nutzer wollte Klick-für-Details, Vollbild, bessere Darstellung und aufleuchtende
+  aktive Knoten — professionell/dezent.
+- **Dateien:** `plugins/tool-graph/widget.tsx`, `force-graph.tsx`, `api/graph/route.ts`,
+  `three` als Dependency.
+
+### Stale-Sessions (kein ewiges „Wartet")
+- **Was:** Sessions ohne Aktivität seit >30 min (nicht beendet) werden als beendet geführt
+  (`MC_STALE_MINUTES`).
+- **Warum:** Sessions hingen ewig in „Wartet"; `waiting` ist korrekt nach jedem Turn, aber
+  ohne Auto-Idle füllte die Spalte sich endlos.
+- **Dateien:** `api/sessions/route.ts`, `plugins/kanban/widget.tsx`.
+
+### Port-3001-Fix (Ursache „keine Sessions")
+- **Was:** Hooks in `~/.claude/settings.json` von Port 3000 → 3001 umgebogen; `.env` MC_PORT=3001.
+- **Warum:** Dashboard lief auf 3001 (3000 belegt), Hooks sendeten an 3000 → DB blieb leer.
+- **Dateien:** `~/.claude/settings.json` (außerhalb Repo), `.env`.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,31 @@
 
 ---
 
+## Demo
+
+<!--
+  DEMO VIDEOS — placeholders. Drop your two recordings into the `assets/` folder
+  with exactly these names:
+    • assets/dashboard.mp4   ← screen recording of the dashboard
+    • assets/graph-3d.mp4    ← screen recording of the 3D tool graph
+  Format: MP4 (H.264) or WebM, ideally ≤ ~20 MB each. GitHub renders <video>
+  inline once the file exists; the link underneath is the fallback.
+-->
+
+### Dashboard
+
+<video src="assets/dashboard.mp4" controls muted playsinline width="100%"></video>
+
+▶️ [assets/dashboard.mp4](assets/dashboard.mp4) <!-- placeholder — replace with your recording -->
+
+### 3D tool graph
+
+<video src="assets/graph-3d.mp4" controls muted playsinline width="100%"></video>
+
+▶️ [assets/graph-3d.mp4](assets/graph-3d.mp4) <!-- placeholder — replace with your recording -->
+
+---
+
 ## Why
 
 Most attempts at a "Claude dashboard" fail because they ask the LLM to *render* the

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "better-sqlite3": "^12.10.0",
         "ccusage": "^20.0.3",
         "clsx": "^2.1.1",
+        "d3-force-3d": "^3.0.6",
         "lucide-react": "^1.16.0",
         "next": "16.2.6",
         "react": "19.2.4",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "lint": "eslint",
     "seed": "node scripts/seed-demo.mjs",
     "backup": "node scripts/backup.mjs",
+    "protect": "node scripts/protect.mjs lock",
+    "unprotect": "node scripts/protect.mjs unlock",
     "import-history": "node scripts/import-history.mjs",
     "install-hooks": "node scripts/install-hooks.mjs"
   },

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint",
     "seed": "node scripts/seed-demo.mjs",
     "backup": "node scripts/backup.mjs",
+    "export-log": "node scripts/export-log.mjs",
     "protect": "node scripts/protect.mjs lock",
     "unprotect": "node scripts/protect.mjs unlock",
     "import-history": "node scripts/import-history.mjs",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "better-sqlite3": "^12.10.0",
     "ccusage": "^20.0.3",
     "clsx": "^2.1.1",
+    "d3-force-3d": "^3.0.6",
     "lucide-react": "^1.16.0",
     "next": "16.2.6",
     "react": "19.2.4",

--- a/scripts/export-log.mjs
+++ b/scripts/export-log.mjs
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+// Exports the stored prompts + tool calls (the "what") into a readable Markdown
+// transcript, grouped by session, newest session first. The "why" lives in
+// DECISIONS.md; persistent Claude knowledge lives in ~/.claude/.../memory.
+//
+//   npm run export-log
+//
+// Output: exports/log-<timestamp>.md
+
+import Database from "better-sqlite3";
+import { mkdirSync, writeFileSync, existsSync } from "node:fs";
+import path from "node:path";
+
+const src = path.join(process.cwd(), "data", "mission-control.db");
+if (!existsSync(src)) {
+  console.error(`Keine Datenbank gefunden: ${src}\nLäuft das Dashboard schon? (./start.sh)`);
+  process.exit(1);
+}
+
+const outDir = path.join(process.cwd(), "exports");
+mkdirSync(outDir, { recursive: true });
+
+const db = new Database(src, { readonly: true, fileMustExist: true });
+
+const sessions = db
+  .prepare(
+    `SELECT s.*,
+            (SELECT COUNT(*) FROM events e WHERE e.session_id = s.id)     AS ev,
+            (SELECT COUNT(*) FROM tool_calls t WHERE t.session_id = s.id) AS tc
+     FROM sessions s ORDER BY datetime(s.last_seen) DESC LIMIT 200`,
+  )
+  .all();
+
+const eventsFor = db.prepare(
+  `SELECT event_type, tool_name, summary, created_at FROM events WHERE session_id = ? ORDER BY id ASC LIMIT 2000`,
+);
+
+const fullTime = (s) => {
+  if (!s) return "—";
+  const d = new Date(s.replace(" ", "T") + "Z");
+  return Number.isNaN(d.getTime()) ? s : d.toLocaleString("de-DE");
+};
+const clock = (s) => {
+  if (!s) return "--:--:--";
+  const d = new Date(s.replace(" ", "T") + "Z");
+  return Number.isNaN(d.getTime()) ? s : d.toLocaleTimeString("de-DE");
+};
+
+let totalEvents = 0;
+const body = [];
+
+for (const s of sessions) {
+  const evs = eventsFor.all(s.id);
+  totalEvents += evs.length;
+  const title = s.title || `Session ${s.id.slice(0, 8)}`;
+  body.push(`## ${s.project_name || "—"} — ${title}`);
+  body.push(
+    `Status: **${s.status}** · ${fullTime(s.first_seen)} → ${fullTime(s.last_seen)} · ` +
+      `${s.ev} Events, ${s.tc} Tools · ID \`${s.id.slice(0, 12)}\``,
+  );
+  body.push("");
+  for (const e of evs) body.push(`- \`${clock(e.created_at)}\`  ${e.summary || e.event_type}`);
+  if (evs.length === 0) body.push("- _(keine Events)_");
+  body.push("");
+}
+
+const header =
+  `# Claude Mission Control — Log-Export\n\n` +
+  `Erzeugt: ${new Date().toLocaleString("de-DE")} · ${sessions.length} Sessions · ${totalEvents} Events\n\n` +
+  `Quelle: \`data/mission-control.db\` (Prompts + Tool-Aufrufe). Das *Warum* steht in \`DECISIONS.md\`.\n\n---\n`;
+
+const stamp = new Date().toISOString().replace(/[:T]/g, "-").slice(0, 19);
+const outFile = path.join(outDir, `log-${stamp}.md`);
+writeFileSync(outFile, header + "\n" + body.join("\n") + "\n");
+
+console.log(`✓ Export: ${path.relative(process.cwd(), outFile)} (${sessions.length} Sessions, ${totalEvents} Events)`);

--- a/scripts/protect-guard.mjs
+++ b/scripts/protect-guard.mjs
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+// PreToolUse guard for My_Dash. When `.mc-protect` exists in the project root,
+// this BLOCKS Claude from modifying protected appearance/config files — so an
+// automated run can't accidentally break the system's look or build.
+//
+// Default (no .mc-protect) allows everything. Toggle from a terminal:
+//   npm run protect      # turn protection on
+//   npm run unprotect    # turn it off (asks for PIN)
+//
+// Registered as a PreToolUse hook in .claude/settings.json. Exit code 2 = block.
+
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+const root = process.env.CLAUDE_PROJECT_DIR || process.cwd();
+const lockFile = path.join(root, ".mc-protect");
+
+// Fast path: protection off → allow everything.
+if (!existsSync(lockFile)) process.exit(0);
+
+// Protected appearance/config files (relative to project root). Includes the lock
+// file itself so it can't be removed through a blocked tool.
+const PROTECTED = [
+  "src/app/globals.css",
+  "src/app/layout.tsx",
+  "next.config.ts",
+  "postcss.config.mjs",
+  "eslint.config.mjs",
+  "tsconfig.json",
+  "package.json",
+  ".mc-protect",
+];
+const protectedAbs = new Set(PROTECTED.map((p) => path.resolve(root, p)));
+
+let payload = {};
+try {
+  payload = JSON.parse(readFileSync(0, "utf8") || "{}");
+} catch {
+  process.exit(0); // unparseable → don't block
+}
+
+const tool = payload.tool_name;
+const input = payload.tool_input || {};
+
+function deny(rel) {
+  console.error(
+    `🔒 Schutz aktiv: "${rel}" darf nicht geändert werden.\n` +
+      `   Zum Ändern in einem Terminal:  npm run unprotect   (PIN)\n` +
+      `   (Schutz wurde mit  npm run protect  gesetzt.)`,
+  );
+  process.exit(2); // block the tool call
+}
+
+// Direct file tools — exact path check.
+if (tool === "Edit" || tool === "Write" || tool === "NotebookEdit") {
+  const f = input.file_path || input.notebook_path;
+  if (typeof f === "string" && protectedAbs.has(path.resolve(root, f))) {
+    deny(path.relative(root, path.resolve(root, f)));
+  }
+  process.exit(0);
+}
+
+// Bash — block only write-ish commands that name a protected file (reads are fine).
+if (tool === "Bash" && typeof input.command === "string") {
+  const cmd = input.command;
+  const writeish = /(>|\bsed\s+-i|\brm\b|\bmv\b|\bcp\b|\btee\b|\btruncate\b|\bdd\b|\bchmod\b|\bchown\b|\bln\b)/i.test(cmd);
+  if (writeish) {
+    for (const rel of PROTECTED) {
+      if (cmd.includes(rel) || cmd.includes(path.basename(rel))) deny(rel);
+    }
+  }
+}
+
+process.exit(0);

--- a/scripts/protect.mjs
+++ b/scripts/protect.mjs
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+// Toggle the appearance/config protection used by scripts/protect-guard.mjs.
+//
+//   npm run protect          # protection ON  (Claude can't change protected files)
+//   npm run unprotect        # protection OFF (asks for PIN; or pass it: ... 0000)
+//
+// PIN defaults to 0000, override with MC_PIN. This is a local speed-bump against
+// accidental changes — not real security.
+
+import { existsSync, writeFileSync, rmSync } from "node:fs";
+import path from "node:path";
+import readline from "node:readline";
+
+const PIN = (process.env.MC_PIN || "0000").trim();
+const lockFile = path.join(process.cwd(), ".mc-protect");
+const mode = process.argv[2];
+
+function lock() {
+  writeFileSync(lockFile, `protected ${new Date().toISOString()}\n`);
+  console.log("🔒 Schutz AKTIV — geschützte Aussehen/Config-Dateien sind für Claude gesperrt.");
+  console.log("   Ausschalten:  npm run unprotect");
+}
+
+function unlock(pin) {
+  if (pin.trim() !== PIN) {
+    console.error("✗ Falscher PIN.");
+    process.exit(1);
+  }
+  if (existsSync(lockFile)) rmSync(lockFile);
+  console.log("🔓 Schutz AUS — Änderungen sind wieder erlaubt.");
+}
+
+if (mode === "lock") {
+  lock();
+} else if (mode === "unlock") {
+  const provided = process.argv[3];
+  if (provided !== undefined) {
+    unlock(provided);
+  } else {
+    const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+    rl.question("PIN: ", (answer) => {
+      rl.close();
+      unlock(answer);
+    });
+  }
+} else {
+  console.log("Nutzung: npm run protect  |  npm run unprotect");
+  process.exit(1);
+}

--- a/src/app/api/graph/route.ts
+++ b/src/app/api/graph/route.ts
@@ -5,7 +5,7 @@ import type { SessionRow, ToolCallRow } from "@/lib/types";
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-type NodeType = "session" | "tool" | "file";
+type NodeType = "session" | "tool" | "file" | "prompt";
 // Refines a "file"-type (resource) node so both Claude and humans see what it is.
 type TargetKind = "file" | "command" | "url" | "pattern";
 
@@ -23,6 +23,8 @@ interface GraphNode {
     path?: string;
     kind?: TargetKind;
     calls?: number;
+    role?: "user" | "agent";
+    text?: string;
   };
 }
 interface GraphLink {
@@ -30,17 +32,28 @@ interface GraphLink {
   target: string;
 }
 
+function clip(s: string, n: number): string {
+  const t = s.replace(/\s+/g, " ").trim();
+  return t.length > n ? t.slice(0, n - 1) + "…" : t;
+}
+
 // Executable of a shell command: drop leading VAR=val and take the first program
 // of the first sub-command. Grouping by this collapses noisy unique commands
 // (e.g. dozens of `grep …`) into one readable "grep" node.
 function programName(cmd: string): string {
-  const head = cmd.trim().split(/&&|\|\||[;|]/)[0].trim();
-  const tokens = head.split(/\s+/).filter(Boolean);
-  let i = 0;
-  while (i < tokens.length && /^[A-Za-z_][A-Za-z0-9_]*=/.test(tokens[i])) i++;
-  let prog = tokens[i] ?? head;
-  if (prog.includes("/")) prog = prog.split("/").pop() || prog;
-  return prog || "cmd";
+  // Scan sub-commands; skip pure `cd`/env prefixes so the *real* program groups
+  // (e.g. `cd x && node …` → "node", not "cd").
+  const parts = cmd.trim().split(/&&|\|\||[;|]/);
+  for (const part of parts) {
+    const tokens = part.trim().split(/\s+/).filter(Boolean);
+    let i = 0;
+    while (i < tokens.length && /^[A-Za-z_][A-Za-z0-9_]*=/.test(tokens[i])) i++;
+    let prog = tokens[i];
+    if (!prog || prog === "cd") continue;
+    if (prog.includes("/")) prog = prog.split("/").pop() || prog;
+    return prog;
+  }
+  return "cd";
 }
 
 // Turn a raw tool target into a compact, unambiguous node: stable key (so equal
@@ -117,6 +130,10 @@ function buildGraph(req: Request) {
   };
 
   const callsForSession = db.prepare(`SELECT * FROM tool_calls WHERE session_id = ? LIMIT 300`);
+  const promptsForSession = db.prepare(
+    `SELECT summary, payload_json, created_at FROM events
+     WHERE session_id = ? AND event_type = 'UserPromptSubmit' ORDER BY id ASC LIMIT 60`,
+  );
 
   for (const s of sessions) {
     const sid = `s:${s.id}`;
@@ -133,13 +150,49 @@ function buildGraph(req: Request) {
       },
     });
 
+    // Your prompts: each UserPromptSubmit becomes a prompt node hanging off the session.
+    const prompts = promptsForSession.all(s.id) as {
+      summary: string | null;
+      payload_json: string;
+      created_at: string;
+    }[];
+    prompts.forEach((p, i) => {
+      let text = "";
+      try {
+        const pj = JSON.parse(p.payload_json);
+        if (typeof pj.prompt === "string") text = pj.prompt;
+      } catch {
+        /* fall back to summary */
+      }
+      if (!text && p.summary) text = p.summary.replace(/^Prompt:\s*/, "");
+      text = text.trim();
+      if (!text) return;
+      const pid = `p:${s.id}:${i}`;
+      nodes.set(pid, {
+        id: pid,
+        label: clip(text, 32),
+        type: "prompt",
+        val: 1.8,
+        meta: { role: "user", text: clip(text, 500), lastSeen: p.created_at },
+      });
+      addLink(sid, pid);
+    });
+
     const calls = callsForSession.all(s.id) as ToolCallRow[];
     for (const c of calls) {
       const tid = `t:${s.id}:${c.tool_name}`;
       addNode(tid, c.tool_name, "tool");
       addLink(sid, tid);
 
-      if (c.target) {
+      if (!c.target) continue;
+
+      // Claude's prompts to sub-agents (Task) become prompt nodes; other targets
+      // become file/command/url/pattern resources.
+      if (c.tool_name === "Task") {
+        const pid = `pa:${s.id}:${c.target}`;
+        addNode(pid, clip(c.target, 32), "prompt", { role: "agent", text: clip(c.target, 500) });
+        addLink(tid, pid);
+      } else {
         const d = describeTarget(c.tool_name, c.target);
         addNode(d.key, d.label, "file", { path: d.full, kind: d.kind });
         addLink(tid, d.key);
@@ -147,5 +200,14 @@ function buildGraph(req: Request) {
     }
   }
 
-  return NextResponse.json({ nodes: [...nodes.values()], links });
+  // Drop isolated nodes (e.g. a session with no tools/prompts). A lone, unconnected
+  // node only pushes the force layout — and the initial camera — far out.
+  const linked = new Set<string>();
+  for (const l of links) {
+    linked.add(l.source);
+    linked.add(l.target);
+  }
+  const connected = [...nodes.values()].filter((n) => linked.has(n.id));
+
+  return NextResponse.json({ nodes: connected, links });
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -73,3 +73,55 @@ body {
 .mc-live-dot {
   animation: mc-pulse 1.6s ease-in-out infinite;
 }
+
+/* ── Entrance + micro-interaction animations ─────────────────────────────── */
+@keyframes mc-fade-up {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+@keyframes mc-fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+@keyframes mc-stream-in {
+  from {
+    opacity: 0;
+    transform: translateX(-7px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+.mc-fade-up {
+  animation: mc-fade-up 0.5s cubic-bezier(0.22, 0.61, 0.36, 1) both;
+}
+.mc-fade-in {
+  animation: mc-fade-in 0.4s ease both;
+}
+.mc-stream-in {
+  animation: mc-stream-in 0.35s ease both;
+}
+
+/* Respect users who prefer less motion. */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  .mc-live-dot,
+  .mc-fade-up,
+  .mc-fade-in,
+  .mc-stream-in {
+    animation: none !important;
+    transition: none !important;
+  }
+}

--- a/src/components/dashboard.tsx
+++ b/src/components/dashboard.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { Radar, Activity } from "lucide-react";
+import { Activity } from "lucide-react";
 import { LiveProvider, useLive } from "@/components/live-provider";
+import { RadarLogo } from "@/components/radar-logo";
 import { InfoHint } from "@/components/info-hint";
 import { WidgetErrorBoundary } from "@/components/error-boundary";
 import { widgets } from "@/plugins/registry";
@@ -47,8 +48,8 @@ function Header() {
   return (
     <header className="mc-fade-in flex items-center justify-between rounded-xl border border-panel-border bg-panel/60 px-5 py-3 backdrop-blur">
       <div className="flex items-center gap-3">
-        <span className="flex h-9 w-9 items-center justify-center rounded-lg bg-accent/15 text-accent ring-1 ring-accent/20">
-          <Radar className="h-5 w-5" />
+        <span className="flex h-9 w-9 items-center justify-center rounded-lg bg-background/80 ring-1 ring-accent/25">
+          <RadarLogo className="h-7 w-7" />
         </span>
         <div>
           <h1 className="flex items-center gap-1.5 text-base font-semibold tracking-tight">

--- a/src/components/dashboard.tsx
+++ b/src/components/dashboard.tsx
@@ -4,11 +4,14 @@ import { useEffect, useState } from "react";
 import { Activity } from "lucide-react";
 import { LiveProvider, useLive } from "@/components/live-provider";
 import { RadarLogo } from "@/components/radar-logo";
+import { LangToggle } from "@/components/lang-toggle";
 import { InfoHint } from "@/components/info-hint";
 import { WidgetErrorBoundary } from "@/components/error-boundary";
+import { useT } from "@/lib/i18n";
 import { widgets } from "@/plugins/registry";
 
 export function Dashboard() {
+  const { t } = useT();
   return (
     <LiveProvider>
       <div className="mx-auto flex min-h-screen max-w-[1600px] flex-col gap-4 p-4 sm:p-6 min-[2560px]:max-w-none min-[2560px]:gap-6 min-[2560px]:p-8 min-[3840px]:gap-8 min-[3840px]:p-12">
@@ -20,15 +23,19 @@ export function Dashboard() {
               className={`mc-fade-up ${w.span} ${w.height}`}
               style={{ animationDelay: `${i * 80}ms` }}
             >
-              <WidgetErrorBoundary label={w.title}>
+              <WidgetErrorBoundary
+                label={w.title}
+                couldNotLoad={t("error.couldNotLoad")}
+                genericText={t("error.generic")}
+                retryLabel={t("common.retry")}
+              >
                 <w.component />
               </WidgetErrorBoundary>
             </div>
           ))}
         </div>
         <footer className="pt-2 text-center text-[11px] text-muted/60">
-          read-only · Daten aus Hooks → SQLite → UI · die KI rendert dieses Dashboard nie ·{" "}
-          <span className="text-muted">by Belkis Aslani</span>
+          {t("footer.text")} · <span className="text-muted">by Belkis Aslani</span>
         </footer>
       </div>
     </LiveProvider>
@@ -37,14 +44,15 @@ export function Dashboard() {
 
 function Header() {
   const { connected, events } = useLive();
+  const { t, lang } = useT();
   const [clock, setClock] = useState("");
 
   useEffect(() => {
-    const update = () => setClock(new Date().toLocaleTimeString("de-DE"));
+    const update = () => setClock(new Date().toLocaleTimeString(lang === "en" ? "en-GB" : "de-DE"));
     update();
-    const t = setInterval(update, 1000);
-    return () => clearInterval(t);
-  }, []);
+    const id = setInterval(update, 1000);
+    return () => clearInterval(id);
+  }, [lang]);
 
   return (
     <header className="mc-fade-in flex items-center justify-between rounded-xl border border-panel-border bg-panel/60 px-5 py-3 backdrop-blur">
@@ -55,19 +63,18 @@ function Header() {
         <div>
           <h1 className="flex items-center gap-1.5 text-base font-semibold tracking-tight">
             Claude Mission Control
-            <InfoHint
-              align="left"
-              text="Read-only Live-Dashboard für Claude Code: Aktivität aus Hooks → SQLite → UI. Die KI rendert dieses Dashboard nie — die Ansicht kann nichts am System ändern."
-            />
+            <InfoHint align="left" text={t("header.info")} />
           </h1>
-          <p className="text-[11px] text-muted">Live-Observability für Claude Code</p>
+          <p className="text-[11px] text-muted">{t("header.subtitle")}</p>
         </div>
       </div>
       <div className="flex items-center gap-2 text-xs text-muted sm:gap-2.5">
+        <LangToggle />
         <span className="hidden font-mono tabular-nums sm:inline">{clock}</span>
         <span className="hidden items-center gap-1 rounded-full border border-panel-border bg-background/40 px-2.5 py-1 tabular-nums sm:flex">
           <Activity className="h-3 w-3 text-accent" />
           {events.length}
+          <InfoHint text={t("header.eventsInfo")} align="right" />
         </span>
         <span
           className={`flex items-center gap-1.5 rounded-full border px-2.5 py-1 transition-colors ${
@@ -79,7 +86,7 @@ function Header() {
           <span
             className={`mc-live-dot h-2 w-2 rounded-full ${connected ? "bg-emerald-400" : "bg-red-500"}`}
           />
-          {connected ? "verbunden" : "getrennt"}
+          {connected ? t("header.connected") : t("header.disconnected")}
         </span>
       </div>
     </header>

--- a/src/components/dashboard.tsx
+++ b/src/components/dashboard.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { Radar } from "lucide-react";
+import { Radar, Activity } from "lucide-react";
 import { LiveProvider, useLive } from "@/components/live-provider";
 import { InfoHint } from "@/components/info-hint";
 import { WidgetErrorBoundary } from "@/components/error-boundary";
@@ -13,8 +13,12 @@ export function Dashboard() {
       <div className="mx-auto flex min-h-screen max-w-[1600px] flex-col gap-4 p-4 sm:p-6 min-[2560px]:max-w-none min-[2560px]:gap-6 min-[2560px]:p-8 min-[3840px]:gap-8 min-[3840px]:p-12">
         <Header />
         <div className="grid grid-cols-1 gap-4 min-[2560px]:gap-6 min-[3840px]:gap-8 lg:grid-cols-6">
-          {widgets.map((w) => (
-            <div key={w.id} className={`${w.span} ${w.height}`}>
+          {widgets.map((w, i) => (
+            <div
+              key={w.id}
+              className={`mc-fade-up ${w.span} ${w.height}`}
+              style={{ animationDelay: `${i * 80}ms` }}
+            >
               <WidgetErrorBoundary label={w.title}>
                 <w.component />
               </WidgetErrorBoundary>
@@ -41,9 +45,9 @@ function Header() {
   }, []);
 
   return (
-    <header className="flex items-center justify-between rounded-xl border border-panel-border bg-panel/60 px-5 py-3 backdrop-blur">
+    <header className="mc-fade-in flex items-center justify-between rounded-xl border border-panel-border bg-panel/60 px-5 py-3 backdrop-blur">
       <div className="flex items-center gap-3">
-        <span className="flex h-9 w-9 items-center justify-center rounded-lg bg-accent/15 text-accent">
+        <span className="flex h-9 w-9 items-center justify-center rounded-lg bg-accent/15 text-accent ring-1 ring-accent/20">
           <Radar className="h-5 w-5" />
         </span>
         <div>
@@ -57,10 +61,19 @@ function Header() {
           <p className="text-[11px] text-muted">Live-Observability für Claude Code</p>
         </div>
       </div>
-      <div className="flex items-center gap-4 text-xs text-muted">
-        <span className="hidden font-mono sm:inline">{clock}</span>
-        <span className="hidden sm:inline">{events.length} Events</span>
-        <span className="flex items-center gap-1.5">
+      <div className="flex items-center gap-2 text-xs text-muted sm:gap-2.5">
+        <span className="hidden font-mono tabular-nums sm:inline">{clock}</span>
+        <span className="hidden items-center gap-1 rounded-full border border-panel-border bg-background/40 px-2.5 py-1 tabular-nums sm:flex">
+          <Activity className="h-3 w-3 text-accent" />
+          {events.length}
+        </span>
+        <span
+          className={`flex items-center gap-1.5 rounded-full border px-2.5 py-1 transition-colors ${
+            connected
+              ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-400"
+              : "border-red-500/30 bg-red-500/10 text-red-400"
+          }`}
+        >
           <span
             className={`mc-live-dot h-2 w-2 rounded-full ${connected ? "bg-emerald-400" : "bg-red-500"}`}
           />

--- a/src/components/dashboard.tsx
+++ b/src/components/dashboard.tsx
@@ -27,7 +27,8 @@ export function Dashboard() {
           ))}
         </div>
         <footer className="pt-2 text-center text-[11px] text-muted/60">
-          read-only · Daten aus Hooks → SQLite → UI · die KI rendert dieses Dashboard nie
+          read-only · Daten aus Hooks → SQLite → UI · die KI rendert dieses Dashboard nie ·{" "}
+          <span className="text-muted">by Belkis Aslani</span>
         </footer>
       </div>
     </LiveProvider>

--- a/src/components/error-boundary.tsx
+++ b/src/components/error-boundary.tsx
@@ -7,6 +7,10 @@ interface Props {
   children: ReactNode;
   /** Shown in the fallback so the user knows which panel failed. */
   label?: string;
+  /** Translated strings (this is a class component → can't use the i18n hook). */
+  couldNotLoad?: string;
+  genericText?: string;
+  retryLabel?: string;
 }
 interface State {
   error: Error | null;
@@ -34,14 +38,16 @@ export class WidgetErrorBoundary extends Component<Props, State> {
         <div className="flex h-full flex-col items-center justify-center gap-2 rounded-xl border border-panel-border bg-panel/80 p-6 text-center text-sm text-muted">
           <AlertTriangle className="h-6 w-6 text-amber-400/80" />
           <p className="text-foreground">
-            {this.props.label ? `„${this.props.label}" konnte nicht geladen werden.` : "Widget-Fehler."}
+            {this.props.label
+              ? `${this.props.label} — ${this.props.couldNotLoad ?? "konnte nicht geladen werden."}`
+              : (this.props.genericText ?? "Widget-Fehler.")}
           </p>
           <p className="max-w-[90%] break-words text-[11px] text-muted/70">{this.state.error.message}</p>
           <button
             onClick={this.reset}
             className="mt-1 rounded-md border border-panel-border px-3 py-1 text-xs text-foreground transition-colors hover:border-accent/50"
           >
-            Erneut versuchen
+            {this.props.retryLabel ?? "Erneut versuchen"}
           </button>
         </div>
       );

--- a/src/components/lang-toggle.tsx
+++ b/src/components/lang-toggle.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { useT, type Lang } from "@/lib/i18n";
+
+// Compact, professional DE/EN segmented switch for the header.
+export function LangToggle() {
+  const { lang, setLang } = useT();
+  return (
+    <div
+      className="flex items-center overflow-hidden rounded-full border border-panel-border bg-background/40 text-[11px] font-medium"
+      role="group"
+      aria-label="Language"
+    >
+      {(["de", "en"] as Lang[]).map((l) => (
+        <button
+          key={l}
+          onClick={() => setLang(l)}
+          aria-pressed={lang === l}
+          className={`px-2 py-1 uppercase tracking-wide transition-colors ${
+            lang === l ? "bg-accent/20 text-accent" : "text-muted hover:text-foreground"
+          }`}
+        >
+          {l}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/components/panel.tsx
+++ b/src/components/panel.tsx
@@ -20,7 +20,7 @@ export function Panel({
   return (
     <section
       className={cn(
-        "flex h-full min-h-0 flex-col overflow-hidden rounded-xl border border-panel-border bg-panel/80 shadow-lg shadow-black/30 backdrop-blur",
+        "flex h-full min-h-0 flex-col overflow-hidden rounded-xl border border-panel-border bg-panel/80 shadow-lg shadow-black/30 backdrop-blur transition-colors duration-300 hover:border-accent/20",
         className,
       )}
     >

--- a/src/components/radar-logo.tsx
+++ b/src/components/radar-logo.tsx
@@ -1,0 +1,58 @@
+// Animated radar mark — the same sweep as the README logo (assets/logo.svg):
+// a sector rotating 360° every 4s plus two blips that flash as it passes.
+// Pure SMIL SVG, so it animates without any JS.
+export function RadarLogo({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 96 96" className={className} aria-hidden="true">
+      <defs>
+        <linearGradient id="mc-radar-sweep" x1="0" y1="0" x2="1" y2="1">
+          <stop offset="0" stopColor="#4f8cff" stopOpacity="0.85" />
+          <stop offset="1" stopColor="#4f8cff" stopOpacity="0" />
+        </linearGradient>
+      </defs>
+
+      {/* rings + crosshair */}
+      <g fill="none" stroke="#4f8cff">
+        <circle cx="48" cy="48" r="46" strokeOpacity="0.2" />
+        <circle cx="48" cy="48" r="31" strokeOpacity="0.3" />
+        <circle cx="48" cy="48" r="16" strokeOpacity="0.42" />
+        <line x1="48" y1="2" x2="48" y2="94" strokeOpacity="0.12" />
+        <line x1="2" y1="48" x2="94" y2="48" strokeOpacity="0.12" />
+      </g>
+
+      {/* rotating sweep */}
+      <g>
+        <path d="M48 48 L48 2 A46 46 0 0 1 80.5 15.5 Z" fill="url(#mc-radar-sweep)" />
+        <line x1="48" y1="48" x2="48" y2="2" stroke="#9bbcff" strokeWidth="2" strokeOpacity="0.9" />
+        <animateTransform
+          attributeName="transform"
+          type="rotate"
+          from="0 48 48"
+          to="360 48 48"
+          dur="4s"
+          repeatCount="indefinite"
+        />
+      </g>
+
+      {/* blips */}
+      <circle cx="68" cy="26" r="3" fill="#9bbcff">
+        <animate
+          attributeName="opacity"
+          values="0;1;1;0"
+          dur="4s"
+          keyTimes="0;0.15;0.4;0.55"
+          repeatCount="indefinite"
+        />
+      </circle>
+      <circle cx="34" cy="66" r="2.5" fill="#9bbcff">
+        <animate
+          attributeName="opacity"
+          values="0;0;1;1;0"
+          dur="4s"
+          keyTimes="0;0.5;0.65;0.85;1"
+          repeatCount="indefinite"
+        />
+      </circle>
+    </svg>
+  );
+}

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -8,18 +8,18 @@ export function parseDbTime(s: string | null | undefined): Date | null {
   return Number.isNaN(d.getTime()) ? null : d;
 }
 
-export function relativeTime(s: string | null | undefined): string {
+export function relativeTime(s: string | null | undefined, lang: "de" | "en" = "de"): string {
   const d = parseDbTime(s);
   if (!d) return "—";
   const secs = Math.max(0, Math.round((Date.now() - d.getTime()) / 1000));
-  if (secs < 5) return "gerade eben";
-  if (secs < 60) return `vor ${secs}s`;
+  if (secs < 5) return lang === "en" ? "just now" : "gerade eben";
+  const ago = (n: number, u: string) => (lang === "en" ? `${n}${u} ago` : `vor ${n}${u}`);
+  if (secs < 60) return ago(secs, "s");
   const mins = Math.round(secs / 60);
-  if (mins < 60) return `vor ${mins}m`;
+  if (mins < 60) return ago(mins, "m");
   const hrs = Math.round(mins / 60);
-  if (hrs < 24) return `vor ${hrs}h`;
-  const days = Math.round(hrs / 24);
-  return `vor ${days}d`;
+  if (hrs < 24) return ago(hrs, "h");
+  return ago(Math.round(hrs / 24), "d");
 }
 
 export function formatCompact(n: number): string {

--- a/src/lib/i18n.tsx
+++ b/src/lib/i18n.tsx
@@ -1,0 +1,212 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+
+// Lightweight i18n: a flat dictionary + a hook backed by an external store over
+// localStorage (hydration-safe, default German). No provider needed — every
+// useT() consumer subscribes to language changes directly.
+export type Lang = "de" | "en";
+const KEY = "mc-lang";
+const listeners = new Set<() => void>();
+
+function readLang(): Lang {
+  try {
+    return localStorage.getItem(KEY) === "en" ? "en" : "de";
+  } catch {
+    return "de";
+  }
+}
+
+function writeLang(l: Lang) {
+  try {
+    localStorage.setItem(KEY, l);
+  } catch {
+    /* storage unavailable */
+  }
+  listeners.forEach((fn) => fn());
+}
+
+function subscribe(cb: () => void) {
+  listeners.add(cb);
+  window.addEventListener("storage", cb);
+  return () => {
+    listeners.delete(cb);
+    window.removeEventListener("storage", cb);
+  };
+}
+
+const DE: Record<string, string> = {
+  "header.subtitle": "Live-Observability für Claude Code",
+  "header.info":
+    "Read-only Live-Dashboard für Claude Code: Aktivität aus Hooks → SQLite → UI. Die KI rendert dieses Dashboard nie — die Ansicht kann nichts am System ändern.",
+  "header.connected": "verbunden",
+  "header.disconnected": "getrennt",
+  "header.eventsInfo":
+    "Events im Live-Puffer dieses Browsers (zuletzt empfangene, max. 300) — kein Gesamtzähler. Die Zahl wächst mit neuen Events und startet beim Neuladen frisch aus den letzten ~100.",
+  "footer.text": "read-only · Daten aus Hooks → SQLite → UI · die KI rendert dieses Dashboard nie",
+
+  "common.allProjects": "Alle Projekte",
+  "common.close": "Schließen",
+  "common.retry": "Erneut versuchen",
+
+  "status.active": "Aktiv",
+  "status.waiting": "Wartet",
+  "status.ended": "Beendet",
+
+  "kanban.title": "Sessions",
+  "kanban.info":
+    "Alle Claude-Code-Sessions nach Status: Aktiv (arbeitet gerade), Wartet (auf deine Eingabe), Beendet. Inaktive Sessions werden nach 30 min automatisch als beendet geführt. Filter rechts nach Projekt.",
+  "kanban.empty": "leer",
+  "kanban.stale": "inaktiv — automatisch beendet",
+  "kanban.sessionFallback": "Session",
+
+  "stream.title": "Live Stream",
+  "stream.info":
+    "Live-Strom aller Hook-Events in Echtzeit (neueste oben): Session-Start/-Ende, Prompts, Tool-Aufrufe und Stops. Speist sich per SSE aus den Claude-Code-Hooks.",
+  "stream.live": "live",
+  "stream.emptyTitle": "Noch keine Events.",
+  "stream.emptyPre": "Starte eine Claude-Code-Session oder führe ",
+  "stream.emptyPost": " aus.",
+
+  "tokens.title": "Tokens & Kosten",
+  "tokens.info":
+    "Tägliche Token-Nutzung und Kosten aus ccusage. Rechts umschaltbar zwischen Tokens (Input/Output/Cache) und Kosten in € (aus USD über EUR_PER_USD umgerechnet).",
+  "tokens.modeTokens": "Tokens",
+  "tokens.modeCost": "Kosten",
+  "tokens.tok": "tok",
+  "tokens.emptyNone": "Noch keine Nutzungsdaten von ccusage.",
+  "tokens.emptyUnavailable": "ccusage nicht verfügbar (offline oder keine Claude-Daten gefunden).",
+  "tokens.cost": "Kosten",
+  "tokens.input": "Input",
+  "tokens.output": "Output",
+  "tokens.cache": "Cache",
+
+  "graph.title": "Tool-Graph (3D)",
+  "graph.info":
+    "Beziehungen Session → Tool → Ziel (Datei, Befehl, URL, Muster). Gleiche Ziele über Sessions hinweg teilen sich einen Knoten. Aktive Sessions leuchten. Knoten anklicken für Details, Vollbild oben rechts.",
+  "graph.fullscreen": "Vollbild",
+  "graph.shrink": "Verkleinern",
+  "graph.shrinkTitle": "Verkleinern (Esc)",
+  "graph.empty": "Noch keine Tool-Aufrufe.",
+  "graph.kind.session": "Session",
+  "graph.kind.prompt": "Prompt",
+  "graph.kind.tool": "Tool",
+  "graph.kind.file": "Datei",
+  "graph.kind.command": "Befehl",
+  "graph.kind.url": "URL",
+  "graph.kind.pattern": "Muster",
+  "graph.project": "Projekt",
+  "graph.status": "Status",
+  "graph.lastActivity": "Letzte Aktivität",
+  "graph.id": "ID",
+  "graph.prompts": "Prompts",
+  "graph.toolsConnected": "Tools verbunden",
+  "graph.calls": "Aufrufe",
+  "graph.targetsTouched": "Ziele berührt",
+  "graph.program": "Programm",
+  "graph.example": "Beispiel",
+  "graph.fromTools": "Von Tools",
+  "graph.address": "Adresse",
+  "graph.pattern": "Muster",
+  "graph.path": "Pfad",
+  "graph.fromToolsTouched": "Von Tools berührt",
+  "graph.from": "Von",
+  "graph.fromYou": "Du",
+  "graph.fromAgent": "Claude → Agent",
+  "graph.time": "Zeit",
+
+  "error.couldNotLoad": "konnte nicht geladen werden.",
+  "error.generic": "Widget-Fehler.",
+};
+
+const EN: Record<string, string> = {
+  "header.subtitle": "Live observability for Claude Code",
+  "header.info":
+    "Read-only live dashboard for Claude Code: activity from hooks → SQLite → UI. The AI never renders this dashboard — the view can't change anything in the system.",
+  "header.connected": "connected",
+  "header.disconnected": "disconnected",
+  "header.eventsInfo":
+    "Events in this browser's live buffer (most recent, max 300) — not a total counter. It grows with new events and re-seeds from the latest ~100 on reload.",
+  "footer.text": "read-only · data from hooks → SQLite → UI · the AI never renders this dashboard",
+
+  "common.allProjects": "All projects",
+  "common.close": "Close",
+  "common.retry": "Retry",
+
+  "status.active": "Active",
+  "status.waiting": "Waiting",
+  "status.ended": "Ended",
+
+  "kanban.title": "Sessions",
+  "kanban.info":
+    "All Claude Code sessions by status: Active (working now), Waiting (for your input), Ended. Inactive sessions are auto-ended after 30 min. Filter by project on the right.",
+  "kanban.empty": "empty",
+  "kanban.stale": "inactive — auto-ended",
+  "kanban.sessionFallback": "Session",
+
+  "stream.title": "Live Stream",
+  "stream.info":
+    "Live stream of all hook events in real time (newest on top): session start/end, prompts, tool calls and stops. Fed via SSE from the Claude Code hooks.",
+  "stream.live": "live",
+  "stream.emptyTitle": "No events yet.",
+  "stream.emptyPre": "Start a Claude Code session or run ",
+  "stream.emptyPost": ".",
+
+  "tokens.title": "Tokens & Cost",
+  "tokens.info":
+    "Daily token usage and cost from ccusage. Toggle on the right between tokens (input/output/cache) and cost in € (converted from USD via EUR_PER_USD).",
+  "tokens.modeTokens": "Tokens",
+  "tokens.modeCost": "Cost",
+  "tokens.tok": "tok",
+  "tokens.emptyNone": "No usage data from ccusage yet.",
+  "tokens.emptyUnavailable": "ccusage unavailable (offline or no Claude data found).",
+  "tokens.cost": "Cost",
+  "tokens.input": "Input",
+  "tokens.output": "Output",
+  "tokens.cache": "Cache",
+
+  "graph.title": "Tool Graph (3D)",
+  "graph.info":
+    "Relationships session → tool → target (file, command, URL, pattern). Equal targets across sessions share a node. Active sessions glow. Click a node for details; fullscreen top-right.",
+  "graph.fullscreen": "Fullscreen",
+  "graph.shrink": "Shrink",
+  "graph.shrinkTitle": "Shrink (Esc)",
+  "graph.empty": "No tool calls yet.",
+  "graph.kind.session": "Session",
+  "graph.kind.prompt": "Prompt",
+  "graph.kind.tool": "Tool",
+  "graph.kind.file": "File",
+  "graph.kind.command": "Command",
+  "graph.kind.url": "URL",
+  "graph.kind.pattern": "Pattern",
+  "graph.project": "Project",
+  "graph.status": "Status",
+  "graph.lastActivity": "Last activity",
+  "graph.id": "ID",
+  "graph.prompts": "Prompts",
+  "graph.toolsConnected": "Tools connected",
+  "graph.calls": "Calls",
+  "graph.targetsTouched": "Targets touched",
+  "graph.program": "Program",
+  "graph.example": "Example",
+  "graph.fromTools": "From tools",
+  "graph.address": "Address",
+  "graph.pattern": "Pattern",
+  "graph.path": "Path",
+  "graph.fromToolsTouched": "Touched by tools",
+  "graph.from": "From",
+  "graph.fromYou": "You",
+  "graph.fromAgent": "Claude → agent",
+  "graph.time": "Time",
+
+  "error.couldNotLoad": "couldn’t load.",
+  "error.generic": "Widget error.",
+};
+
+const T: Record<Lang, Record<string, string>> = { de: DE, en: EN };
+
+export function useT() {
+  const lang = useSyncExternalStore(subscribe, readLang, () => "de" as Lang);
+  const t = (key: string) => T[lang][key] ?? DE[key] ?? key;
+  return { lang, t, setLang: writeLang };
+}

--- a/src/plugins/kanban/widget.tsx
+++ b/src/plugins/kanban/widget.tsx
@@ -75,7 +75,9 @@ export function Kanban() {
                   <span className={`h-2 w-2 rounded-full ${meta.dot}`} />
                   {meta.label}
                 </span>
-                <span className="text-xs text-muted">{items.length}</span>
+                <span className="rounded-full bg-background/60 px-1.5 py-0.5 text-[11px] tabular-nums text-muted">
+                  {items.length}
+                </span>
               </div>
               <div className="flex min-h-0 flex-1 flex-col gap-2 overflow-auto px-2 pb-2">
                 {items.map((s) => (
@@ -95,7 +97,7 @@ export function Kanban() {
 
 function Card({ s }: { s: SessionCard }) {
   return (
-    <div className="rounded-lg border border-panel-border bg-background/60 p-2.5 transition-colors hover:border-accent/50">
+    <div className="mc-fade-in rounded-lg border border-panel-border bg-background/60 p-2.5 transition-all duration-200 hover:-translate-y-0.5 hover:border-accent/50 hover:shadow-md hover:shadow-black/20">
       <p className="line-clamp-2 text-sm text-foreground">
         {s.title || `Session ${s.id.slice(0, 8)}`}
       </p>

--- a/src/plugins/kanban/widget.tsx
+++ b/src/plugins/kanban/widget.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState } from "react";
 import { KanbanSquare, Folder, Hammer, Radio } from "lucide-react";
 import { Panel } from "@/components/panel";
 import { useLive } from "@/components/live-provider";
+import { useT } from "@/lib/i18n";
 import { relativeTime, STATUS_META } from "@/lib/format";
 import type { SessionRow, SessionStatus } from "@/lib/types";
 
@@ -13,6 +14,7 @@ const COLUMNS: SessionStatus[] = ["active", "waiting", "ended"];
 
 export function Kanban() {
   const { tick } = useLive();
+  const { t } = useT();
   const [sessions, setSessions] = useState<SessionCard[]>([]);
   const [project, setProject] = useState<string>("all");
 
@@ -46,16 +48,16 @@ export function Kanban() {
 
   return (
     <Panel
-      title="Sessions"
+      title={t("kanban.title")}
       icon={<KanbanSquare className="h-4 w-4 text-accent" />}
-      info="Alle Claude-Code-Sessions nach Status: Aktiv (arbeitet gerade), Wartet (auf deine Eingabe), Beendet. Inaktive Sessions werden nach 30 min automatisch als beendet geführt. Filter rechts nach Projekt."
+      info={t("kanban.info")}
       right={
         <select
           value={project}
           onChange={(e) => setProject(e.target.value)}
           className="rounded-md border border-panel-border bg-background px-2 py-1 text-xs text-foreground outline-none focus:border-accent"
         >
-          <option value="all">Alle Projekte</option>
+          <option value="all">{t("common.allProjects")}</option>
           {projects.map((p) => (
             <option key={p} value={p}>
               {p}
@@ -73,7 +75,7 @@ export function Kanban() {
               <div className="flex items-center justify-between px-3 py-2">
                 <span className={`flex items-center gap-1.5 text-xs font-semibold ${meta.text}`}>
                   <span className={`h-2 w-2 rounded-full ${meta.dot}`} />
-                  {meta.label}
+                  {t(`status.${status}`)}
                 </span>
                 <span className="rounded-full bg-background/60 px-1.5 py-0.5 text-[11px] tabular-nums text-muted">
                   {items.length}
@@ -84,7 +86,7 @@ export function Kanban() {
                   <Card key={s.id} s={s} />
                 ))}
                 {items.length === 0 && (
-                  <p className="px-1 py-3 text-center text-[11px] text-muted/60">leer</p>
+                  <p className="px-1 py-3 text-center text-[11px] text-muted/60">{t("kanban.empty")}</p>
                 )}
               </div>
             </div>
@@ -96,14 +98,15 @@ export function Kanban() {
 }
 
 function Card({ s }: { s: SessionCard }) {
+  const { t, lang } = useT();
   return (
     <div className="mc-fade-in rounded-lg border border-panel-border bg-background/60 p-2.5 transition-all duration-200 hover:-translate-y-0.5 hover:border-accent/50 hover:shadow-md hover:shadow-black/20">
       <p className="line-clamp-2 text-sm text-foreground">
-        {s.title || `Session ${s.id.slice(0, 8)}`}
+        {s.title || `${t("kanban.sessionFallback")} ${s.id.slice(0, 8)}`}
       </p>
       {s.stale && (
         <span className="mt-1 inline-block rounded bg-zinc-500/15 px-1.5 py-0.5 text-[10px] text-zinc-400">
-          inaktiv — automatisch beendet
+          {t("kanban.stale")}
         </span>
       )}
       <div className="mt-1.5 flex items-center gap-2 text-[11px] text-muted">
@@ -125,7 +128,7 @@ function Card({ s }: { s: SessionCard }) {
             {s.tool_count}
           </span>
         </span>
-        <span>{relativeTime(s.last_seen)}</span>
+        <span>{relativeTime(s.last_seen, lang)}</span>
       </div>
     </div>
   );

--- a/src/plugins/live-stream/widget.tsx
+++ b/src/plugins/live-stream/widget.tsx
@@ -16,6 +16,7 @@ import {
 } from "lucide-react";
 import { Panel } from "@/components/panel";
 import { useLive } from "@/components/live-provider";
+import { useT } from "@/lib/i18n";
 import { eventKind, KIND_COLOR, relativeTime, type EventKind } from "@/lib/format";
 
 const ICONS: Record<EventKind, LucideIcon> = {
@@ -33,6 +34,7 @@ const ICONS: Record<EventKind, LucideIcon> = {
 
 export function LiveStream() {
   const { events, connected } = useLive();
+  const { t, lang } = useT();
   const [, setNow] = useState(0);
 
   // Re-render periodically so relative timestamps stay fresh.
@@ -43,15 +45,15 @@ export function LiveStream() {
 
   return (
     <Panel
-      title="Live Stream"
+      title={t("stream.title")}
       icon={<Activity className="h-4 w-4 text-accent" />}
-      info="Live-Strom aller Hook-Events in Echtzeit (neueste oben): Session-Start/-Ende, Prompts, Tool-Aufrufe und Stops. Speist sich per SSE aus den Claude-Code-Hooks."
+      info={t("stream.info")}
       right={
         <span className="flex items-center gap-1.5 text-xs text-muted">
           <span
             className={`mc-live-dot h-2 w-2 rounded-full ${connected ? "bg-emerald-400" : "bg-red-500"}`}
           />
-          {connected ? "live" : "getrennt"}
+          {connected ? t("stream.live") : t("header.disconnected")}
         </span>
       }
     >
@@ -75,7 +77,7 @@ export function LiveStream() {
                   </p>
                 </div>
                 <span className="shrink-0 whitespace-nowrap text-[11px] text-muted">
-                  {relativeTime(e.created_at)}
+                  {relativeTime(e.created_at, lang)}
                 </span>
               </li>
             );
@@ -87,12 +89,15 @@ export function LiveStream() {
 }
 
 function Empty() {
+  const { t } = useT();
   return (
     <div className="flex h-full flex-col items-center justify-center gap-2 p-6 text-center text-sm text-muted">
       <Activity className="h-6 w-6 opacity-50" />
-      <p>Noch keine Events.</p>
+      <p>{t("stream.emptyTitle")}</p>
       <p className="text-xs">
-        Starte eine Claude-Code-Session oder führe <code className="text-accent">npm run seed</code> aus.
+        {t("stream.emptyPre")}
+        <code className="text-accent">npm run seed</code>
+        {t("stream.emptyPost")}
       </p>
     </div>
   );

--- a/src/plugins/live-stream/widget.tsx
+++ b/src/plugins/live-stream/widget.tsx
@@ -63,7 +63,10 @@ export function LiveStream() {
             const kind = eventKind(e.event_type);
             const Icon = ICONS[kind];
             return (
-              <li key={e.id} className="flex items-start gap-2.5 px-4 py-2 hover:bg-white/[0.02]">
+              <li
+                key={e.id}
+                className="mc-stream-in flex items-start gap-2.5 px-4 py-2 transition-colors hover:bg-white/[0.03]"
+              >
                 <Icon className={`mt-0.5 h-4 w-4 shrink-0 ${KIND_COLOR[kind]}`} />
                 <div className="min-w-0 flex-1">
                   <p className="truncate text-sm text-foreground">{e.summary ?? e.event_type}</p>

--- a/src/plugins/token-chart/widget.tsx
+++ b/src/plugins/token-chart/widget.tsx
@@ -14,12 +14,14 @@ import {
 } from "recharts";
 import { Coins } from "lucide-react";
 import { Panel } from "@/components/panel";
+import { useT } from "@/lib/i18n";
 import type { UsageReport } from "@/lib/ccusage";
 import { formatCompact, formatMoney } from "@/lib/format";
 
 type Mode = "tokens" | "cost";
 
 export function TokenChart() {
+  const { t } = useT();
   const [usage, setUsage] = useState<UsageReport | null>(null);
   const [mode, setMode] = useState<Mode>("tokens");
 
@@ -50,14 +52,15 @@ export function TokenChart() {
 
   return (
     <Panel
-      title="Tokens & Kosten"
+      title={t("tokens.title")}
       icon={<Coins className="h-4 w-4 text-accent" />}
-      info="Tägliche Token-Nutzung und Kosten aus ccusage. Rechts umschaltbar zwischen Tokens (Input/Output/Cache) und Kosten in € (aus USD über EUR_PER_USD umgerechnet)."
+      info={t("tokens.info")}
       right={
         <div className="flex items-center gap-2">
           {usage?.totals && (
             <span className="text-xs text-muted">
-              {formatMoney(usage.totals.costEur, "EUR")} · {formatCompact(usage.totals.totalTokens)} tok
+              {formatMoney(usage.totals.costEur, "EUR")} · {formatCompact(usage.totals.totalTokens)}{" "}
+              {t("tokens.tok")}
             </span>
           )}
           <div className="flex rounded-md border border-panel-border text-xs">
@@ -67,7 +70,7 @@ export function TokenChart() {
                 onClick={() => setMode(m)}
                 className={`px-2 py-1 ${mode === m ? "bg-accent/20 text-accent" : "text-muted hover:text-foreground"}`}
               >
-                {m === "tokens" ? "Tokens" : "Kosten"}
+                {m === "tokens" ? t("tokens.modeTokens") : t("tokens.modeCost")}
               </button>
             ))}
           </div>
@@ -106,7 +109,7 @@ export function TokenChart() {
                 />
                 <Tooltip
                   contentStyle={tooltipStyle}
-                  formatter={(value, name) => [formatCompact(Number(value)), labelFor(String(name))]}
+                  formatter={(value, name) => [formatCompact(Number(value)), t(`tokens.${String(name)}`)]}
                 />
                 <Area type="monotone" dataKey="cache" stackId="1" stroke="#a78bfa" fill="url(#gCache)" />
                 <Area type="monotone" dataKey="input" stackId="1" stroke="#38bdf8" fill="url(#gIn)" />
@@ -125,7 +128,7 @@ export function TokenChart() {
                 />
                 <Tooltip
                   contentStyle={tooltipStyle}
-                  formatter={(value) => [formatMoney(Number(value), "EUR"), "Kosten"]}
+                  formatter={(value) => [formatMoney(Number(value), "EUR"), t("tokens.cost")]}
                 />
                 <Bar dataKey="cost" fill="#4f8cff" radius={[4, 4, 0, 0]} />
               </BarChart>
@@ -144,22 +147,12 @@ const tooltipStyle = {
   fontSize: 12,
 } as const;
 
-function labelFor(key: string): string {
-  if (key === "input") return "Input";
-  if (key === "output") return "Output";
-  if (key === "cache") return "Cache";
-  return key;
-}
-
 function Empty({ available }: { available: boolean }) {
+  const { t } = useT();
   return (
     <div className="flex h-full flex-col items-center justify-center gap-2 p-6 text-center text-sm text-muted">
       <Coins className="h-6 w-6 opacity-50" />
-      {available ? (
-        <p>Noch keine Nutzungsdaten von ccusage.</p>
-      ) : (
-        <p>ccusage nicht verfügbar (offline oder keine Claude-Daten gefunden).</p>
-      )}
+      <p>{available ? t("tokens.emptyNone") : t("tokens.emptyUnavailable")}</p>
     </div>
   );
 }

--- a/src/plugins/tool-graph/widget.tsx
+++ b/src/plugins/tool-graph/widget.tsx
@@ -6,6 +6,7 @@ import { forceCollide } from "d3-force-3d";
 import { Boxes, Maximize2, Minimize2, X } from "lucide-react";
 import { Panel } from "@/components/panel";
 import { useLive } from "@/components/live-provider";
+import { useT } from "@/lib/i18n";
 import { relativeTime, STATUS_META } from "@/lib/format";
 
 // Wrapper preserves the imperative ref through next/dynamic (camera + bloom composer).
@@ -55,21 +56,12 @@ const KIND_COLOR: Record<string, string> = {
   url: "#34e0f5", // cyan   — URLs
   pattern: "#aab6cc", // slate  — patterns/queries
 };
-const KIND_NOUN: Record<string, string> = {
-  session: "Session",
-  prompt: "Prompt",
-  tool: "Tool",
-  file: "Datei",
-  command: "Befehl",
-  url: "URL",
-  pattern: "Muster",
-};
 const KIND_ORDER = ["session", "prompt", "tool", "file", "command", "url", "pattern"] as const;
 const SELECTED = "#f1f5f9";
 
 const nodeKey = (n: GraphNode): string => (n.type === "file" ? n.meta?.kind ?? "file" : n.type);
 const baseColor = (n: GraphNode): string => KIND_COLOR[nodeKey(n)] ?? KIND_COLOR.file;
-const noun = (n: GraphNode): string => KIND_NOUN[nodeKey(n)] ?? "Datei";
+const noun = (n: GraphNode, t: (k: string) => string): string => t(`graph.kind.${nodeKey(n)}`);
 
 const endId = (e: string | GraphNode): string => (typeof e === "object" ? e.id : e);
 
@@ -81,6 +73,7 @@ function dim(hex: string, f: number): string {
 
 export function ToolGraph() {
   const { tick } = useLive();
+  const { t } = useT();
   const [data, setData] = useState<GraphData>({ nodes: [], links: [] });
   const [selected, setSelected] = useState<GraphNode | null>(null);
   const [maximized, setMaximized] = useState(false);
@@ -363,23 +356,23 @@ export function ToolGraph() {
   // Only show legend entries for kinds actually present in the current graph.
   const legend = useMemo(() => {
     const present = new Set(data.nodes.map((n) => nodeKey(n)));
-    return KIND_ORDER.filter((k) => present.has(k)).map((k) => ({ c: KIND_COLOR[k], t: KIND_NOUN[k] }));
-  }, [data.nodes]);
+    return KIND_ORDER.filter((k) => present.has(k)).map((k) => ({ c: KIND_COLOR[k], label: t(`graph.kind.${k}`) }));
+  }, [data.nodes, t]);
 
   return (
     <div className={maximized ? "fixed inset-0 z-50 bg-background p-3 sm:p-4" : "h-full"}>
       <Panel
-        title="Tool-Graph (3D)"
+        title={t("graph.title")}
         icon={<Boxes className="h-4 w-4 text-accent" />}
-        info="Beziehungen Session → Tool → Ziel (Datei, Befehl, URL, Muster). Gleiche Ziele über Sessions hinweg teilen sich einen Knoten. Aktive Sessions leuchten. Knoten anklicken für Details, Vollbild oben rechts."
+        info={t("graph.info")}
         right={
           <button
             onClick={() => setMaximized((m) => !m)}
-            title={maximized ? "Verkleinern (Esc)" : "Vollbild"}
+            title={maximized ? t("graph.shrinkTitle") : t("graph.fullscreen")}
             className="flex items-center gap-1 rounded-md border border-panel-border px-2 py-1 text-[11px] text-muted transition-colors hover:border-accent/50 hover:text-foreground"
           >
             {maximized ? <Minimize2 className="h-3.5 w-3.5" /> : <Maximize2 className="h-3.5 w-3.5" />}
-            <span className="hidden sm:inline">{maximized ? "Verkleinern" : "Vollbild"}</span>
+            <span className="hidden sm:inline">{maximized ? t("graph.shrink") : t("graph.fullscreen")}</span>
           </button>
         }
       >
@@ -387,7 +380,7 @@ export function ToolGraph() {
           {data.nodes.length === 0 ? (
             <div className="flex h-full flex-col items-center justify-center gap-2 p-6 text-center text-sm text-muted">
               <Boxes className="h-6 w-6 opacity-50" />
-              <p>Noch keine Tool-Aufrufe.</p>
+              <p>{t("graph.empty")}</p>
             </div>
           ) : dims.w > 0 ? (
             <>
@@ -400,7 +393,7 @@ export function ToolGraph() {
                 showNavInfo={false}
                 nodeLabel={(n: object) => {
                   const g = n as GraphNode;
-                  return `<div style="font:12px sans-serif;color:#e5e7eb">${noun(g)}: ${g.label}</div>`;
+                  return `<div style="font:12px sans-serif;color:#e5e7eb">${noun(g, t)}: ${g.label}</div>`;
                 }}
                 nodeVal={(n: object) => (n as GraphNode).val}
                 nodeColor={(n: object) => {
@@ -448,9 +441,9 @@ export function ToolGraph() {
               {selected && <DetailCard node={selected} neighbours={neighbours} onClose={() => setSelected(null)} />}
               <div className="pointer-events-none absolute bottom-2 left-3 flex max-w-[78%] flex-wrap gap-x-2.5 gap-y-1 text-[10px] text-muted/80">
                 {legend.map((l) => (
-                  <span key={l.t} className="flex items-center gap-1">
+                  <span key={l.label} className="flex items-center gap-1">
                     <span className="h-2 w-2 rounded-full" style={{ background: l.c }} />
-                    {l.t}
+                    {l.label}
                   </span>
                 ))}
               </div>
@@ -471,15 +464,16 @@ function DetailCard({
   neighbours: { session: number; prompt: number; tool: number; file: number };
   onClose: () => void;
 }) {
+  const { t, lang } = useT();
   const meta = node.meta ?? {};
   return (
     <div className="absolute right-3 top-3 flex max-h-[calc(100%-1.5rem)] w-64 max-w-[80%] flex-col overflow-hidden rounded-lg border border-panel-border bg-panel/95 p-3 text-xs shadow-xl shadow-black/40 backdrop-blur">
       <div className="mb-2 flex items-start justify-between gap-2">
         <div className="flex items-center gap-1.5">
           <span className="h-2.5 w-2.5 rounded-full" style={{ background: baseColor(node) }} />
-          <span className="font-semibold text-foreground">{noun(node)}</span>
+          <span className="font-semibold text-foreground">{noun(node, t)}</span>
         </div>
-        <button onClick={onClose} className="text-muted hover:text-foreground" title="Schließen">
+        <button onClick={onClose} className="text-muted hover:text-foreground" title={t("common.close")}>
           <X className="h-3.5 w-3.5" />
         </button>
       </div>
@@ -490,25 +484,25 @@ function DetailCard({
         <dl className="space-y-1 text-muted">
         {node.type === "session" && (
           <>
-            <Row k="Projekt" v={meta.project ?? "—"} />
+            <Row k={t("graph.project")} v={meta.project ?? "—"} />
             <Row
-              k="Status"
+              k={t("graph.status")}
               v={
                 <span className={STATUS_META[meta.status ?? ""]?.text ?? ""}>
-                  {STATUS_META[meta.status ?? ""]?.label ?? meta.status ?? "—"}
+                  {meta.status ? t(`status.${meta.status}`) : "—"}
                 </span>
               }
             />
-            <Row k="Letzte Aktivität" v={relativeTime(meta.lastSeen)} />
-            <Row k="ID" v={<span className="font-mono">{(meta.sessionId ?? node.id).slice(0, 12)}</span>} />
-            <Row k="Prompts" v={String(neighbours.prompt)} />
-            <Row k="Tools verbunden" v={String(neighbours.tool)} />
+            <Row k={t("graph.lastActivity")} v={relativeTime(meta.lastSeen, lang)} />
+            <Row k={t("graph.id")} v={<span className="font-mono">{(meta.sessionId ?? node.id).slice(0, 12)}</span>} />
+            <Row k={t("graph.prompts")} v={String(neighbours.prompt)} />
+            <Row k={t("graph.toolsConnected")} v={String(neighbours.tool)} />
           </>
         )}
         {node.type === "tool" && (
           <>
-            <Row k="Aufrufe" v={String(node.val)} />
-            <Row k="Ziele berührt" v={String(neighbours.file)} />
+            <Row k={t("graph.calls")} v={String(node.val)} />
+            <Row k={t("graph.targetsTouched")} v={String(neighbours.file)} />
           </>
         )}
         {node.type === "file" &&
@@ -517,37 +511,37 @@ function DetailCard({
             if (kind === "command")
               return (
                 <>
-                  <Row k="Programm" v={node.label} />
-                  <Row k="Aufrufe" v={String(meta.calls ?? node.val)} />
-                  <Row k="Von Tools" v={String(neighbours.tool)} />
-                  {meta.path && <LongField label="Beispiel" text={meta.path} />}
+                  <Row k={t("graph.program")} v={node.label} />
+                  <Row k={t("graph.calls")} v={String(meta.calls ?? node.val)} />
+                  <Row k={t("graph.fromTools")} v={String(neighbours.tool)} />
+                  {meta.path && <LongField label={t("graph.example")} text={meta.path} />}
                 </>
               );
             if (kind === "url")
               return (
                 <>
-                  <Row k="Von Tools" v={String(neighbours.tool)} />
-                  <LongField label="Adresse" text={meta.path ?? node.label} />
+                  <Row k={t("graph.fromTools")} v={String(neighbours.tool)} />
+                  <LongField label={t("graph.address")} text={meta.path ?? node.label} />
                 </>
               );
             if (kind === "pattern")
               return (
                 <>
-                  <Row k="Von Tools" v={String(neighbours.tool)} />
-                  <LongField label="Muster" text={meta.path ?? node.label} />
+                  <Row k={t("graph.fromTools")} v={String(neighbours.tool)} />
+                  <LongField label={t("graph.pattern")} text={meta.path ?? node.label} />
                 </>
               );
             return (
               <>
-                <Row k="Von Tools berührt" v={String(neighbours.tool)} />
-                <LongField label="Pfad" text={meta.path ?? node.label} />
+                <Row k={t("graph.fromToolsTouched")} v={String(neighbours.tool)} />
+                <LongField label={t("graph.path")} text={meta.path ?? node.label} />
               </>
             );
           })()}
         {node.type === "prompt" && (
           <>
-            <Row k="Von" v={meta.role === "agent" ? "Claude → Agent" : "Du"} />
-            <Row k="Zeit" v={relativeTime(meta.lastSeen)} />
+            <Row k={t("graph.from")} v={meta.role === "agent" ? t("graph.fromAgent") : t("graph.fromYou")} />
+            <Row k={t("graph.time")} v={relativeTime(meta.lastSeen, lang)} />
             {meta.text && (
               <div className="mt-1 max-h-32 overflow-auto rounded bg-background/60 p-2 text-[11px] leading-relaxed text-foreground">
                 {meta.text}

--- a/src/plugins/tool-graph/widget.tsx
+++ b/src/plugins/tool-graph/widget.tsx
@@ -2,6 +2,7 @@
 
 import dynamic from "next/dynamic";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { forceCollide } from "d3-force-3d";
 import { Boxes, Maximize2, Minimize2, X } from "lucide-react";
 import { Panel } from "@/components/panel";
 import { useLive } from "@/components/live-provider";
@@ -46,13 +47,13 @@ interface GraphData {
 // spread evenly around the wheel for clear, harmonious distinction on the dark
 // background. Claude reads meta.kind/role; humans read these.
 const KIND_COLOR: Record<string, string> = {
-  session: "#4f8cff", // blue   — the run itself
-  prompt: "#fb7185", // rose   — prompts (you & Claude)
-  tool: "#fbbf24", // amber  — tools
-  file: "#34d399", // emerald— files
-  command: "#a78bfa", // violet — shell commands
-  url: "#22d3ee", // cyan   — URLs
-  pattern: "#94a3b8", // slate  — patterns/queries
+  session: "#5b9dff", // blue   — the run itself
+  prompt: "#ff6b9d", // rose   — prompts (you & Claude)
+  tool: "#ffc53d", // amber  — tools
+  file: "#3ee9a6", // emerald— files
+  command: "#b98aff", // violet — shell commands
+  url: "#34e0f5", // cyan   — URLs
+  pattern: "#aab6cc", // slate  — patterns/queries
 };
 const KIND_NOUN: Record<string, string> = {
   session: "Session",
@@ -92,6 +93,26 @@ export function ToolGraph() {
   const bloomRef = useRef<any>(null);
   const bloomAdded = useRef(false);
   const fitted = useRef(false);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const threeRef = useRef<any>(null);
+  const [threeReady, setThreeReady] = useState(false);
+  const sig = useRef("");
+
+  // Load three on the client for the metallic node material.
+  useEffect(() => {
+    let cancelled = false;
+    import("three")
+      .then((m) => {
+        if (!cancelled) {
+          threeRef.current = m;
+          setThreeReady(true);
+        }
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   useEffect(() => {
     // Debounce: at most one graph rebuild every 3s even under event bursts.
@@ -102,6 +123,10 @@ export function ToolGraph() {
       fetch("/api/graph")
         .then((r) => r.json())
         .then((d: GraphData) => {
+          // Only rebuild meshes when the graph structure actually changed.
+          const next = d.nodes.map((n) => n.id).join(",") + "|" + d.links.length;
+          if (next === sig.current) return;
+          sig.current = next;
           setData(d);
           setSelected((cur) => (cur ? d.nodes.find((n) => n.id === cur.id) ?? null : null));
         })
@@ -144,6 +169,76 @@ export function ToolGraph() {
   }, [data]);
   const hasActive = activeIds.size > 0;
 
+  const SIZE = maximized ? 4.6 : 3.6;
+  const nodeRadius = useCallback((n: GraphNode) => Math.cbrt(Math.max(n.val, 0.6)) * SIZE, [SIZE]);
+
+  // Colour + whether a node glows. Only the active subgraph (or the selection)
+  // glows; everything else stays metallic-lit but unglowing.
+  const styleFor = useCallback(
+    (n: GraphNode): { color: string; glow: boolean } => {
+      if (selected?.id === n.id) return { color: SELECTED, glow: true };
+      const base = baseColor(n);
+      if (activeIds.has(n.id)) return { color: base, glow: true };
+      return { color: hasActive ? dim(base, 0.5) : base, glow: false };
+    },
+    [selected, activeIds, hasActive],
+  );
+  const styleRef = useRef(styleFor);
+  const nodesRef = useRef<GraphNode[]>([]);
+  useEffect(() => {
+    styleRef.current = styleFor;
+    nodesRef.current = data.nodes;
+  });
+
+  // Metallic, glossy spheres (Phong specular). Emissive only when glowing, so the
+  // bloom lights up exactly the active elements — not everything.
+  const nodeThreeObject = useCallback(
+    (node: object) => {
+      const THREE = threeRef.current;
+      if (!THREE) return undefined;
+      const n = node as GraphNode;
+      const { color, glow } = styleRef.current(n);
+      const mat = new THREE.MeshPhongMaterial({
+        color,
+        emissive: color,
+        emissiveIntensity: glow ? 0.7 : 0,
+        shininess: 120,
+        specular: 0x9aa6c0,
+      });
+      return new THREE.Mesh(new THREE.SphereGeometry(nodeRadius(n), 28, 20), mat);
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [threeReady, nodeRadius],
+  );
+
+  // Recolour existing meshes on selection/active change without rebuilding them.
+  // Meshes are reached via a ref (not React state) so it's a pure side effect.
+  useEffect(() => {
+    if (!threeReady) return;
+    for (const n of nodesRef.current) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const mat = (n as any).__threeObj?.material;
+      if (!mat?.color) continue;
+      const { color, glow } = styleFor(n);
+      mat.color.set(color);
+      mat.emissive?.set?.(color);
+      // eslint-disable-next-line react-hooks/immutability -- three.js material, not React state
+      mat.emissiveIntensity = glow ? 0.7 : 0;
+    }
+  }, [selected, activeIds, threeReady, styleFor]);
+
+  // Spacing + no overlap: repulsion, link distance, and a collision force whose
+  // radius matches the sphere radius (+ padding) so spheres never overlap.
+  useEffect(() => {
+    const fg = fgRef.current;
+    if (!threeReady || !fg?.d3Force) return;
+    fg.d3Force("charge")?.strength?.(-90);
+    fg.d3Force("link")?.distance?.(48);
+    fg.d3Force("collide", forceCollide((n: object) => nodeRadius(n as GraphNode) + 4));
+    fg.d3ReheatSimulation?.();
+    fitted.current = false;
+  }, [threeReady, maximized, nodeRadius, data.nodes.length]);
+
   const nodeById = useMemo(() => {
     const m = new Map<string, GraphNode>();
     for (const n of data.nodes) m.set(n.id, n);
@@ -185,21 +280,23 @@ export function ToolGraph() {
           import("three"),
         ]);
         if (cancelled) return;
-        const bloom = new UnrealBloomPass(new THREE.Vector2(dims.w, dims.h), 0.32, 0.6, 0.4);
+        // Selective bloom: high threshold so only the bright, emissive (active)
+        // elements glow — not the whole graph.
+        const bloom = new UnrealBloomPass(new THREE.Vector2(dims.w, dims.h), 0.85, 0.7, 0.34);
         composer.addPass(bloom);
         bloomRef.current = bloom;
         bloomAdded.current = true;
 
-        // No artificial lighting: flatten to bright, even ambient so nodes show
-        // their true colours (self-lit look) instead of side-shaded fake light.
+        // Real lighting → metallic highlight + visible 3D curvature. Ambient fills
+        // shadows so unglowing nodes still read as solid (not pitch black).
         const scene = fgRef.current?.scene?.();
         scene?.traverse((o: { isLight?: boolean; type?: string; intensity?: number; color?: { set?: (c: number) => void } }) => {
           if (!o.isLight) return;
           if (o.type === "AmbientLight") {
-            o.intensity = 2;
+            o.intensity = 0.65;
             o.color?.set?.(0xffffff);
           } else {
-            o.intensity = 0; // kill directional/point "artificial" shading
+            o.intensity = 1.6; // restore directional → glossy highlight + depth
           }
         });
       } catch {
@@ -218,8 +315,8 @@ export function ToolGraph() {
     const start = performance.now();
     const loop = (now: number) => {
       const b = bloomRef.current;
-      // Subtle "breathing" — keep it understated/professional (range ~0.22–0.40).
-      if (b) b.strength = 0.31 + 0.09 * Math.sin(((now - start) / 1000) * 1.3);
+      // Lively but smooth "breathing" of the glow (range ~0.48–0.72).
+      if (b) b.strength = 0.6 + 0.12 * Math.sin(((now - start) / 1000) * 1.3);
       raf = requestAnimationFrame(loop);
     };
     raf = requestAnimationFrame(loop);
@@ -316,6 +413,7 @@ export function ToolGraph() {
                 nodeOpacity={1}
                 nodeRelSize={maximized ? 6 : 5}
                 nodeResolution={maximized ? 32 : 24}
+                nodeThreeObject={nodeThreeObject}
                 onNodeClick={onNodeClick}
                 onBackgroundClick={() => setSelected(null)}
                 onEngineStop={() => {
@@ -329,10 +427,11 @@ export function ToolGraph() {
                 }}
                 linkColor={(l: object) => {
                   const hot = isHot(l);
-                  if (hot === "selected") return "#9ec5ff";
-                  if (hot === "active") return "#4f8cff";
-                  // Inactive links stay clearly visible, just subordinate to hot ones.
-                  return hasActive ? "#3a465e" : "#46566f";
+                  // Bright (above bloom threshold) → glows. Only active/selected links.
+                  if (hot === "selected") return "#cfe0ff";
+                  if (hot === "active") return "#5b9dff";
+                  // Inactive links: visible grey but below the bloom threshold → no glow.
+                  return hasActive ? "#2b3444" : "#3b4860";
                 }}
                 linkWidth={(l: object) => {
                   const hot = isHot(l);

--- a/src/plugins/tool-graph/widget.tsx
+++ b/src/plugins/tool-graph/widget.tsx
@@ -10,7 +10,7 @@ import { relativeTime, STATUS_META } from "@/lib/format";
 // Wrapper preserves the imperative ref through next/dynamic (camera + bloom composer).
 const ForceGraph3D = dynamic(() => import("./force-graph"), { ssr: false });
 
-type NodeType = "session" | "tool" | "file";
+type NodeType = "session" | "tool" | "file" | "prompt";
 type TargetKind = "file" | "command" | "url" | "pattern";
 interface NodeMeta {
   sessionId?: string;
@@ -20,6 +20,8 @@ interface NodeMeta {
   path?: string;
   kind?: TargetKind;
   calls?: number;
+  role?: "user" | "agent";
+  text?: string;
 }
 interface GraphNode {
   id: string;
@@ -40,26 +42,29 @@ interface GraphData {
   links: GraphLink[];
 }
 
-// One palette + one noun map, keyed by the node's effective kind (resource nodes
-// refine "file" into command/url/pattern). Claude reads meta.kind; humans read these.
+// One cohesive palette + noun map, keyed by the node's effective kind. Hues are
+// spread evenly around the wheel for clear, harmonious distinction on the dark
+// background. Claude reads meta.kind/role; humans read these.
 const KIND_COLOR: Record<string, string> = {
-  session: "#4f8cff",
-  tool: "#fbbf24",
-  file: "#34d399",
-  command: "#c084fc",
-  url: "#38bdf8",
-  pattern: "#94a3b8",
+  session: "#4f8cff", // blue   — the run itself
+  prompt: "#fb7185", // rose   — prompts (you & Claude)
+  tool: "#fbbf24", // amber  — tools
+  file: "#34d399", // emerald— files
+  command: "#a78bfa", // violet — shell commands
+  url: "#22d3ee", // cyan   — URLs
+  pattern: "#94a3b8", // slate  — patterns/queries
 };
 const KIND_NOUN: Record<string, string> = {
   session: "Session",
+  prompt: "Prompt",
   tool: "Tool",
   file: "Datei",
   command: "Befehl",
   url: "URL",
   pattern: "Muster",
 };
-const KIND_ORDER = ["session", "tool", "file", "command", "url", "pattern"] as const;
-const SELECTED = "#dbe8ff";
+const KIND_ORDER = ["session", "prompt", "tool", "file", "command", "url", "pattern"] as const;
+const SELECTED = "#f1f5f9";
 
 const nodeKey = (n: GraphNode): string => (n.type === "file" ? n.meta?.kind ?? "file" : n.type);
 const baseColor = (n: GraphNode): string => KIND_COLOR[nodeKey(n)] ?? KIND_COLOR.file;
@@ -86,6 +91,7 @@ export function ToolGraph() {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const bloomRef = useRef<any>(null);
   const bloomAdded = useRef(false);
+  const fitted = useRef(false);
 
   useEffect(() => {
     // Debounce: at most one graph rebuild every 3s even under event bursts.
@@ -145,7 +151,8 @@ export function ToolGraph() {
   }, [data.nodes]);
 
   const neighbours = useMemo(() => {
-    if (!selected) return { session: 0, tool: 0, file: 0 };
+    const counts = { session: 0, prompt: 0, tool: 0, file: 0 };
+    if (!selected) return counts;
     const ids = new Set<string>();
     for (const l of data.links) {
       const s = endId(l.source);
@@ -153,7 +160,6 @@ export function ToolGraph() {
       if (s === selected.id) ids.add(t);
       else if (t === selected.id) ids.add(s);
     }
-    const counts = { session: 0, tool: 0, file: 0 };
     for (const id of ids) {
       const n = nodeById.get(id);
       if (n) counts[n.type] += 1;
@@ -183,6 +189,19 @@ export function ToolGraph() {
         composer.addPass(bloom);
         bloomRef.current = bloom;
         bloomAdded.current = true;
+
+        // No artificial lighting: flatten to bright, even ambient so nodes show
+        // their true colours (self-lit look) instead of side-shaded fake light.
+        const scene = fgRef.current?.scene?.();
+        scene?.traverse((o: { isLight?: boolean; type?: string; intensity?: number; color?: { set?: (c: number) => void } }) => {
+          if (!o.isLight) return;
+          if (o.type === "AmbientLight") {
+            o.intensity = 2;
+            o.color?.set?.(0xffffff);
+          } else {
+            o.intensity = 0; // kill directional/point "artificial" shading
+          }
+        });
       } catch {
         /* bloom is a nicety — graph works without it */
       }
@@ -257,24 +276,14 @@ export function ToolGraph() {
         icon={<Boxes className="h-4 w-4 text-accent" />}
         info="Beziehungen Session → Tool → Ziel (Datei, Befehl, URL, Muster). Gleiche Ziele über Sessions hinweg teilen sich einen Knoten. Aktive Sessions leuchten. Knoten anklicken für Details, Vollbild oben rechts."
         right={
-          <div className="flex items-center gap-3 text-[11px] text-muted">
-            <div className="hidden items-center gap-3 sm:flex">
-              {legend.map((l) => (
-                <span key={l.t} className="flex items-center gap-1">
-                  <span className="h-2 w-2 rounded-full" style={{ background: l.c }} />
-                  {l.t}
-                </span>
-              ))}
-            </div>
-            <button
-              onClick={() => setMaximized((m) => !m)}
-              title={maximized ? "Verkleinern (Esc)" : "Vollbild"}
-              className="flex items-center gap-1 rounded-md border border-panel-border px-2 py-1 text-muted transition-colors hover:border-accent/50 hover:text-foreground"
-            >
-              {maximized ? <Minimize2 className="h-3.5 w-3.5" /> : <Maximize2 className="h-3.5 w-3.5" />}
-              <span className="hidden sm:inline">{maximized ? "Verkleinern" : "Vollbild"}</span>
-            </button>
-          </div>
+          <button
+            onClick={() => setMaximized((m) => !m)}
+            title={maximized ? "Verkleinern (Esc)" : "Vollbild"}
+            className="flex items-center gap-1 rounded-md border border-panel-border px-2 py-1 text-[11px] text-muted transition-colors hover:border-accent/50 hover:text-foreground"
+          >
+            {maximized ? <Minimize2 className="h-3.5 w-3.5" /> : <Maximize2 className="h-3.5 w-3.5" />}
+            <span className="hidden sm:inline">{maximized ? "Verkleinern" : "Vollbild"}</span>
+          </button>
         }
       >
         <div ref={wrapRef} className="relative h-full w-full">
@@ -304,11 +313,20 @@ export function ToolGraph() {
                   if (activeIds.has(g.id)) return base;
                   return hasActive ? dim(base, 0.62) : base;
                 }}
-                nodeOpacity={0.95}
+                nodeOpacity={1}
                 nodeRelSize={maximized ? 6 : 5}
-                nodeResolution={18}
+                nodeResolution={maximized ? 32 : 24}
                 onNodeClick={onNodeClick}
                 onBackgroundClick={() => setSelected(null)}
+                onEngineStop={() => {
+                  if (fitted.current) return;
+                  try {
+                    fgRef.current?.zoomToFit?.(600, 40);
+                    fitted.current = true;
+                  } catch {
+                    /* ref API unavailable */
+                  }
+                }}
                 linkColor={(l: object) => {
                   const hot = isHot(l);
                   if (hot === "selected") return "#9ec5ff";
@@ -329,9 +347,14 @@ export function ToolGraph() {
                 cooldownTicks={120}
               />
               {selected && <DetailCard node={selected} neighbours={neighbours} onClose={() => setSelected(null)} />}
-              <p className="pointer-events-none absolute bottom-2 left-3 text-[10px] text-muted/60">
-                Knoten anklicken für Details · ziehen zum Drehen · scrollen zum Zoomen
-              </p>
+              <div className="pointer-events-none absolute bottom-2 left-3 flex max-w-[78%] flex-wrap gap-x-2.5 gap-y-1 text-[10px] text-muted/80">
+                {legend.map((l) => (
+                  <span key={l.t} className="flex items-center gap-1">
+                    <span className="h-2 w-2 rounded-full" style={{ background: l.c }} />
+                    {l.t}
+                  </span>
+                ))}
+              </div>
             </>
           ) : null}
         </div>
@@ -346,12 +369,12 @@ function DetailCard({
   onClose,
 }: {
   node: GraphNode;
-  neighbours: { session: number; tool: number; file: number };
+  neighbours: { session: number; prompt: number; tool: number; file: number };
   onClose: () => void;
 }) {
   const meta = node.meta ?? {};
   return (
-    <div className="absolute right-3 top-3 w-64 max-w-[80%] rounded-lg border border-panel-border bg-panel/95 p-3 text-xs shadow-xl shadow-black/40 backdrop-blur">
+    <div className="absolute right-3 top-3 flex max-h-[calc(100%-1.5rem)] w-64 max-w-[80%] flex-col overflow-hidden rounded-lg border border-panel-border bg-panel/95 p-3 text-xs shadow-xl shadow-black/40 backdrop-blur">
       <div className="mb-2 flex items-start justify-between gap-2">
         <div className="flex items-center gap-1.5">
           <span className="h-2.5 w-2.5 rounded-full" style={{ background: baseColor(node) }} />
@@ -362,9 +385,10 @@ function DetailCard({
         </button>
       </div>
 
-      <p className="mb-2 break-words text-sm text-foreground">{node.label}</p>
+      <div className="min-h-0 flex-1 overflow-auto pr-0.5">
+        <p className="mb-2 break-words text-sm text-foreground">{node.label}</p>
 
-      <dl className="space-y-1 text-muted">
+        <dl className="space-y-1 text-muted">
         {node.type === "session" && (
           <>
             <Row k="Projekt" v={meta.project ?? "—"} />
@@ -378,6 +402,7 @@ function DetailCard({
             />
             <Row k="Letzte Aktivität" v={relativeTime(meta.lastSeen)} />
             <Row k="ID" v={<span className="font-mono">{(meta.sessionId ?? node.id).slice(0, 12)}</span>} />
+            <Row k="Prompts" v={String(neighbours.prompt)} />
             <Row k="Tools verbunden" v={String(neighbours.tool)} />
           </>
         )}
@@ -390,38 +415,60 @@ function DetailCard({
         {node.type === "file" &&
           (() => {
             const kind = meta.kind ?? "file";
-            const mono = (s: string) => <span className="break-all font-mono text-[11px]">{s}</span>;
             if (kind === "command")
               return (
                 <>
                   <Row k="Programm" v={node.label} />
                   <Row k="Aufrufe" v={String(meta.calls ?? node.val)} />
-                  {meta.path && <Row k="Beispiel" v={mono(meta.path)} />}
                   <Row k="Von Tools" v={String(neighbours.tool)} />
+                  {meta.path && <LongField label="Beispiel" text={meta.path} />}
                 </>
               );
             if (kind === "url")
               return (
                 <>
-                  <Row k="Adresse" v={mono(meta.path ?? node.label)} />
                   <Row k="Von Tools" v={String(neighbours.tool)} />
+                  <LongField label="Adresse" text={meta.path ?? node.label} />
                 </>
               );
             if (kind === "pattern")
               return (
                 <>
-                  <Row k="Muster" v={mono(meta.path ?? node.label)} />
                   <Row k="Von Tools" v={String(neighbours.tool)} />
+                  <LongField label="Muster" text={meta.path ?? node.label} />
                 </>
               );
             return (
               <>
-                <Row k="Pfad" v={mono(meta.path ?? node.label)} />
                 <Row k="Von Tools berührt" v={String(neighbours.tool)} />
+                <LongField label="Pfad" text={meta.path ?? node.label} />
               </>
             );
           })()}
-      </dl>
+        {node.type === "prompt" && (
+          <>
+            <Row k="Von" v={meta.role === "agent" ? "Claude → Agent" : "Du"} />
+            <Row k="Zeit" v={relativeTime(meta.lastSeen)} />
+            {meta.text && (
+              <div className="mt-1 max-h-32 overflow-auto rounded bg-background/60 p-2 text-[11px] leading-relaxed text-foreground">
+                {meta.text}
+              </div>
+            )}
+          </>
+        )}
+        </dl>
+      </div>
+    </div>
+  );
+}
+
+function LongField({ label, text }: { label: string; text: string }) {
+  return (
+    <div className="pt-0.5">
+      <dt className="mb-0.5 text-muted">{label}</dt>
+      <dd className="max-h-28 overflow-auto rounded bg-background/60 p-2 font-mono text-[11px] leading-relaxed break-all text-foreground">
+        {text}
+      </dd>
     </div>
   );
 }

--- a/src/types/three-shim.d.ts
+++ b/src/types/three-shim.d.ts
@@ -3,3 +3,5 @@
 // (Vector2 + UnrealBloomPass), so we declare those modules loosely here.
 declare module "three";
 declare module "three/examples/jsm/postprocessing/UnrealBloomPass.js";
+// d3-force-3d ships no types; the 3D graph only uses forceCollide.
+declare module "d3-force-3d";


### PR DESCRIPTION
## Überblick
Ausbau und Härtung von Claude Mission Control über mehrere Iterationen. 10 Commits.

## Highlights

### 3D-Tool-Graph
- Knoten **anklickbar** → Kamera-Fokus + Detailkarte (Session/Tool/Ziel).
- **Vollbild**-Modus (Esc schließt), bessere Darstellung.
- Aktive Sessions + ihre Linien **glühen sanft** (UnrealBloom + dezenter Puls); inaktive sichtbar gedimmt.
- **Claude-first Labels**: explizites `kind` (file/command/url/pattern), Bash nach Programm gruppiert, Dateien als kurzer Pfad, URLs als Host; Farbe/Substantiv/dynamische Legende für Menschen.

### Sessions
- **Auto-Idle**: Sessions ohne Aktivität >30 min (nicht beendet) werden als beendet geführt (`MC_STALE_MINUTES`) — kein ewiges „Wartet" mehr.

### Härtung
- **Error-Boundary pro Widget** + `app/error.tsx` / `global-error.tsx`.
- API-Routen (sessions/graph/events) mit try/catch + sicherem Fallback.
- **SSE-Reconnect** mit Backoff + Backlog-Nachladen.
- Ingest **Body-Limit** (413); diverse Guards.

### Großbild / 4K
- Ab 2560px **randlos** (kein Breitenlimit), Root-Schrift 20px (QHD) / 24px (4K), größere Panels/Abstände. **HD (≤1920px) unverändert.**

### System-Schutz (gegen versehentliches Kaputtmachen)
- PreToolUse-Guard-Hook (`.claude/settings.json` → `scripts/protect-guard.mjs`) blockt Edits an Aussehen/Config-Dateien, **wenn** `.mc-protect` existiert.
- Toggle: `npm run protect` / `npm run unprotect` (PIN 0000). **Standard: aus.** Ehrlich: lokaler Speed-Bump, keine harte Sicherheit.

### Persistenz & Nachvollziehbarkeit
- `npm run backup` — konsistente SQLite-Snapshots.
- `npm run export-log` — lesbares Markdown der Prompts + Tool-Aufrufe.
- `DECISIONS.md` — Entscheidungs-Journal (was/warum).
- `three` als direkte Dependency gepinnt.

### Info-Hinweise
- Dezente ℹ️ (Hover/Fokus) an jedem Panel + Header.

## Verifikation
tsc + ESLint + Production-Build grün; Guard, Backup, Export und APIs live getestet.

## Hinweise
- `.env`, `data/`, `backups/`, `exports/`, `.mc-protect` sind gitignored.
- Der neue Projekt-Hook in `.claude/settings.json` muss in Claude Code ggf. einmal als vertrauenswürdig bestätigt werden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)