### PR TITLE
Run 3: Extract graph builder into a testable pure module

### DIFF
--- a/src/app/api/graph/route.ts
+++ b/src/app/api/graph/route.ts
@@ -1,97 +1,13 @@
 import { NextResponse } from "next/server";
 import { db } from "@/lib/db";
+import { buildGraphData, type PromptRow } from "@/lib/graph";
 import type { SessionRow, ToolCallRow } from "@/lib/types";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-type NodeType = "session" | "tool" | "file" | "prompt";
-// Refines a "file"-type (resource) node so both Claude and humans see what it is.
-type TargetKind = "file" | "command" | "url" | "pattern";
-
-interface GraphNode {
-  id: string;
-  label: string;
-  type: NodeType;
-  val: number;
-  // Extra context surfaced when a node is clicked in the 3D graph.
-  meta?: {
-    sessionId?: string;
-    project?: string | null;
-    status?: string;
-    lastSeen?: string;
-    path?: string;
-    kind?: TargetKind;
-    calls?: number;
-    role?: "user" | "agent";
-    text?: string;
-  };
-}
-interface GraphLink {
-  source: string;
-  target: string;
-}
-
-function clip(s: string, n: number): string {
-  const t = s.replace(/\s+/g, " ").trim();
-  return t.length > n ? t.slice(0, n - 1) + "…" : t;
-}
-
-// Executable of a shell command: drop leading VAR=val and take the first program
-// of the first sub-command. Grouping by this collapses noisy unique commands
-// (e.g. dozens of `grep …`) into one readable "grep" node.
-function programName(cmd: string): string {
-  // Scan sub-commands; skip pure `cd`/env prefixes so the *real* program groups
-  // (e.g. `cd x && node …` → "node", not "cd").
-  const parts = cmd.trim().split(/&&|\|\||[;|]/);
-  for (const part of parts) {
-    const tokens = part.trim().split(/\s+/).filter(Boolean);
-    let i = 0;
-    while (i < tokens.length && /^[A-Za-z_][A-Za-z0-9_]*=/.test(tokens[i])) i++;
-    let prog = tokens[i];
-    if (!prog || prog === "cd") continue;
-    if (prog.includes("/")) prog = prog.split("/").pop() || prog;
-    return prog;
-  }
-  return "cd";
-}
-
-// Turn a raw tool target into a compact, unambiguous node: stable key (so equal
-// targets share a node across sessions), short label, explicit kind, full value.
-function describeTarget(
-  toolName: string | null,
-  raw: string,
-): { key: string; label: string; kind: TargetKind; full: string } {
-  const t = raw.trim();
-
-  if (/^https?:\/\//i.test(t)) {
-    try {
-      const host = new URL(t).host;
-      return { key: `u:${host}`, label: host, kind: "url", full: t };
-    } catch {
-      /* fall through */
-    }
-  }
-
-  const looksPath =
-    t.startsWith("/") || t.startsWith("./") || t.startsWith("../") || t.startsWith("~") || (!/\s/.test(t) && t.includes("/"));
-
-  if (toolName === "Bash" || (!looksPath && /\s/.test(t))) {
-    const prog = programName(t);
-    return { key: `cmd:${prog}`, label: prog, kind: "command", full: t };
-  }
-
-  if (looksPath) {
-    const parts = t.replace(/\/+$/, "").split("/").filter(Boolean);
-    return { key: `f:${t}`, label: parts.slice(-2).join("/") || t, kind: "file", full: t };
-  }
-
-  const label = t.length > 24 ? t.slice(0, 23) + "…" : t;
-  return { key: `q:${t}`, label, kind: "pattern", full: t };
-}
-
-// Builds Session -> Tool -> Resource. Resource ids are global so the same file/command/url
-// across sessions links them — that's what makes the 3D graph reveal structure.
+// Reads the rows for the most recent sessions and hands them to the pure
+// graph-assembler (src/lib/graph.ts) to build Session -> Tool -> Resource.
 export async function GET(req: Request) {
   try {
     return buildGraph(req);
@@ -109,105 +25,18 @@ function buildGraph(req: Request) {
     .prepare(`SELECT * FROM sessions ORDER BY datetime(last_seen) DESC LIMIT ?`)
     .all(sessionLimit) as SessionRow[];
 
-  const nodes = new Map<string, GraphNode>();
-  const links: GraphLink[] = [];
-  const linkSeen = new Set<string>();
-
-  const addNode = (id: string, label: string, type: NodeType, meta?: GraphNode["meta"]) => {
-    const n = nodes.get(id);
-    if (n) {
-      n.val += 1;
-      if (n.meta) n.meta.calls = (n.meta.calls ?? 1) + 1;
-    } else {
-      nodes.set(id, { id, label, type, val: 1, meta: { ...meta, calls: 1 } });
-    }
-  };
-  const addLink = (source: string, target: string) => {
-    const key = `${source}->${target}`;
-    if (linkSeen.has(key)) return;
-    linkSeen.add(key);
-    links.push({ source, target });
-  };
-
   const callsForSession = db.prepare(`SELECT * FROM tool_calls WHERE session_id = ? LIMIT 300`);
   const promptsForSession = db.prepare(
     `SELECT summary, payload_json, created_at FROM events
      WHERE session_id = ? AND event_type = 'UserPromptSubmit' ORDER BY id ASC LIMIT 60`,
   );
 
+  const promptsBySession = new Map<string, PromptRow[]>();
+  const callsBySession = new Map<string, ToolCallRow[]>();
   for (const s of sessions) {
-    const sid = `s:${s.id}`;
-    nodes.set(sid, {
-      id: sid,
-      label: s.title || s.project_name || s.id.slice(0, 8),
-      type: "session",
-      val: 3,
-      meta: {
-        sessionId: s.id,
-        project: s.project_name,
-        status: s.status,
-        lastSeen: s.last_seen,
-      },
-    });
-
-    // Your prompts: each UserPromptSubmit becomes a prompt node hanging off the session.
-    const prompts = promptsForSession.all(s.id) as {
-      summary: string | null;
-      payload_json: string;
-      created_at: string;
-    }[];
-    prompts.forEach((p, i) => {
-      let text = "";
-      try {
-        const pj = JSON.parse(p.payload_json);
-        if (typeof pj.prompt === "string") text = pj.prompt;
-      } catch {
-        /* fall back to summary */
-      }
-      if (!text && p.summary) text = p.summary.replace(/^Prompt:\s*/, "");
-      text = text.trim();
-      if (!text) return;
-      const pid = `p:${s.id}:${i}`;
-      nodes.set(pid, {
-        id: pid,
-        label: clip(text, 32),
-        type: "prompt",
-        val: 1.8,
-        meta: { role: "user", text: clip(text, 500), lastSeen: p.created_at },
-      });
-      addLink(sid, pid);
-    });
-
-    const calls = callsForSession.all(s.id) as ToolCallRow[];
-    for (const c of calls) {
-      const tid = `t:${s.id}:${c.tool_name}`;
-      addNode(tid, c.tool_name, "tool");
-      addLink(sid, tid);
-
-      if (!c.target) continue;
-
-      // Claude's prompts to sub-agents (Task) become prompt nodes; other targets
-      // become file/command/url/pattern resources.
-      if (c.tool_name === "Task") {
-        const pid = `pa:${s.id}:${c.target}`;
-        addNode(pid, clip(c.target, 32), "prompt", { role: "agent", text: clip(c.target, 500) });
-        addLink(tid, pid);
-      } else {
-        const d = describeTarget(c.tool_name, c.target);
-        addNode(d.key, d.label, "file", { path: d.full, kind: d.kind });
-        addLink(tid, d.key);
-      }
-    }
+    promptsBySession.set(s.id, promptsForSession.all(s.id) as PromptRow[]);
+    callsBySession.set(s.id, callsForSession.all(s.id) as ToolCallRow[]);
   }
 
-  // Drop isolated nodes (e.g. a session with no tools/prompts). A lone, unconnected
-  // node only pushes the force layout — and the initial camera — far out.
-  const linked = new Set<string>();
-  for (const l of links) {
-    linked.add(l.source);
-    linked.add(l.target);
-  }
-  const connected = [...nodes.values()].filter((n) => linked.has(n.id));
-
-  return NextResponse.json({ nodes: connected, links });
+  return NextResponse.json(buildGraphData(sessions, promptsBySession, callsBySession));
 }

--- a/src/lib/graph.test.ts
+++ b/src/lib/graph.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, it } from "vitest";
+import { buildGraphData, describeTarget, programName, type PromptRow } from "@/lib/graph";
+import type { SessionRow, ToolCallRow } from "@/lib/types";
+
+function mkSession(over: Partial<SessionRow> & { id: string }): SessionRow {
+  return {
+    id: over.id,
+    project_path: "/home/user/proj",
+    project_name: "proj",
+    title: null,
+    status: "active",
+    source: null,
+    first_seen: "2026-05-23 10:00:00",
+    last_seen: "2026-05-23 10:00:00",
+    ended_at: null,
+    token_input: 0,
+    token_output: 0,
+    cost_usd: 0,
+    ...over,
+  };
+}
+
+function mkCall(over: Partial<ToolCallRow> & { session_id: string; tool_name: string }): ToolCallRow {
+  return {
+    id: 1,
+    target: null,
+    duration_ms: null,
+    success: 1,
+    created_at: "2026-05-23 10:00:00",
+    ...over,
+  };
+}
+
+describe("programName", () => {
+  it("takes the first program of a simple command", () => {
+    expect(programName("grep -r foo .")).toBe("grep");
+  });
+
+  it("skips leading VAR=val assignments", () => {
+    expect(programName("FOO=bar node script.js")).toBe("node");
+  });
+
+  it("skips a cd prefix and groups the real program", () => {
+    expect(programName("cd /x && node app.js")).toBe("node");
+  });
+
+  it("reduces an absolute path to its basename", () => {
+    expect(programName("/usr/bin/python3 main.py")).toBe("python3");
+  });
+
+  it("uses the first sub-command of a pipe", () => {
+    expect(programName("ls -la | grep foo")).toBe("ls");
+  });
+
+  it("falls back to cd when there is nothing else", () => {
+    expect(programName("cd /some/dir")).toBe("cd");
+  });
+});
+
+describe("describeTarget", () => {
+  it("classifies an http(s) target by host", () => {
+    const d = describeTarget("WebFetch", "https://example.com/a/b?q=1");
+    expect(d).toMatchObject({ key: "u:example.com", label: "example.com", kind: "url" });
+  });
+
+  it("classifies an absolute path as a file with a 2-segment label", () => {
+    const d = describeTarget("Read", "/home/user/My_Dash/src/lib/db.ts");
+    expect(d.kind).toBe("file");
+    expect(d.key).toBe("f:/home/user/My_Dash/src/lib/db.ts");
+    expect(d.label).toBe("lib/db.ts");
+  });
+
+  it("treats a slash-bearing relative target without spaces as a file", () => {
+    expect(describeTarget("Read", "src/lib/db.ts").kind).toBe("file");
+  });
+
+  it("classifies a Bash target as a command keyed by program", () => {
+    const d = describeTarget("Bash", "npm run build");
+    expect(d).toMatchObject({ key: "cmd:npm", label: "npm", kind: "command" });
+  });
+
+  it("treats a spaced non-path target from any tool as a command", () => {
+    expect(describeTarget(null, "some free text").kind).toBe("command");
+  });
+
+  it("classifies a plain token as a pattern", () => {
+    const d = describeTarget("Grep", "TODO");
+    expect(d).toMatchObject({ key: "q:TODO", label: "TODO", kind: "pattern" });
+  });
+
+  it("truncates a long pattern label", () => {
+    const d = describeTarget("Grep", "x".repeat(40));
+    expect(d.kind).toBe("pattern");
+    expect(d.label.length).toBe(24);
+    expect(d.label.endsWith("…")).toBe(true);
+  });
+});
+
+describe("buildGraphData", () => {
+  const noPrompts = new Map<string, PromptRow[]>();
+
+  it("prunes a session with no tools or prompts", () => {
+    const data = buildGraphData([mkSession({ id: "s1" })], noPrompts, new Map());
+    expect(data.nodes).toEqual([]);
+    expect(data.links).toEqual([]);
+  });
+
+  it("builds session -> tool -> file and dedups a shared resource across sessions", () => {
+    const sessions = [mkSession({ id: "A" }), mkSession({ id: "B" })];
+    const calls = new Map<string, ToolCallRow[]>([
+      ["A", [mkCall({ session_id: "A", tool_name: "Read", target: "/x.ts" })]],
+      ["B", [mkCall({ session_id: "B", tool_name: "Read", target: "/x.ts" })]],
+    ]);
+    const { nodes, links } = buildGraphData(sessions, noPrompts, calls);
+
+    const file = nodes.find((n) => n.id === "f:/x.ts");
+    expect(file).toBeDefined();
+    expect(file!.type).toBe("file");
+    // Same file referenced from both sessions -> one shared node, val/calls bumped.
+    expect(file!.val).toBe(2);
+    expect(file!.meta?.calls).toBe(2);
+
+    // Tool nodes are per-session; the file node is global.
+    expect(nodes.filter((n) => n.type === "tool").map((n) => n.id).sort()).toEqual([
+      "t:A:Read",
+      "t:B:Read",
+    ]);
+    expect(links).toContainEqual({ source: "s:A", target: "t:A:Read" });
+    expect(links).toContainEqual({ source: "t:A:Read", target: "f:/x.ts" });
+    expect(links).toContainEqual({ source: "t:B:Read", target: "f:/x.ts" });
+  });
+
+  it("dedups repeated links and bumps the per-session tool node value", () => {
+    const calls = new Map<string, ToolCallRow[]>([
+      [
+        "A",
+        [
+          mkCall({ session_id: "A", tool_name: "Read", target: "/x.ts" }),
+          mkCall({ session_id: "A", tool_name: "Read", target: "/x.ts" }),
+        ],
+      ],
+    ]);
+    const { nodes, links } = buildGraphData([mkSession({ id: "A" })], noPrompts, calls);
+    const tool = nodes.find((n) => n.id === "t:A:Read");
+    expect(tool!.val).toBe(2); // two calls increment the node
+    // ...but the identical links collapse to one each.
+    expect(links.filter((l) => l.source === "s:A" && l.target === "t:A:Read")).toHaveLength(1);
+    expect(links.filter((l) => l.source === "t:A:Read" && l.target === "f:/x.ts")).toHaveLength(1);
+  });
+
+  it("makes a Task target an agent prompt node, not a file", () => {
+    const calls = new Map<string, ToolCallRow[]>([
+      ["A", [mkCall({ session_id: "A", tool_name: "Task", target: "investigate the bug" })]],
+    ]);
+    const { nodes } = buildGraphData([mkSession({ id: "A" })], noPrompts, calls);
+    const agent = nodes.find((n) => n.id === "pa:A:investigate the bug");
+    expect(agent!.type).toBe("prompt");
+    expect(agent!.meta?.role).toBe("agent");
+  });
+
+  it("creates a tool node with no resource when the call has no target", () => {
+    const calls = new Map<string, ToolCallRow[]>([
+      ["A", [mkCall({ session_id: "A", tool_name: "Bash", target: null })]],
+    ]);
+    const { nodes, links } = buildGraphData([mkSession({ id: "A" })], noPrompts, calls);
+    expect(nodes.map((n) => n.type).sort()).toEqual(["session", "tool"]);
+    expect(links).toEqual([{ source: "s:A", target: "t:A:Bash" }]);
+  });
+
+  it("derives prompt text from payload_json and links it to the session", () => {
+    const prompts = new Map<string, PromptRow[]>([
+      [
+        "A",
+        [{ summary: "Prompt: ignored", payload_json: '{"prompt":"do the thing"}', created_at: "t" }],
+      ],
+    ]);
+    const { nodes, links } = buildGraphData([mkSession({ id: "A" })], prompts, new Map());
+    const prompt = nodes.find((n) => n.type === "prompt");
+    expect(prompt!.label).toBe("do the thing");
+    expect(prompt!.meta?.role).toBe("user");
+    expect(links).toContainEqual({ source: "s:A", target: "p:A:0" });
+  });
+
+  it("falls back to the summary (minus the 'Prompt:' prefix) when payload has no prompt", () => {
+    const prompts = new Map<string, PromptRow[]>([
+      ["A", [{ summary: "Prompt: hello there", payload_json: "{}", created_at: "t" }]],
+    ]);
+    const { nodes } = buildGraphData([mkSession({ id: "A" })], prompts, new Map());
+    expect(nodes.find((n) => n.type === "prompt")!.label).toBe("hello there");
+  });
+
+  it("skips an empty prompt", () => {
+    const prompts = new Map<string, PromptRow[]>([
+      ["A", [{ summary: null, payload_json: "{}", created_at: "t" }]],
+    ]);
+    const { nodes } = buildGraphData([mkSession({ id: "A" })], prompts, new Map());
+    expect(nodes).toEqual([]); // session has no links -> pruned
+  });
+});

--- a/src/lib/graph.ts
+++ b/src/lib/graph.ts
@@ -1,0 +1,202 @@
+import type { SessionRow, ToolCallRow } from "./types";
+
+// Pure graph-assembly logic for /api/graph, kept free of the DB and Next.js so it
+// can be unit-tested in isolation. The route fetches rows and hands them here.
+
+export type NodeType = "session" | "tool" | "file" | "prompt";
+// Refines a "file"-type (resource) node so both Claude and humans see what it is.
+export type TargetKind = "file" | "command" | "url" | "pattern";
+
+export interface GraphNode {
+  id: string;
+  label: string;
+  type: NodeType;
+  val: number;
+  // Extra context surfaced when a node is clicked in the 3D graph.
+  meta?: {
+    sessionId?: string;
+    project?: string | null;
+    status?: string;
+    lastSeen?: string;
+    path?: string;
+    kind?: TargetKind;
+    calls?: number;
+    role?: "user" | "agent";
+    text?: string;
+  };
+}
+
+export interface GraphLink {
+  source: string;
+  target: string;
+}
+
+export interface GraphData {
+  nodes: GraphNode[];
+  links: GraphLink[];
+}
+
+// One UserPromptSubmit event, as read for a session's prompt nodes.
+export interface PromptRow {
+  summary: string | null;
+  payload_json: string;
+  created_at: string;
+}
+
+export function clip(s: string, n: number): string {
+  const t = s.replace(/\s+/g, " ").trim();
+  return t.length > n ? t.slice(0, n - 1) + "…" : t;
+}
+
+// Executable of a shell command: drop leading VAR=val and take the first program
+// of the first sub-command. Grouping by this collapses noisy unique commands
+// (e.g. dozens of `grep …`) into one readable "grep" node.
+export function programName(cmd: string): string {
+  // Scan sub-commands; skip pure `cd`/env prefixes so the *real* program groups
+  // (e.g. `cd x && node …` → "node", not "cd").
+  const parts = cmd.trim().split(/&&|\|\||[;|]/);
+  for (const part of parts) {
+    const tokens = part.trim().split(/\s+/).filter(Boolean);
+    let i = 0;
+    while (i < tokens.length && /^[A-Za-z_][A-Za-z0-9_]*=/.test(tokens[i])) i++;
+    let prog = tokens[i];
+    if (!prog || prog === "cd") continue;
+    if (prog.includes("/")) prog = prog.split("/").pop() || prog;
+    return prog;
+  }
+  return "cd";
+}
+
+// Turn a raw tool target into a compact, unambiguous node: stable key (so equal
+// targets share a node across sessions), short label, explicit kind, full value.
+export function describeTarget(
+  toolName: string | null,
+  raw: string,
+): { key: string; label: string; kind: TargetKind; full: string } {
+  const t = raw.trim();
+
+  if (/^https?:\/\//i.test(t)) {
+    try {
+      const host = new URL(t).host;
+      return { key: `u:${host}`, label: host, kind: "url", full: t };
+    } catch {
+      /* fall through */
+    }
+  }
+
+  const looksPath =
+    t.startsWith("/") || t.startsWith("./") || t.startsWith("../") || t.startsWith("~") || (!/\s/.test(t) && t.includes("/"));
+
+  if (toolName === "Bash" || (!looksPath && /\s/.test(t))) {
+    const prog = programName(t);
+    return { key: `cmd:${prog}`, label: prog, kind: "command", full: t };
+  }
+
+  if (looksPath) {
+    const parts = t.replace(/\/+$/, "").split("/").filter(Boolean);
+    return { key: `f:${t}`, label: parts.slice(-2).join("/") || t, kind: "file", full: t };
+  }
+
+  const label = t.length > 24 ? t.slice(0, 23) + "…" : t;
+  return { key: `q:${t}`, label, kind: "pattern", full: t };
+}
+
+// Builds Session -> Tool -> Resource. Resource ids are global so the same file/command/url
+// across sessions links them — that's what makes the 3D graph reveal structure.
+export function buildGraphData(
+  sessions: SessionRow[],
+  promptsBySession: Map<string, PromptRow[]>,
+  callsBySession: Map<string, ToolCallRow[]>,
+): GraphData {
+  const nodes = new Map<string, GraphNode>();
+  const links: GraphLink[] = [];
+  const linkSeen = new Set<string>();
+
+  const addNode = (id: string, label: string, type: NodeType, meta?: GraphNode["meta"]) => {
+    const n = nodes.get(id);
+    if (n) {
+      n.val += 1;
+      if (n.meta) n.meta.calls = (n.meta.calls ?? 1) + 1;
+    } else {
+      nodes.set(id, { id, label, type, val: 1, meta: { ...meta, calls: 1 } });
+    }
+  };
+  const addLink = (source: string, target: string) => {
+    const key = `${source}->${target}`;
+    if (linkSeen.has(key)) return;
+    linkSeen.add(key);
+    links.push({ source, target });
+  };
+
+  for (const s of sessions) {
+    const sid = `s:${s.id}`;
+    nodes.set(sid, {
+      id: sid,
+      label: s.title || s.project_name || s.id.slice(0, 8),
+      type: "session",
+      val: 3,
+      meta: {
+        sessionId: s.id,
+        project: s.project_name,
+        status: s.status,
+        lastSeen: s.last_seen,
+      },
+    });
+
+    // Your prompts: each UserPromptSubmit becomes a prompt node hanging off the session.
+    const prompts = promptsBySession.get(s.id) ?? [];
+    prompts.forEach((p, i) => {
+      let text = "";
+      try {
+        const pj = JSON.parse(p.payload_json);
+        if (typeof pj.prompt === "string") text = pj.prompt;
+      } catch {
+        /* fall back to summary */
+      }
+      if (!text && p.summary) text = p.summary.replace(/^Prompt:\s*/, "");
+      text = text.trim();
+      if (!text) return;
+      const pid = `p:${s.id}:${i}`;
+      nodes.set(pid, {
+        id: pid,
+        label: clip(text, 32),
+        type: "prompt",
+        val: 1.8,
+        meta: { role: "user", text: clip(text, 500), lastSeen: p.created_at },
+      });
+      addLink(sid, pid);
+    });
+
+    const calls = callsBySession.get(s.id) ?? [];
+    for (const c of calls) {
+      const tid = `t:${s.id}:${c.tool_name}`;
+      addNode(tid, c.tool_name, "tool");
+      addLink(sid, tid);
+
+      if (!c.target) continue;
+
+      // Claude's prompts to sub-agents (Task) become prompt nodes; other targets
+      // become file/command/url/pattern resources.
+      if (c.tool_name === "Task") {
+        const pid = `pa:${s.id}:${c.target}`;
+        addNode(pid, clip(c.target, 32), "prompt", { role: "agent", text: clip(c.target, 500) });
+        addLink(tid, pid);
+      } else {
+        const d = describeTarget(c.tool_name, c.target);
+        addNode(d.key, d.label, "file", { path: d.full, kind: d.kind });
+        addLink(tid, d.key);
+      }
+    }
+  }
+
+  // Drop isolated nodes (e.g. a session with no tools/prompts). A lone, unconnected
+  // node only pushes the force layout — and the initial camera — far out.
+  const linked = new Set<string>();
+  for (const l of links) {
+    linked.add(l.source);
+    linked.add(l.target);
+  }
+  const connected = [...nodes.values()].filter((n) => linked.has(n.id));
+
+  return { nodes: connected, links };
+}


### PR DESCRIPTION
## Summary

Roadmap **Run 3 — Make the graph builder testable.** Extracts the pure logic out of `src/app/api/graph/route.ts` into a new `src/lib/graph.ts`, then adds unit tests for it. **No behavior change** — the route still produces the same `{ nodes, links }`.

- **New `src/lib/graph.ts`** — exports the graph types plus the pure functions: `clip`, `programName`, `describeTarget`, and `buildGraphData(sessions, promptsBySession, callsBySession)`.
- **Slimmed route** — `route.ts` now only runs the DB queries (sessions, per-session prompts + tool_calls), builds the maps, and delegates to `buildGraphData`. Still `runtime=nodejs`, `force-dynamic`, read-only.
- **New `src/lib/graph.test.ts`** (21 tests) covering:
  - `programName` — first program, skipping `VAR=val` and `cd` prefixes, pipe sub-commands, path basename.
  - `describeTarget` — url/file/command/pattern classification + label truncation.
  - `buildGraphData` — cross-session resource dedup (shared file node, bumped `val`/`calls`), link dedup, `Task` → agent prompt node, prompt-text-from-payload with summary fallback, empty-prompt skip, and isolated-node pruning.

49 tests pass total (21 new + 28 existing).

## Test plan

- [x] `npm run lint` — clean
- [x] `npm test` — 49 passed
- [x] `npm run build` — succeeds (graph route still builds)
- [ ] CI `verify` job green on this PR

https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk)_