### PR TITLE
Show Icon.png large at top of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
 <p align="center">
+  <img src="assets/Icon.png" alt="Claude Mission Control" width="360">
+</p>
+
+<p align="center">
   <img src="assets/logo.svg" alt="Claude Mission Control" width="520">
 </p>
 


### PR DESCRIPTION
## Summary
- Adds `assets/Icon.png` as the first, centered, large image at the very top of the README (width 360; the icon is 4096×4096 square, so a fixed width keeps it prominent without overwhelming the page).
- Nothing else in the README is changed.

## Test plan
- [ ] Open the README on `main` after merge; confirm the icon shows large at the very top, above everything else.

https://claude.ai/code/session_01DF43Ts2scYjnjHn4iF4UYF

---
_Generated by [Claude Code](https://claude.ai/code/session_01DF43Ts2scYjnjHn4iF4UYF)_