### PR TITLE
Add Obsidian-style download section with OS detection to the demo site

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,9 +146,9 @@ workflow and attached to every [GitHub Release](https://github.com/BEKO2210/My_D
 
 | OS | File ([latest](https://github.com/BEKO2210/My_Dash/releases/latest)) |
 |----|------|
-| Windows | `Claude Mission Control Setup <version>.exe` (NSIS installer) |
-| macOS | `Claude Mission Control-<version>.dmg` |
-| Linux | `.AppImage` (portable) or `.deb` |
+| Windows | `Claude-Mission-Control-Setup.exe` (NSIS installer) |
+| macOS | `Claude-Mission-Control.dmg` (Apple Silicon) |
+| Linux | `Claude-Mission-Control.AppImage` (portable) or `Claude-Mission-Control.deb` |
 
 > **Alpha note:** the installers are **unsigned**. On Windows, SmartScreen shows
 > *More info → Run anyway*; on macOS, right-click the app → **Open** the first time.

--- a/package.json
+++ b/package.json
@@ -82,8 +82,8 @@
     },
     "npmRebuild": false,
     "win": { "target": ["nsis"], "icon": "electron/build/icon.ico" },
-    "nsis": { "oneClick": false, "allowToChangeInstallationDirectory": true },
-    "mac": { "target": ["dmg"], "category": "public.app-category.developer-tools", "identity": null, "icon": "electron/build/icon.icns" },
-    "linux": { "target": ["AppImage", "deb"], "category": "Development", "icon": "electron/build/icon.png" }
+    "nsis": { "oneClick": false, "allowToChangeInstallationDirectory": true, "artifactName": "Claude-Mission-Control-Setup.${ext}" },
+    "mac": { "target": ["dmg"], "category": "public.app-category.developer-tools", "identity": null, "icon": "electron/build/icon.icns", "artifactName": "Claude-Mission-Control.${ext}" },
+    "linux": { "target": ["AppImage", "deb"], "category": "Development", "icon": "electron/build/icon.png", "artifactName": "Claude-Mission-Control.${ext}" }
   }
 }

--- a/src/components/download.tsx
+++ b/src/components/download.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Download } from "lucide-react";
+import { WindowsIcon, AppleIcon, LinuxIcon } from "@/components/os-icons";
+import { useT } from "@/lib/i18n";
+
+const REPO = "https://github.com/BEKO2210/My_Dash";
+const LATEST = `${REPO}/releases/latest/download`;
+const ALL_RELEASES = `${REPO}/releases`;
+
+// Stable, version-less asset names (see electron-builder `artifactName` in
+// package.json) so these links always resolve to the newest release.
+const URLS = {
+  windows: `${LATEST}/Claude-Mission-Control-Setup.exe`,
+  mac: `${LATEST}/Claude-Mission-Control.dmg`,
+  linuxAppImage: `${LATEST}/Claude-Mission-Control.AppImage`,
+  linuxDeb: `${LATEST}/Claude-Mission-Control.deb`,
+};
+
+type OS = "windows" | "mac" | "linux";
+
+function detectOS(): OS | null {
+  if (typeof navigator === "undefined") return null;
+  const ua = navigator.userAgent;
+  if (/Android/i.test(ua)) return null; // mobile — no desktop build
+  if (/Windows|Win32|Win64|WOW64/i.test(ua)) return "windows";
+  if (/Macintosh|Mac OS X|iPhone|iPad|iPod/i.test(ua)) return "mac";
+  if (/Linux|X11/i.test(ua)) return "linux";
+  return null;
+}
+
+export function DownloadSection() {
+  const { t } = useT();
+  const [os, setOs] = useState<OS | null>(null);
+
+  // Detect on the client only, deferred a frame so SSR/hydration output matches.
+  useEffect(() => {
+    const id = requestAnimationFrame(() => setOs(detectOS()));
+    return () => cancelAnimationFrame(id);
+  }, []);
+
+  const cards = [
+    { id: "windows" as const, Icon: WindowsIcon, name: "Windows", file: t("download.winFile"), primary: URLS.windows, extra: [] as { label: string; url: string }[] },
+    { id: "mac" as const, Icon: AppleIcon, name: "macOS", file: t("download.macFile"), primary: URLS.mac, extra: [] },
+    { id: "linux" as const, Icon: LinuxIcon, name: "Linux", file: t("download.linuxFile"), primary: URLS.linuxAppImage, extra: [{ label: ".deb", url: URLS.linuxDeb }] },
+  ];
+  const detected = cards.find((c) => c.id === os) ?? null;
+
+  return (
+    <section id="download" className="mt-12 scroll-mt-6">
+      <h2 className="text-xl font-bold tracking-tight sm:text-2xl">{t("download.title")}</h2>
+      <p className="mx-auto mt-2 max-w-xl text-sm text-muted">{t("download.subtitle")}</p>
+
+      {detected && (
+        <div className="mt-5 flex flex-col items-center gap-1.5">
+          <a
+            href={detected.primary}
+            className="inline-flex items-center gap-2 rounded-xl bg-accent px-5 py-2.5 text-sm font-semibold text-white shadow-lg shadow-accent/25 transition-transform hover:-translate-y-0.5"
+          >
+            <Download className="h-4 w-4" />
+            {t("download.for")} {detected.name}
+          </a>
+          <span className="text-[11px] text-muted">{detected.file}</span>
+        </div>
+      )}
+
+      <div className="mx-auto mt-7 grid max-w-3xl grid-cols-1 gap-3 text-left sm:grid-cols-3">
+        {cards.map((c) => {
+          const isDetected = detected?.id === c.id;
+          return (
+            <div
+              key={c.id}
+              className={`relative flex flex-col items-center rounded-xl border bg-panel/60 p-5 text-center transition-colors ${
+                isDetected ? "border-accent/60 ring-1 ring-accent/40" : "border-panel-border hover:border-accent/30"
+              }`}
+            >
+              {isDetected && (
+                <span className="absolute right-2 top-2 rounded-full bg-accent/15 px-2 py-0.5 text-[10px] font-medium text-accent">
+                  {t("download.detected")}
+                </span>
+              )}
+              <c.Icon className="h-9 w-9 text-foreground" />
+              <h3 className="mt-3 text-sm font-semibold text-foreground">{c.name}</h3>
+              <p className="mt-1 text-[11px] leading-relaxed text-muted">{c.file}</p>
+              <a
+                href={c.primary}
+                className="mt-3 inline-flex items-center gap-1.5 rounded-lg border border-panel-border px-3 py-1.5 text-xs font-medium text-foreground transition-colors hover:border-accent/50 hover:text-accent"
+              >
+                <Download className="h-3.5 w-3.5" />
+                {t("download.download")}
+              </a>
+              {c.extra.length > 0 && (
+                <div className="mt-2 flex gap-2 text-[11px]">
+                  {c.extra.map((e) => (
+                    <a key={e.url} href={e.url} className="text-muted underline-offset-2 hover:text-accent hover:underline">
+                      {e.label}
+                    </a>
+                  ))}
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+
+      <p className="mt-4 text-[11px] text-muted/80">{t("download.unsigned")}</p>
+      <p className="mt-1 text-[11px]">
+        <a href={ALL_RELEASES} target="_blank" rel="noreferrer" className="text-accent hover:underline">
+          {t("download.allReleases")}
+        </a>
+      </p>
+    </section>
+  );
+}

--- a/src/components/download.tsx
+++ b/src/components/download.tsx
@@ -20,16 +20,19 @@ const URLS = {
 
 type OS = "windows" | "mac" | "linux";
 
+/** Best-effort desktop OS from the user agent; null for mobile/unknown (no desktop build). */
 function detectOS(): OS | null {
   if (typeof navigator === "undefined") return null;
   const ua = navigator.userAgent;
-  if (/Android/i.test(ua)) return null; // mobile — no desktop build
+  if (/Android/i.test(ua)) return null; // Android mobile — no desktop build
+  if (/iPhone|iPad|iPod/i.test(ua)) return null; // iOS mobile — no desktop build
   if (/Windows|Win32|Win64|WOW64/i.test(ua)) return "windows";
-  if (/Macintosh|Mac OS X|iPhone|iPad|iPod/i.test(ua)) return "mac";
+  if (/Macintosh|Mac OS X/i.test(ua)) return "mac";
   if (/Linux|X11/i.test(ua)) return "linux";
   return null;
 }
 
+/** Landing-page download block: detects the visitor's OS and offers per-platform installers. */
 export function DownloadSection() {
   const { t } = useT();
   const [os, setOs] = useState<OS | null>(null);

--- a/src/components/landing.tsx
+++ b/src/components/landing.tsx
@@ -3,6 +3,7 @@
 import { Activity, KanbanSquare, Coins, Boxes } from "lucide-react";
 import { RadarLogo } from "@/components/radar-logo";
 import { LangToggle } from "@/components/lang-toggle";
+import { DownloadSection } from "@/components/download";
 import { useT } from "@/lib/i18n";
 
 const GITHUB = "https://github.com/BEKO2210/My_Dash";
@@ -58,7 +59,9 @@ export function Landing() {
           {t("landing.lead")}
         </p>
 
-        <div className="mt-9 grid grid-cols-1 gap-3 text-left sm:grid-cols-2 lg:grid-cols-4">
+        <DownloadSection />
+
+        <div className="mt-12 grid grid-cols-1 gap-3 text-left sm:grid-cols-2 lg:grid-cols-4">
           {features.map((f) => (
             <div
               key={f.title}

--- a/src/components/os-icons.tsx
+++ b/src/components/os-icons.tsx
@@ -1,6 +1,7 @@
 // Minimal, monochrome OS glyphs (currentColor) for the download section.
 // Kept as small inline SVGs so no icon dependency or brand asset is needed.
 
+/** Inline Windows logo glyph (currentColor). */
 export function WindowsIcon({ className }: { className?: string }) {
   return (
     <svg viewBox="0 0 24 24" className={className} fill="currentColor" aria-hidden="true">
@@ -9,6 +10,7 @@ export function WindowsIcon({ className }: { className?: string }) {
   );
 }
 
+/** Inline Apple logo glyph (currentColor). */
 export function AppleIcon({ className }: { className?: string }) {
   return (
     <svg viewBox="0 0 24 24" className={className} fill="currentColor" aria-hidden="true">
@@ -17,6 +19,7 @@ export function AppleIcon({ className }: { className?: string }) {
   );
 }
 
+/** Inline Linux (penguin) glyph (currentColor). */
 export function LinuxIcon({ className }: { className?: string }) {
   return (
     <svg viewBox="0 0 24 24" className={className} fill="currentColor" aria-hidden="true">

--- a/src/components/os-icons.tsx
+++ b/src/components/os-icons.tsx
@@ -1,0 +1,30 @@
+// Minimal, monochrome OS glyphs (currentColor) for the download section.
+// Kept as small inline SVGs so no icon dependency or brand asset is needed.
+
+export function WindowsIcon({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 24 24" className={className} fill="currentColor" aria-hidden="true">
+      <path d="M3 4.6 10.4 3.58V11.3H3zM11.55 3.43 21 2.1V11.3h-9.45zM3 12.7h7.4v7.72L3 19.4zM11.55 12.7H21v9.2l-9.45-1.3z" />
+    </svg>
+  );
+}
+
+export function AppleIcon({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 24 24" className={className} fill="currentColor" aria-hidden="true">
+      <path d="M16.365 1.43c0 1.14-.493 2.27-1.177 3.08-.744.9-1.99 1.57-2.987 1.57-.12 0-.23-.02-.3-.03-.01-.06-.04-.22-.04-.39 0-1.15.572-2.27 1.206-2.98.804-.94 2.142-1.64 3.248-1.68.03.13.05.28.05.43zm4.565 15.71c-.03.07-.463 1.58-1.518 3.12-.945 1.34-1.94 2.71-3.43 2.71-1.517 0-1.9-.88-3.63-.88-1.698 0-2.302.91-3.67.91-1.377 0-2.332-1.26-3.428-2.8C2.54 18.18 1.5 15.37 1.5 12.72c0-4.28 2.797-6.55 5.552-6.55 1.448 0 2.675.95 3.6.95.865 0 2.222-1.01 3.902-1.01.613 0 2.886.06 4.374 2.19-.13.09-2.383 1.37-2.383 4.19 0 3.26 2.854 4.42 2.955 4.45z" />
+    </svg>
+  );
+}
+
+export function LinuxIcon({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 24 24" className={className} fill="currentColor" aria-hidden="true">
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M12 2c2.1 0 3.6 1.62 3.6 3.82 0 1.03.3 1.6 1 2.3C18.4 9.86 19.7 11.7 19.7 15.1c0 3.65-2.3 6.5-7.7 6.5S4.3 18.75 4.3 15.1c0-3.4 1.3-5.24 3.1-6.98.7-.7 1-1.27 1-2.3C8.4 3.62 9.9 2 12 2zm-1.75 3.2a1 1 0 100 2 1 1 0 000-2zm3.5 0a1 1 0 100 2 1 1 0 000-2z"
+      />
+    </svg>
+  );
+}

--- a/src/lib/i18n.tsx
+++ b/src/lib/i18n.tsx
@@ -63,6 +63,19 @@ const DE: Record<string, string> = {
   "landing.github": "Auf GitHub ansehen",
   "landing.scroll": "Live-Demo ↓",
 
+  "download.title": "Herunterladen",
+  "download.subtitle":
+    "Lokale Desktop-App für Claude Code — installieren, starten, verbinden. Für Windows, macOS und Linux.",
+  "download.for": "Download für",
+  "download.download": "Herunterladen",
+  "download.detected": "Dein System",
+  "download.winFile": "Windows 10/11 · .exe-Installer",
+  "download.macFile": "macOS (Apple Silicon) · .dmg",
+  "download.linuxFile": "Linux · .AppImage",
+  "download.unsigned":
+    "Unsigniert (Alpha): Windows-SmartScreen bzw. macOS-Gatekeeper einmalig bestätigen.",
+  "download.allReleases": "Alle Versionen & Release-Notes →",
+
   "common.allProjects": "Alle Projekte",
   "common.close": "Schließen",
   "common.retry": "Erneut versuchen",
@@ -185,6 +198,19 @@ const EN: Record<string, string> = {
     "A live demo with random, simulated Claude tasks is running below — entirely in your browser, no server.",
   "landing.github": "View on GitHub",
   "landing.scroll": "Live demo ↓",
+
+  "download.title": "Download",
+  "download.subtitle":
+    "Local desktop app for Claude Code — install, launch, connect. For Windows, macOS and Linux.",
+  "download.for": "Download for",
+  "download.download": "Download",
+  "download.detected": "Your system",
+  "download.winFile": "Windows 10/11 · .exe installer",
+  "download.macFile": "macOS (Apple Silicon) · .dmg",
+  "download.linuxFile": "Linux · .AppImage",
+  "download.unsigned":
+    "Unsigned (alpha): confirm the Windows SmartScreen / macOS Gatekeeper prompt once.",
+  "download.allReleases": "All versions & release notes →",
 
   "common.allProjects": "All projects",
   "common.close": "Close",


### PR DESCRIPTION
## Summary
Adds an Obsidian-style **Download** section to the public demo site (the landing page shown at the top of the GitHub Pages demo).

- **OS auto-detection** (Windows / macOS / Linux) → highlighted "your system" card + a primary **Download for <OS>** button. Android/mobile correctly shows all options without a desktop CTA.
- **Per-OS cards** with inline OS logos (Windows / Apple / Linux penguin), file descriptions, a Download button each, and a secondary **.deb** link for Linux.
- **Inline monochrome OS glyphs** (`src/components/os-icons.tsx`) — no new dependency.
- **Stable, version-less installer names** via electron-builder `artifactName`, so the `releases/latest/download/*` links the site uses always resolve to the newest installer.
- i18n (DE/EN) for all new copy; README install table updated to the stable filenames.

## Debugging done (verified)
- `tsc --noEmit` ✅, `npm run lint` ✅, `npm test` ✅ (14), normal build ✅, **static demo export build** ✅ (the CI/Pages path).
- Local preview driven with Playwright across spoofed user agents:
  - Windows UA → "Download für Windows", Mac UA → macOS card highlighted (.dmg), Linux UA → Linux (.AppImage), Android → no CTA, all cards shown.
  - All link hrefs verified to the correct `releases/latest/download/*` URLs.
  - Both languages (DE/EN) and mobile (390px, cards stack) checked; **no page errors**.

> Note: the links 404 until the first GitHub Release with the built installers exists; once you publish the release (tag `v0.1.0`, CI attaches the assets), they resolve.

https://claude.ai/code/session_01DF43Ts2scYjnjHn4iF4UYF

---
_Generated by [Claude Code](https://claude.ai/code/session_01DF43Ts2scYjnjHn4iF4UYF)_