### PR TITLE
Fix "database is locked" during build; add README download links

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 <p align="center">
   <img alt="Status: alpha" src="https://img.shields.io/badge/status-alpha-f59e0b?style=flat-square">
   <img alt="Version 0.1.0" src="https://img.shields.io/badge/version-0.1.0-4f8cff?style=flat-square">
+  <a href="https://github.com/BEKO2210/My_Dash/releases/latest"><img alt="Download" src="https://img.shields.io/badge/download-Win_·_macOS_·_Linux-4f8cff?style=flat-square&logo=githubactions&logoColor=white"></a>
   <a href="https://beko2210.github.io/My_Dash/"><img alt="Live demo" src="https://img.shields.io/badge/live_demo-online-34d399?style=flat-square&logo=githubpages&logoColor=white"></a>
   <a href="LICENSE"><img alt="License: MIT" src="https://img.shields.io/badge/license-MIT-4f8cff?style=flat-square"></a>
   <a href="CONTRIBUTING.md"><img alt="PRs welcome" src="https://img.shields.io/badge/PRs-welcome-ff6b9d?style=flat-square"></a>
@@ -138,10 +139,12 @@ One Next.js process. SQLite file at `./data/mission-control.db` (gitignored).
 
 ## Install (desktop app)
 
-Double-click installers for **Windows, macOS and Linux** are built by the release
-workflow and attached to each [GitHub Release](https://github.com/BEKO2210/My_Dash/releases):
+### ⬇️ [Download the latest release](https://github.com/BEKO2210/My_Dash/releases/latest)
 
-| OS | File |
+Double-click installers for **Windows, macOS and Linux** are built by the release
+workflow and attached to every [GitHub Release](https://github.com/BEKO2210/My_Dash/releases):
+
+| OS | File on the [latest release](https://github.com/BEKO2210/My_Dash/releases/latest) |
 |----|------|
 | Windows | `Claude Mission Control Setup <version>.exe` (NSIS installer) |
 | macOS | `Claude Mission Control-<version>.dmg` |

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -47,6 +47,16 @@ CREATE INDEX IF NOT EXISTS idx_tool_calls_session ON tool_calls(session_id);
 `;
 
 function createDb(): Database.Database {
+  // During `next build`, route modules are evaluated by several workers in parallel.
+  // Opening the real database file then races on the SQLite lock ("database is
+  // locked"). The build only needs the schema to exist for page-data collection, so
+  // use a throwaway in-memory database during the build phase.
+  if (process.env.NEXT_PHASE === "phase-production-build") {
+    const mem = new Database(":memory:");
+    mem.exec(SCHEMA);
+    return mem;
+  }
+
   // Packaged builds (Electron) pass MC_DATA_DIR (a stable per-user location);
   // source runs fall back to ./data next to the project.
   const dataDir = process.env.MC_DATA_DIR || path.join(process.cwd(), "data");


### PR DESCRIPTION
## Summary
Fixes the `npm run dist` failure you hit on macOS (`SqliteError: database is locked` during `next build`) and adds download links to the README.

**Build fix (all OSes)**
`next build` collects page data with several parallel workers; each evaluates the `/api/*` route modules, which import `src/lib/db.ts` and open the real SQLite file. Concurrent opens race on the lock → intermittent `SQLITE_BUSY` ("database is locked"). The build only needs the schema to exist, so during the build phase (`NEXT_PHASE === "phase-production-build"`) we now use a throwaway **in-memory** database. Runtime is unchanged — the packaged app still uses the real per-user database (`MC_DATA_DIR`).

This is platform-independent; it was a race that happened to surface on your Mac (Windows + Linux passed that time).

**README**
- Prominent **⬇️ Download the latest release** link + a "download" badge → `releases/latest`.
- Install table now points at the latest release.

## Verification
- `npm run build:standalone` now completes cleanly (previously failed at "Collecting page data for /api/events").
- `npm run lint` ✅, `npm test` ✅ (14).
- Runtime path unaffected (build-phase branch only).

https://claude.ai/code/session_01DF43Ts2scYjnjHn4iF4UYF

---
_Generated by [Claude Code](https://claude.ai/code/session_01DF43Ts2scYjnjHn4iF4UYF)_