### PR TITLE
Run 5: Validate ingest payloads with a tolerant Zod schema

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,8 @@
         "react-force-graph-3d": "^1.29.1",
         "recharts": "^3.8.1",
         "tailwind-merge": "^2.6.0",
-        "three": "^0.184.0"
+        "three": "^0.184.0",
+        "zod": "^4.4.3"
       },
       "devDependencies": {
         "@electron/rebuild": "^3.7.0",
@@ -13414,7 +13415,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -45,15 +45,16 @@
     "react-force-graph-3d": "^1.29.1",
     "recharts": "^3.8.1",
     "tailwind-merge": "^2.6.0",
-    "three": "^0.184.0"
+    "three": "^0.184.0",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
+    "@electron/rebuild": "^3.7.0",
     "@tailwindcss/postcss": "^4",
     "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
-    "@electron/rebuild": "^3.7.0",
     "electron": "^33.0.0",
     "electron-builder": "^25.1.8",
     "eslint": "^9",
@@ -72,18 +73,52 @@
       "package.json"
     ],
     "extraResources": [
-      { "from": ".next/standalone", "to": "standalone" },
-      { "from": "scripts", "to": "scripts" },
-      { "from": "assets/Icon.png", "to": "Icon.png" }
+      {
+        "from": ".next/standalone",
+        "to": "standalone"
+      },
+      {
+        "from": "scripts",
+        "to": "scripts"
+      },
+      {
+        "from": "assets/Icon.png",
+        "to": "Icon.png"
+      }
     ],
     "directories": {
       "output": "dist",
       "buildResources": "electron/build"
     },
     "npmRebuild": false,
-    "win": { "target": ["nsis"], "icon": "electron/build/icon.ico" },
-    "nsis": { "oneClick": false, "allowToChangeInstallationDirectory": true, "artifactName": "Claude-Mission-Control-Setup.${ext}" },
-    "mac": { "target": ["dmg"], "category": "public.app-category.developer-tools", "identity": null, "icon": "electron/build/icon.icns", "artifactName": "Claude-Mission-Control.${ext}" },
-    "linux": { "target": ["AppImage", "deb"], "category": "Development", "icon": "electron/build/icon.png", "artifactName": "Claude-Mission-Control.${ext}" }
+    "win": {
+      "target": [
+        "nsis"
+      ],
+      "icon": "electron/build/icon.ico"
+    },
+    "nsis": {
+      "oneClick": false,
+      "allowToChangeInstallationDirectory": true,
+      "artifactName": "Claude-Mission-Control-Setup.${ext}"
+    },
+    "mac": {
+      "target": [
+        "dmg"
+      ],
+      "category": "public.app-category.developer-tools",
+      "identity": null,
+      "icon": "electron/build/icon.icns",
+      "artifactName": "Claude-Mission-Control.${ext}"
+    },
+    "linux": {
+      "target": [
+        "AppImage",
+        "deb"
+      ],
+      "category": "Development",
+      "icon": "electron/build/icon.png",
+      "artifactName": "Claude-Mission-Control.${ext}"
+    }
   }
 }

--- a/src/app/api/ingest/route.ts
+++ b/src/app/api/ingest/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { ingest } from "@/lib/ingest";
-import type { HookPayload } from "@/lib/types";
+import { parseHookPayload } from "@/lib/hook-schema";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -20,16 +20,24 @@ export async function POST(req: Request) {
   }
 
   const headerEvent = req.headers.get("x-hook-event") ?? "";
-  let payload: HookPayload;
+  let raw: unknown;
   try {
     const text = await req.text();
     if (text.length > MAX_BODY) {
       return NextResponse.json({ ok: false, error: "payload too large" }, { status: 413 });
     }
-    payload = text ? (JSON.parse(text) as HookPayload) : {};
+    raw = text ? JSON.parse(text) : {};
   } catch {
     return NextResponse.json({ ok: false, error: "invalid json" }, { status: 400 });
   }
+
+  // Tolerant schema check: unknown fields pass, but a wrong-typed known field is
+  // a malformed request (real hooks never send those).
+  const parsed = parseHookPayload(raw);
+  if (!parsed.ok) {
+    return NextResponse.json({ ok: false, error: parsed.error }, { status: 400 });
+  }
+  const payload = parsed.payload;
 
   // Real Claude Code hooks always carry a session_id. Anything without one
   // (health checks, stray/empty POSTs) is ignored so it never creates a junk

--- a/src/lib/hook-schema.test.ts
+++ b/src/lib/hook-schema.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { parseHookPayload } from "@/lib/hook-schema";
+
+describe("parseHookPayload", () => {
+  it("accepts a full, well-typed payload", () => {
+    const input = {
+      session_id: "abc",
+      cwd: "/home/user/proj",
+      hook_event_name: "PostToolUse",
+      tool_name: "Read",
+      tool_input: { file_path: "/x.ts" },
+      tool_response: { ok: true },
+      source: "startup",
+    };
+    const r = parseHookPayload(input);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.payload).toMatchObject(input);
+  });
+
+  it("accepts an empty object (all fields optional)", () => {
+    expect(parseHookPayload({}).ok).toBe(true);
+  });
+
+  it("passes unknown fields through untouched", () => {
+    const r = parseHookPayload({ session_id: "abc", custom_field: 42, nested: { a: 1 } });
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.payload.custom_field).toBe(42);
+      expect(r.payload.nested).toEqual({ a: 1 });
+    }
+  });
+
+  it("accepts arbitrary tool_response shapes", () => {
+    expect(parseHookPayload({ tool_response: "a string" }).ok).toBe(true);
+    expect(parseHookPayload({ tool_response: [1, 2, 3] }).ok).toBe(true);
+    expect(parseHookPayload({ tool_response: null }).ok).toBe(true);
+  });
+
+  it("rejects a non-string session_id", () => {
+    const r = parseHookPayload({ session_id: 123 });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toContain("session_id");
+  });
+
+  it("rejects a wrong-typed known field", () => {
+    expect(parseHookPayload({ tool_name: 5 }).ok).toBe(false);
+    expect(parseHookPayload({ prompt: { not: "a string" } }).ok).toBe(false);
+  });
+
+  it("rejects a non-object tool_input", () => {
+    expect(parseHookPayload({ tool_input: "nope" }).ok).toBe(false);
+  });
+
+  it("rejects a non-object root", () => {
+    expect(parseHookPayload("not an object").ok).toBe(false);
+    expect(parseHookPayload(null).ok).toBe(false);
+    expect(parseHookPayload(42).ok).toBe(false);
+  });
+});

--- a/src/lib/hook-schema.ts
+++ b/src/lib/hook-schema.ts
@@ -1,0 +1,36 @@
+import { z } from "zod";
+import type { HookPayload } from "./types";
+
+// Tolerant validation for the single write path (/api/ingest). Every field is
+// optional and unknown keys pass through (hook payloads vary per event and evolve
+// across Claude Code versions), but a known field that IS present must have the
+// right type — a wrong type is treated as a malformed request.
+export const HookPayloadSchema = z.looseObject({
+  session_id: z.string().optional(),
+  transcript_path: z.string().optional(),
+  cwd: z.string().optional(),
+  hook_event_name: z.string().optional(),
+  tool_name: z.string().optional(),
+  tool_input: z.record(z.string(), z.unknown()).optional(),
+  tool_response: z.unknown().optional(),
+  prompt: z.string().optional(),
+  message: z.string().optional(),
+  source: z.string().optional(),
+  reason: z.string().optional(),
+  trigger: z.string().optional(),
+});
+
+export type HookPayloadParse =
+  | { ok: true; payload: HookPayload }
+  | { ok: false; error: string };
+
+export function parseHookPayload(input: unknown): HookPayloadParse {
+  const result = HookPayloadSchema.safeParse(input);
+  if (!result.success) {
+    const error = result.error.issues
+      .map((i) => `${i.path.join(".") || "(root)"}: ${i.message}`)
+      .join("; ");
+    return { ok: false, error };
+  }
+  return { ok: true, payload: result.data as HookPayload };
+}


### PR DESCRIPTION
## Summary

Roadmap **Run 5 — Tolerant Zod validation on the ingest boundary.** Hardens the single write path (`/api/ingest`) without rejecting the natural per-event variation of hook payloads.

- **New `src/lib/hook-schema.ts`** — adds `zod` and a `HookPayloadSchema` built with `z.looseObject`: every field is optional, **unknown keys pass through** (payloads vary per event and evolve across Claude Code versions), but a **known field that is present must have the right type**. `parseHookPayload(input)` returns `{ ok: true, payload }` or `{ ok: false, error }` with the offending field path.
- **`/api/ingest` route** — after JSON parsing, runs `parseHookPayload`; a wrong-typed known field (or non-object root) now returns **400**. The existing size/`invalid json` checks and the "no `session_id` → skip" behavior are unchanged.
- **New `src/lib/hook-schema.test.ts`** (8 tests) — full payload accepted, empty object accepted, unknown fields pass through, arbitrary `tool_response` shapes accepted, and rejects: non-string `session_id`, wrong-typed known fields, non-object `tool_input`, and non-object root.

Validation lives at the system boundary (the route), per the project's read-only/one-way-data-flow design. 69 tests pass total (8 new + 61 existing).

## Test plan

- [x] `npm run lint` — clean
- [x] `npm test` — 69 passed
- [x] `npm run build` — succeeds (zod resolves, route compiles)
- [ ] CI `verify` job green on this PR

https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk)_