### PR TITLE
Run 4: Make the ccusage parser unit-testable

### DIFF
--- a/src/lib/ccusage.test.ts
+++ b/src/lib/ccusage.test.ts
@@ -1,0 +1,171 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  buildReport,
+  empty,
+  eurRate,
+  mapBlockRows,
+  mapDailyRows,
+  type CcusageBlock,
+  type CcusageDaily,
+} from "@/lib/ccusage";
+
+const NOW = Date.parse("2026-05-23T12:00:00Z");
+
+describe("mapDailyRows", () => {
+  it("maps a full row and converts cost to EUR", () => {
+    const rows: CcusageDaily[] = [
+      {
+        period: "2026-05-23",
+        inputTokens: 100,
+        outputTokens: 200,
+        cacheCreationTokens: 30,
+        cacheReadTokens: 70,
+        totalTokens: 400,
+        totalCost: 2,
+      },
+    ];
+    expect(mapDailyRows(rows, 0.5)).toEqual([
+      {
+        date: "2026-05-23",
+        inputTokens: 100,
+        outputTokens: 200,
+        cacheTokens: 100, // creation + read
+        totalTokens: 400,
+        costUsd: 2,
+        costEur: 1, // 2 * 0.5
+      },
+    ]);
+  });
+
+  it("defaults every missing field to 0", () => {
+    expect(mapDailyRows([{}], 0.92)).toEqual([
+      {
+        date: "",
+        inputTokens: 0,
+        outputTokens: 0,
+        cacheTokens: 0,
+        totalTokens: 0,
+        costUsd: 0,
+        costEur: 0,
+      },
+    ]);
+  });
+
+  it("returns an empty array for no rows", () => {
+    expect(mapDailyRows([], 0.92)).toEqual([]);
+  });
+});
+
+describe("mapBlockRows", () => {
+  const recent: CcusageBlock = {
+    startTime: "2026-05-23T10:00:00Z",
+    endTime: "2026-05-23T11:00:00Z",
+    isActive: true,
+    costUSD: 4,
+    tokenCounts: {
+      inputTokens: 10,
+      outputTokens: 20,
+      cacheCreationInputTokens: 5,
+      cacheReadInputTokens: 5,
+    },
+  };
+
+  it("maps a recent block, summing cache tokens and converting cost", () => {
+    const [b] = mapBlockRows([recent], 0.5, NOW);
+    expect(b).toMatchObject({
+      start: "2026-05-23T10:00:00Z",
+      isActive: true,
+      inputTokens: 10,
+      outputTokens: 20,
+      cacheTokens: 10,
+      totalTokens: 40, // fallback: input + output + cache
+      costUsd: 4,
+      costEur: 2,
+    });
+  });
+
+  it("prefers an explicit totalTokens over the fallback sum", () => {
+    expect(mapBlockRows([{ ...recent, totalTokens: 999 }], 0.5, NOW)[0].totalTokens).toBe(999);
+  });
+
+  it("drops gap blocks, undated blocks and blocks older than 24h", () => {
+    const old: CcusageBlock = { startTime: "2026-05-21T10:00:00Z", endTime: "2026-05-21T11:00:00Z" };
+    const gap: CcusageBlock = { ...recent, isGap: true };
+    const undated: CcusageBlock = { costUSD: 1 };
+    expect(mapBlockRows([recent, old, gap, undated], 0.92, NOW)).toHaveLength(1);
+  });
+});
+
+describe("buildReport", () => {
+  it("sums totals across days and includes mapped blocks", () => {
+    const daily: CcusageDaily[] = [
+      { period: "d1", inputTokens: 1, outputTokens: 2, totalTokens: 3, totalCost: 1 },
+      { period: "d2", inputTokens: 4, outputTokens: 8, totalTokens: 12, totalCost: 3 },
+    ];
+    const blocks: CcusageBlock[] = [{ startTime: "2026-05-23T10:00:00Z", costUSD: 1 }];
+    const report = buildReport(daily, blocks, 1, NOW);
+
+    expect(report.available).toBe(true);
+    expect(report.days).toHaveLength(2);
+    expect(report.blocks).toHaveLength(1);
+    expect(report.totals).toMatchObject({
+      inputTokens: 5,
+      outputTokens: 10,
+      totalTokens: 15,
+      costUsd: 4,
+      costEur: 4,
+    });
+  });
+
+  it("treats null blocks (command unavailable) as an empty list but still reports daily", () => {
+    const report = buildReport([{ period: "d1", totalCost: 1 }], null, 1, NOW);
+    expect(report.available).toBe(true);
+    expect(report.days).toHaveLength(1);
+    expect(report.blocks).toEqual([]);
+  });
+
+  it("yields zeroed totals for no data", () => {
+    const report = buildReport([], null, 0.92, NOW);
+    expect(report.days).toEqual([]);
+    expect(report.totals).toEqual({
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheTokens: 0,
+      totalTokens: 0,
+      costUsd: 0,
+      costEur: 0,
+    });
+  });
+});
+
+describe("empty", () => {
+  it("is the graceful-degradation report (available=false)", () => {
+    const e = empty();
+    expect(e.available).toBe(false);
+    expect(e.days).toEqual([]);
+    expect(e.blocks).toEqual([]);
+    expect(e.totals.totalTokens).toBe(0);
+  });
+});
+
+describe("eurRate", () => {
+  const original = process.env.EUR_PER_USD;
+  afterEach(() => {
+    if (original === undefined) delete process.env.EUR_PER_USD;
+    else process.env.EUR_PER_USD = original;
+  });
+
+  it("defaults to 0.92 when unset or invalid", () => {
+    delete process.env.EUR_PER_USD;
+    expect(eurRate()).toBe(0.92);
+    process.env.EUR_PER_USD = "not-a-number";
+    expect(eurRate()).toBe(0.92);
+    process.env.EUR_PER_USD = "-1";
+    expect(eurRate()).toBe(0.92);
+  });
+
+  it("honours a valid override", () => {
+    process.env.EUR_PER_USD = "0.8";
+    expect(eurRate()).toBe(0.8);
+  });
+});

--- a/src/lib/ccusage.ts
+++ b/src/lib/ccusage.ts
@@ -40,7 +40,7 @@ export interface UsageReport {
   available: boolean; // false when ccusage couldn't run (offline / no data)
 }
 
-interface CcusageDaily {
+export interface CcusageDaily {
   period?: string;
   inputTokens?: number;
   outputTokens?: number;
@@ -50,7 +50,7 @@ interface CcusageDaily {
   totalCost?: number;
 }
 
-interface CcusageBlock {
+export interface CcusageBlock {
   startTime?: string;
   endTime?: string;
   isActive?: boolean;
@@ -68,18 +68,88 @@ interface CcusageBlock {
 const TTL_MS = 30_000;
 let cache: { at: number; report: UsageReport } | null = null;
 
-function eurRate(): number {
+export function eurRate(): number {
   const r = Number(process.env.EUR_PER_USD);
   return Number.isFinite(r) && r > 0 ? r : 0.92;
 }
 
-function empty(): UsageReport {
+export function empty(): UsageReport {
   return {
     days: [],
     blocks: [],
     totals: { inputTokens: 0, outputTokens: 0, cacheTokens: 0, totalTokens: 0, costUsd: 0, costEur: 0 },
     available: false,
   };
+}
+
+// ── Pure parsers (no exec, no cache) so the mapping is unit-testable ──────────
+
+export function mapDailyRows(rows: CcusageDaily[], rate: number): UsageDay[] {
+  return rows.map((d) => {
+    const cacheTokens = (d.cacheCreationTokens ?? 0) + (d.cacheReadTokens ?? 0);
+    const costUsd = d.totalCost ?? 0;
+    return {
+      date: d.period ?? "",
+      inputTokens: d.inputTokens ?? 0,
+      outputTokens: d.outputTokens ?? 0,
+      cacheTokens,
+      totalTokens: d.totalTokens ?? 0,
+      costUsd,
+      costEur: costUsd * rate,
+    };
+  });
+}
+
+// Keep only non-gap blocks whose end falls within the 24h before `now`.
+export function mapBlockRows(rows: CcusageBlock[], rate: number, now: number): UsageBlock[] {
+  const since = now - 24 * 60 * 60 * 1000;
+  return rows
+    .filter((b) => {
+      if (b.isGap || !b.startTime) return false;
+      const end = Date.parse(b.endTime ?? b.startTime);
+      return Number.isFinite(end) && end >= since;
+    })
+    .map((b) => {
+      const tc = b.tokenCounts ?? {};
+      const input = tc.inputTokens ?? 0;
+      const output = tc.outputTokens ?? 0;
+      const cacheTokens = (tc.cacheCreationInputTokens ?? 0) + (tc.cacheReadInputTokens ?? 0);
+      const costUsd = b.costUSD ?? 0;
+      return {
+        start: b.startTime as string,
+        isActive: !!b.isActive,
+        inputTokens: input,
+        outputTokens: output,
+        cacheTokens,
+        totalTokens: b.totalTokens ?? input + output + cacheTokens,
+        costUsd,
+        costEur: costUsd * rate,
+      };
+    });
+}
+
+// Assemble the full report from already-parsed ccusage rows. `blocks === null`
+// means the blocks command was unavailable (best-effort) → empty blocks list.
+export function buildReport(
+  daily: CcusageDaily[],
+  blocks: CcusageBlock[] | null,
+  rate: number,
+  now: number,
+): UsageReport {
+  const days = mapDailyRows(daily, rate);
+  const totals = days.reduce(
+    (acc, d) => {
+      acc.inputTokens += d.inputTokens;
+      acc.outputTokens += d.outputTokens;
+      acc.cacheTokens += d.cacheTokens;
+      acc.totalTokens += d.totalTokens;
+      acc.costUsd += d.costUsd;
+      acc.costEur += d.costEur;
+      return acc;
+    },
+    { inputTokens: 0, outputTokens: 0, cacheTokens: 0, totalTokens: 0, costUsd: 0, costEur: 0 },
+  );
+  return { days, blocks: blocks ? mapBlockRows(blocks, rate, now) : [], totals, available: true };
 }
 
 export async function getUsage(): Promise<UsageReport> {
@@ -97,66 +167,13 @@ export async function getUsage(): Promise<UsageReport> {
 
     if (dailyRes.status !== "fulfilled") throw new Error("ccusage daily failed");
 
-    const parsed = JSON.parse(dailyRes.value.stdout) as { daily?: CcusageDaily[] };
-    const rows = parsed.daily ?? [];
+    const daily = (JSON.parse(dailyRes.value.stdout) as { daily?: CcusageDaily[] }).daily ?? [];
+    const blocks =
+      blocksRes.status === "fulfilled"
+        ? (JSON.parse(blocksRes.value.stdout) as { blocks?: CcusageBlock[] }).blocks ?? []
+        : null;
 
-    const days: UsageDay[] = rows.map((d) => {
-      const cacheTokens = (d.cacheCreationTokens ?? 0) + (d.cacheReadTokens ?? 0);
-      const costUsd = d.totalCost ?? 0;
-      return {
-        date: d.period ?? "",
-        inputTokens: d.inputTokens ?? 0,
-        outputTokens: d.outputTokens ?? 0,
-        cacheTokens,
-        totalTokens: d.totalTokens ?? 0,
-        costUsd,
-        costEur: costUsd * rate,
-      };
-    });
-
-    const totals = days.reduce(
-      (acc, d) => {
-        acc.inputTokens += d.inputTokens;
-        acc.outputTokens += d.outputTokens;
-        acc.cacheTokens += d.cacheTokens;
-        acc.totalTokens += d.totalTokens;
-        acc.costUsd += d.costUsd;
-        acc.costEur += d.costEur;
-        return acc;
-      },
-      { inputTokens: 0, outputTokens: 0, cacheTokens: 0, totalTokens: 0, costUsd: 0, costEur: 0 },
-    );
-
-    let blocks: UsageBlock[] = [];
-    if (blocksRes.status === "fulfilled") {
-      const since = Date.now() - 24 * 60 * 60 * 1000;
-      const parsedBlocks = JSON.parse(blocksRes.value.stdout) as { blocks?: CcusageBlock[] };
-      blocks = (parsedBlocks.blocks ?? [])
-        .filter((b) => {
-          if (b.isGap || !b.startTime) return false;
-          const end = Date.parse(b.endTime ?? b.startTime);
-          return Number.isFinite(end) && end >= since;
-        })
-        .map((b) => {
-          const tc = b.tokenCounts ?? {};
-          const input = tc.inputTokens ?? 0;
-          const output = tc.outputTokens ?? 0;
-          const cacheTokens = (tc.cacheCreationInputTokens ?? 0) + (tc.cacheReadInputTokens ?? 0);
-          const costUsd = b.costUSD ?? 0;
-          return {
-            start: b.startTime as string,
-            isActive: !!b.isActive,
-            inputTokens: input,
-            outputTokens: output,
-            cacheTokens,
-            totalTokens: b.totalTokens ?? input + output + cacheTokens,
-            costUsd,
-            costEur: costUsd * rate,
-          };
-        });
-    }
-
-    const report: UsageReport = { days, blocks, totals, available: true };
+    const report = buildReport(daily, blocks, rate, Date.now());
     cache = { at: Date.now(), report };
     return report;
   } catch {


### PR DESCRIPTION
## Summary

Roadmap **Run 4 — Make the ccusage parser testable.** Extracts the JSON-row mapping out of `getUsage()` in `src/lib/ccusage.ts` into pure functions, then tests them with fixture data. **No behavior change.**

- **New pure functions** (exported): `mapDailyRows`, `mapBlockRows(rows, rate, now)`, and `buildReport(daily, blocks, rate, now)`. `eurRate` and `empty` are now exported too, and the `CcusageDaily`/`CcusageBlock` row types.
- **Slimmed `getUsage`** — still caches (TTL), runs `ccusage daily`/`blocks` in parallel, parses stdout, and delegates to `buildReport`. Blocks remain best-effort (a rejected blocks command → `null` → empty blocks list but daily still returned); a failed daily still degrades to `empty()`.
- **New `src/lib/ccusage.test.ts`** (12 tests): field mapping + zero-defaults, USD→EUR conversion, 24h block window filtering (gap / undated / stale dropped), `totalTokens` fallback vs explicit, totals aggregation, the null-blocks path, the `empty()` degradation report (`available=false`), and `eurRate` env handling (default 0.92 / invalid / override).

61 tests pass total (12 new + 49 existing).

## Test plan

- [x] `npm run lint` — clean
- [x] `npm test` — 61 passed
- [x] `npm run build` — succeeds
- [ ] CI `verify` job green on this PR

https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk)_