### PR TITLE
Address CodeRabbit feedback: use PHASE_PRODUCTION_BUILD constant

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 <p align="center">
   <img alt="Status: alpha" src="https://img.shields.io/badge/status-alpha-f59e0b?style=flat-square">
   <img alt="Version 0.1.0" src="https://img.shields.io/badge/version-0.1.0-4f8cff?style=flat-square">
-  <a href="https://github.com/BEKO2210/My_Dash/releases/latest"><img alt="Download" src="https://img.shields.io/badge/download-Win_·_macOS_·_Linux-4f8cff?style=flat-square&logo=githubactions&logoColor=white"></a>
+  <a href="https://github.com/BEKO2210/My_Dash/releases/latest"><img alt="Download" src="https://img.shields.io/badge/download-Win_·_macOS_·_Linux-4f8cff?style=flat-square&logo=github&logoColor=white"></a>
   <a href="https://beko2210.github.io/My_Dash/"><img alt="Live demo" src="https://img.shields.io/badge/live_demo-online-34d399?style=flat-square&logo=githubpages&logoColor=white"></a>
   <a href="LICENSE"><img alt="License: MIT" src="https://img.shields.io/badge/license-MIT-4f8cff?style=flat-square"></a>
   <a href="CONTRIBUTING.md"><img alt="PRs welcome" src="https://img.shields.io/badge/PRs-welcome-ff6b9d?style=flat-square"></a>
@@ -144,7 +144,7 @@ One Next.js process. SQLite file at `./data/mission-control.db` (gitignored).
 Double-click installers for **Windows, macOS and Linux** are built by the release
 workflow and attached to every [GitHub Release](https://github.com/BEKO2210/My_Dash/releases):
 
-| OS | File on the [latest release](https://github.com/BEKO2210/My_Dash/releases/latest) |
+| OS | File ([latest](https://github.com/BEKO2210/My_Dash/releases/latest)) |
 |----|------|
 | Windows | `Claude Mission Control Setup <version>.exe` (NSIS installer) |
 | macOS | `Claude Mission Control-<version>.dmg` |

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,6 +1,7 @@
 import Database from "better-sqlite3";
 import { mkdirSync } from "node:fs";
 import path from "node:path";
+import { PHASE_PRODUCTION_BUILD } from "next/constants";
 
 // Schema lives here as the single source of truth (avoids runtime file-path lookups
 // that break under Next's bundling). Every statement is IF NOT EXISTS → safe to run on each boot.
@@ -51,7 +52,7 @@ function createDb(): Database.Database {
   // Opening the real database file then races on the SQLite lock ("database is
   // locked"). The build only needs the schema to exist for page-data collection, so
   // use a throwaway in-memory database during the build phase.
-  if (process.env.NEXT_PHASE === "phase-production-build") {
+  if (process.env.NEXT_PHASE === PHASE_PRODUCTION_BUILD) {
     const mem = new Database(":memory:");
     mem.exec(SCHEMA);
     return mem;


### PR DESCRIPTION
## Summary
Applies CodeRabbit's review feedback from PR #17 (small, low-risk follow-ups).

- **`src/lib/db.ts`**: use the `PHASE_PRODUCTION_BUILD` constant from `next/constants` instead of the hardcoded `"phase-production-build"` string, so a typo can't silently break the build-phase in-memory-DB guard.
- **`README.md`**: download badge now uses the `github` logo (was `githubactions`); the install-table header is more compact (`File ([latest](…))`).

> Opened as a normal (non-draft) PR so CodeRabbit reviews it automatically.

## Verification
- `npm run build:standalone` ✅ (confirms the `PHASE_PRODUCTION_BUILD` guard still routes the build to the in-memory DB)
- `npm run lint` ✅, `npm test` ✅ (14)

https://claude.ai/code/session_01DF43Ts2scYjnjHn4iF4UYF

---
_Generated by [Claude Code](https://claude.ai/code/session_01DF43Ts2scYjnjHn4iF4UYF)_