### PR TITLE
Fix 404 download links (point to actual v0.1.0 release assets)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 <p align="center">
   <img alt="Status: alpha" src="https://img.shields.io/badge/status-alpha-f59e0b?style=flat-square">
   <img alt="Version 0.1.0" src="https://img.shields.io/badge/version-0.1.0-4f8cff?style=flat-square">
-  <a href="https://github.com/BEKO2210/My_Dash/releases/latest"><img alt="Download" src="https://img.shields.io/badge/download-Win_·_macOS_·_Linux-4f8cff?style=flat-square&logo=github&logoColor=white"></a>
+  <a href="https://github.com/BEKO2210/My_Dash/releases/tag/v0.1.0"><img alt="Download" src="https://img.shields.io/badge/download-Win_·_macOS_·_Linux-4f8cff?style=flat-square&logo=github&logoColor=white"></a>
   <a href="https://beko2210.github.io/My_Dash/"><img alt="Live demo" src="https://img.shields.io/badge/live_demo-online-34d399?style=flat-square&logo=githubpages&logoColor=white"></a>
   <a href="LICENSE"><img alt="License: MIT" src="https://img.shields.io/badge/license-MIT-4f8cff?style=flat-square"></a>
   <a href="CONTRIBUTING.md"><img alt="PRs welcome" src="https://img.shields.io/badge/PRs-welcome-ff6b9d?style=flat-square"></a>
@@ -139,16 +139,16 @@ One Next.js process. SQLite file at `./data/mission-control.db` (gitignored).
 
 ## Install (desktop app)
 
-### ⬇️ [Download the latest release](https://github.com/BEKO2210/My_Dash/releases/latest)
+### ⬇️ [Download v0.1.0 (alpha)](https://github.com/BEKO2210/My_Dash/releases/tag/v0.1.0)
 
 Double-click installers for **Windows, macOS and Linux** are built by the release
 workflow and attached to every [GitHub Release](https://github.com/BEKO2210/My_Dash/releases):
 
-| OS | File ([latest](https://github.com/BEKO2210/My_Dash/releases/latest)) |
+| OS | Direct download |
 |----|------|
-| Windows | `Claude-Mission-Control-Setup.exe` (NSIS installer) |
-| macOS | `Claude-Mission-Control.dmg` (Apple Silicon) |
-| Linux | `Claude-Mission-Control.AppImage` (portable) or `Claude-Mission-Control.deb` |
+| Windows | [`Claude.Mission.Control.Setup.0.1.0.exe`](https://github.com/BEKO2210/My_Dash/releases/download/v0.1.0/Claude.Mission.Control.Setup.0.1.0.exe) (NSIS installer) |
+| macOS | [`Claude.Mission.Control-0.1.0-arm64.dmg`](https://github.com/BEKO2210/My_Dash/releases/download/v0.1.0/Claude.Mission.Control-0.1.0-arm64.dmg) (Apple Silicon) |
+| Linux | [`.AppImage`](https://github.com/BEKO2210/My_Dash/releases/download/v0.1.0/Claude.Mission.Control-0.1.0.AppImage) (portable) or [`.deb`](https://github.com/BEKO2210/My_Dash/releases/download/v0.1.0/claude-mission-control_0.1.0_amd64.deb) |
 
 > **Alpha note:** the installers are **unsigned**. On Windows, SmartScreen shows
 > *More info → Run anyway*; on macOS, right-click the app → **Open** the first time.

--- a/src/components/download.tsx
+++ b/src/components/download.tsx
@@ -6,16 +6,19 @@ import { WindowsIcon, AppleIcon, LinuxIcon } from "@/components/os-icons";
 import { useT } from "@/lib/i18n";
 
 const REPO = "https://github.com/BEKO2210/My_Dash";
-const LATEST = `${REPO}/releases/latest/download`;
 const ALL_RELEASES = `${REPO}/releases`;
 
-// Stable, version-less asset names (see electron-builder `artifactName` in
-// package.json) so these links always resolve to the newest release.
+// Pinned to the published v0.1.0 release assets (verified live). The v0.1.0 tag
+// predates the stable artifactName config, so its filenames are version-stamped;
+// once a release is cut from main as a normal (non-prerelease) release, these can
+// move to the stable `releases/latest/download/Claude-Mission-Control*` form.
+const TAG = "v0.1.0";
+const DL = `${REPO}/releases/download/${TAG}`;
 const URLS = {
-  windows: `${LATEST}/Claude-Mission-Control-Setup.exe`,
-  mac: `${LATEST}/Claude-Mission-Control.dmg`,
-  linuxAppImage: `${LATEST}/Claude-Mission-Control.AppImage`,
-  linuxDeb: `${LATEST}/Claude-Mission-Control.deb`,
+  windows: `${DL}/Claude.Mission.Control.Setup.0.1.0.exe`,
+  mac: `${DL}/Claude.Mission.Control-0.1.0-arm64.dmg`,
+  linuxAppImage: `${DL}/Claude.Mission.Control-0.1.0.AppImage`,
+  linuxDeb: `${DL}/claude-mission-control_0.1.0_amd64.deb`,
 };
 
 type OS = "windows" | "mac" | "linux";


### PR DESCRIPTION
## Summary
Fixes the **404 on every download link**. Root cause was two things:

1. The published **`v0.1.0` release is a prerelease**, and GitHub's `releases/latest/download/…` (which the site/README used) **ignores prereleases** → 404.
2. The `v0.1.0` tag predates the stable `artifactName` config, so its built assets are **version-stamped** (`Claude.Mission.Control.Setup.0.1.0.exe`, `…-arm64.dmg`, etc.) — not the stable names the links expected.

The installers themselves are fine and uploaded. This points the download buttons (`download.tsx`) and the README at the **actual, verified-live** tag-pinned assets:

| OS | Asset (HTTP 200 ✓) |
|----|------|
| Windows | `releases/download/v0.1.0/Claude.Mission.Control.Setup.0.1.0.exe` |
| macOS (arm64) | `releases/download/v0.1.0/Claude.Mission.Control-0.1.0-arm64.dmg` |
| Linux | `…/Claude.Mission.Control-0.1.0.AppImage` · `…/claude-mission-control_0.1.0_amd64.deb` |

All four URLs were checked with `curl` and return **200**.

## Follow-up (optional, for clean auto-latest links)
To go back to stable `releases/latest/download/Claude-Mission-Control*.…` links (which auto-track the newest version), cut a release from **current `main`** (it has the stable artifact names) and publish it as a **normal release, not a prerelease**. The electron-builder config already produces the stable names.

## Verification
- `curl -I` on all 4 asset URLs → 200.
- `tsc --noEmit` ✅, `npm run lint` ✅.

https://claude.ai/code/session_01DF43Ts2scYjnjHn4iF4UYF

---
_Generated by [Claude Code](https://claude.ai/code/session_01DF43Ts2scYjnjHn4iF4UYF)_