### PR TITLE
Run 1: Add CI workflow (lint, test, build)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: CI
+
+# Lint, test and build on every pull request and on pushes to main.
+# This is the green gate every change must pass before it can be merged —
+# the safety net the rest of the roadmap builds on.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# Newer pushes to the same branch/PR cancel in-flight runs.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Test
+        run: npm test
+
+      # Full production build (better-sqlite3 builds during npm ci; the DB layer
+      # uses an in-memory database during `next build`, so no data dir is needed).
+      - name: Build
+        run: npm run build


### PR DESCRIPTION
## Summary

**Roadmap Run 1 — CI-Pipeline.** Adds `.github/workflows/ci.yml`, the green gate every change must pass before merge. The rest of the roadmap builds on this safety net (the repo previously had only Pages + Release workflows, no test/lint CI).

The workflow runs on every pull request and on pushes to `main`:
1. `npm ci`
2. `npm run lint` (eslint)
3. `npm test` (vitest)
4. `npm run build` (production `next build`)

Conventions match the existing workflows: Node 20, npm cache, `actions/checkout@v4` + `actions/setup-node@v4`. Adds `concurrency` so newer pushes cancel in-flight runs, and `permissions: contents: read`.

No application code changed.

## Verified locally

- `npm run lint` → clean
- `npm test` → 14 tests pass
- `npm run build` → succeeds (all 8 routes compiled)

## Test plan

- [ ] CI workflow appears and passes green on this PR
- [ ] Confirm it triggers on PRs and on pushes to main

https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk)_