### PR TITLE
Fix README demo videos not playing

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,12 +31,13 @@ graph — animates with no server. Deployed from `.github/workflows/pages.yml`
 (enable repo → Settings → Pages → Source: **GitHub Actions**).
 
 <!--
-  DEMO VIDEOS — placeholders. Drop your two recordings into the `assets/` folder
-  with exactly these names:
+  DEMO VIDEOS live in the `assets/` folder:
     • assets/dashboard.mp4   ← screen recording of the dashboard
     • assets/graph-3d.mp4    ← screen recording of the 3D tool graph
-  Format: MP4 (H.264) or WebM, ideally ≤ ~20 MB each. GitHub renders <video>
-  inline once the file exists; the link underneath is the fallback.
+  IMPORTANT: GitHub only renders an inline <video> player when src is an ABSOLUTE
+  raw URL (https://github.com/BEKO2210/My_Dash/raw/main/assets/<file>.mp4).
+  Relative paths like "assets/dashboard.mp4" do NOT play in the rendered README.
+  Format: MP4 (H.264) or WebM, ideally ≤ ~20 MB each. The link underneath is the fallback.
 -->
 
 ### Dashboard
@@ -45,9 +46,9 @@ graph — animates with no server. Deployed from `.github/workflows/pages.yml`
   <img src="assets/screenshot-dashboard.png" alt="Claude Mission Control dashboard" width="100%">
 </p>
 
-<video src="assets/dashboard.mp4" controls muted playsinline width="100%"></video>
+<video src="https://github.com/BEKO2210/My_Dash/raw/main/assets/dashboard.mp4" controls muted playsinline width="100%"></video>
 
-▶️ [assets/dashboard.mp4](assets/dashboard.mp4) <!-- placeholder — replace with your recording -->
+▶️ [Watch dashboard.mp4](https://github.com/BEKO2210/My_Dash/raw/main/assets/dashboard.mp4)
 
 ### 3D tool graph
 
@@ -55,9 +56,9 @@ graph — animates with no server. Deployed from `.github/workflows/pages.yml`
   <img src="assets/screenshot-graph.png" alt="3D tool-call graph (fullscreen)" width="100%">
 </p>
 
-<video src="assets/graph-3d.mp4" controls muted playsinline width="100%"></video>
+<video src="https://github.com/BEKO2210/My_Dash/raw/main/assets/graph-3d.mp4" controls muted playsinline width="100%"></video>
 
-▶️ [assets/graph-3d.mp4](assets/graph-3d.mp4) <!-- placeholder — replace with your recording -->
+▶️ [Watch graph-3d.mp4](https://github.com/BEKO2210/My_Dash/raw/main/assets/graph-3d.mp4)
 
 ---
 


### PR DESCRIPTION
## Summary
- The two uploaded demo recordings (`assets/dashboard.mp4`, `assets/graph-3d.mp4`) showed up as empty players in the rendered README.
- Root cause: GitHub does **not** render `<video>` tags whose `src` is a relative repo path (relative paths only work for `<img>`). It needs an absolute raw URL.
- Fix: point both `<video>` sources and their fallback links at `https://github.com/BEKO2210/My_Dash/raw/main/assets/<file>.mp4` so the videos play inline.
- Updated the HTML comment to document the absolute-URL requirement so the relative paths aren't reintroduced.

## Test plan
- [ ] View the README on the `main` branch after merge and confirm both videos render an inline player and play.
- [ ] Confirm the "Watch …" fallback links open the raw MP4.

Note: the inline players resolve against `main`, so they go live once this is merged.

https://claude.ai/code/session_01DF43Ts2scYjnjHn4iF4UYF

---
_Generated by [Claude Code](https://claude.ai/code/session_01DF43Ts2scYjnjHn4iF4UYF)_