### PR TITLE
Run 6: Add a versioned SQLite migration runner

### DIFF
--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -2,50 +2,7 @@ import Database from "better-sqlite3";
 import { mkdirSync } from "node:fs";
 import path from "node:path";
 import { PHASE_PRODUCTION_BUILD } from "next/constants";
-
-// Schema lives here as the single source of truth (avoids runtime file-path lookups
-// that break under Next's bundling). Every statement is IF NOT EXISTS → safe to run on each boot.
-const SCHEMA = `
-CREATE TABLE IF NOT EXISTS sessions (
-  id            TEXT PRIMARY KEY,
-  project_path  TEXT,
-  project_name  TEXT,
-  title         TEXT,
-  status        TEXT NOT NULL DEFAULT 'active',
-  source        TEXT,
-  first_seen    DATETIME DEFAULT CURRENT_TIMESTAMP,
-  last_seen     DATETIME DEFAULT CURRENT_TIMESTAMP,
-  ended_at      DATETIME,
-  token_input   INTEGER DEFAULT 0,
-  token_output  INTEGER DEFAULT 0,
-  cost_usd      REAL DEFAULT 0
-);
-
-CREATE TABLE IF NOT EXISTS events (
-  id            INTEGER PRIMARY KEY AUTOINCREMENT,
-  session_id    TEXT NOT NULL,
-  event_type    TEXT NOT NULL,
-  tool_name     TEXT,
-  summary       TEXT,
-  payload_json  TEXT NOT NULL,
-  created_at    DATETIME DEFAULT CURRENT_TIMESTAMP
-);
-
-CREATE TABLE IF NOT EXISTS tool_calls (
-  id            INTEGER PRIMARY KEY AUTOINCREMENT,
-  session_id    TEXT NOT NULL,
-  tool_name     TEXT NOT NULL,
-  target        TEXT,
-  duration_ms   INTEGER,
-  success       INTEGER,
-  created_at    DATETIME DEFAULT CURRENT_TIMESTAMP
-);
-
-CREATE INDEX IF NOT EXISTS idx_events_session ON events(session_id);
-CREATE INDEX IF NOT EXISTS idx_events_created ON events(created_at);
-CREATE INDEX IF NOT EXISTS idx_sessions_status ON sessions(status);
-CREATE INDEX IF NOT EXISTS idx_tool_calls_session ON tool_calls(session_id);
-`;
+import { migrate } from "./migrations";
 
 function createDb(): Database.Database {
   // During `next build`, route modules are evaluated by several workers in parallel.
@@ -54,7 +11,7 @@ function createDb(): Database.Database {
   // use a throwaway in-memory database during the build phase.
   if (process.env.NEXT_PHASE === PHASE_PRODUCTION_BUILD) {
     const mem = new Database(":memory:");
-    mem.exec(SCHEMA);
+    migrate(mem);
     return mem;
   }
 
@@ -65,7 +22,7 @@ function createDb(): Database.Database {
   const db = new Database(path.join(dataDir, "mission-control.db"));
   db.pragma("journal_mode = WAL");
   db.pragma("busy_timeout = 5000");
-  db.exec(SCHEMA);
+  migrate(db);
   return db;
 }
 

--- a/src/lib/migrations.test.ts
+++ b/src/lib/migrations.test.ts
@@ -1,0 +1,58 @@
+import Database from "better-sqlite3";
+import { afterEach, describe, expect, it } from "vitest";
+import { MIGRATIONS, migrate } from "@/lib/migrations";
+
+let open: Database.Database | null = null;
+const fresh = () => (open = new Database(":memory:"));
+const version = (db: Database.Database) => db.pragma("user_version", { simple: true }) as number;
+const tables = (db: Database.Database) =>
+  (db.prepare("SELECT name FROM sqlite_master WHERE type='table'").all() as { name: string }[]).map(
+    (r) => r.name,
+  );
+
+afterEach(() => {
+  open?.close();
+  open = null;
+});
+
+describe("migrate", () => {
+  it("brings a fresh database to the latest version with all tables", () => {
+    const db = fresh();
+    expect(version(db)).toBe(0);
+    expect(migrate(db)).toBe(MIGRATIONS.length);
+    expect(version(db)).toBe(MIGRATIONS.length);
+    expect(tables(db)).toEqual(expect.arrayContaining(["sessions", "events", "tool_calls"]));
+  });
+
+  it("is idempotent — a second run is a no-op", () => {
+    const db = fresh();
+    migrate(db);
+    const before = version(db);
+    expect(() => migrate(db)).not.toThrow();
+    expect(version(db)).toBe(before);
+  });
+
+  it("adopts a pre-existing v0 database (old inline-schema) without losing data", () => {
+    const db = fresh();
+    // Simulate a database created by the previous code: tables exist, but the
+    // version was never stamped, so it sits at user_version 0.
+    db.exec(MIGRATIONS[0]);
+    expect(version(db)).toBe(0);
+    db.prepare("INSERT INTO sessions (id) VALUES (?)").run("legacy");
+
+    migrate(db);
+
+    expect(version(db)).toBe(MIGRATIONS.length);
+    expect(db.prepare("SELECT id FROM sessions WHERE id = ?").get("legacy")).toEqual({
+      id: "legacy",
+    });
+  });
+
+  it("leaves a database that is already current untouched", () => {
+    const db = fresh();
+    migrate(db);
+    db.prepare("INSERT INTO sessions (id) VALUES (?)").run("keep");
+    migrate(db);
+    expect(db.prepare("SELECT COUNT(*) AS n FROM sessions").get()).toEqual({ n: 1 });
+  });
+});

--- a/src/lib/migrations.ts
+++ b/src/lib/migrations.ts
@@ -1,0 +1,74 @@
+import type Database from "better-sqlite3";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SCHEMA MIGRATIONS
+// Ordered, append-only list. The (1-based) position of a migration is the schema
+// version it brings the database to, tracked via SQLite's `PRAGMA user_version`.
+//
+// Rules:
+//   • NEVER edit or reorder a migration once it has shipped — only append new ones.
+//   • Migration 1 is the baseline. It uses IF NOT EXISTS so it adopts databases
+//     created before this runner existed (those sit at user_version 0 already).
+//   • Later migrations run exactly once, in order, each in its own transaction.
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const MIGRATIONS: string[] = [
+  // v1 — baseline schema (sessions, events, tool_calls + indexes).
+  `
+  CREATE TABLE IF NOT EXISTS sessions (
+    id            TEXT PRIMARY KEY,
+    project_path  TEXT,
+    project_name  TEXT,
+    title         TEXT,
+    status        TEXT NOT NULL DEFAULT 'active',
+    source        TEXT,
+    first_seen    DATETIME DEFAULT CURRENT_TIMESTAMP,
+    last_seen     DATETIME DEFAULT CURRENT_TIMESTAMP,
+    ended_at      DATETIME,
+    token_input   INTEGER DEFAULT 0,
+    token_output  INTEGER DEFAULT 0,
+    cost_usd      REAL DEFAULT 0
+  );
+
+  CREATE TABLE IF NOT EXISTS events (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id    TEXT NOT NULL,
+    event_type    TEXT NOT NULL,
+    tool_name     TEXT,
+    summary       TEXT,
+    payload_json  TEXT NOT NULL,
+    created_at    DATETIME DEFAULT CURRENT_TIMESTAMP
+  );
+
+  CREATE TABLE IF NOT EXISTS tool_calls (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id    TEXT NOT NULL,
+    tool_name     TEXT NOT NULL,
+    target        TEXT,
+    duration_ms   INTEGER,
+    success       INTEGER,
+    created_at    DATETIME DEFAULT CURRENT_TIMESTAMP
+  );
+
+  CREATE INDEX IF NOT EXISTS idx_events_session ON events(session_id);
+  CREATE INDEX IF NOT EXISTS idx_events_created ON events(created_at);
+  CREATE INDEX IF NOT EXISTS idx_sessions_status ON sessions(status);
+  CREATE INDEX IF NOT EXISTS idx_tool_calls_session ON tool_calls(session_id);
+  `,
+];
+
+// Apply any migrations the database hasn't seen yet. Each runs in a transaction
+// together with the version bump, so a failure rolls back cleanly and leaves the
+// version untouched. Returns the resulting schema version. Safe to call on boot.
+export function migrate(db: Database.Database): number {
+  const current = db.pragma("user_version", { simple: true }) as number;
+  for (let v = current; v < MIGRATIONS.length; v++) {
+    const sql = MIGRATIONS[v];
+    db.transaction(() => {
+      db.exec(sql);
+      // user_version takes a literal, not a bound parameter; v is a controlled index.
+      db.pragma(`user_version = ${v + 1}`);
+    })();
+  }
+  return MIGRATIONS.length;
+}


### PR DESCRIPTION
## Summary

Roadmap **Run 6 (⚙️) — Versioned SQLite migration system.** Replaces the inline `IF NOT EXISTS` schema in `src/lib/db.ts` with an ordered, append-only migration runner tracked via `PRAGMA user_version`. This is the foundation every Phase B "capture more data" run depends on.

- **New `src/lib/migrations.ts`** — `MIGRATIONS` (append-only array; position = schema version) plus `migrate(db)`. Each pending migration runs **once, in its own transaction together with the version bump**, so a failure rolls back cleanly and the version is never left half-applied.
- **Backward-compatible adoption** — Migration 1 is the existing schema **verbatim** (still `IF NOT EXISTS`). Databases created by the previous code sit at `user_version` 0; on first boot the runner runs migration 1 (a no-op on existing tables) and stamps them to v1. **No data loss, no manual step.**
- **`db.ts`** — both the build-phase in-memory DB and the real file DB now call `migrate()` instead of `exec(SCHEMA)`. Connection pragmas (WAL, busy_timeout) unchanged.
- **New `src/lib/migrations.test.ts`** (4 tests) — fresh DB reaches latest version with all tables, idempotent second run, **legacy v0 adoption preserves existing rows**, already-current DB untouched.

73 tests pass total (4 new + 69 existing; the ingest tests now run through the migration runner too).

### How to add the next migration

Append a new SQL string (e.g. `ALTER TABLE ... ADD COLUMN ...`) to `MIGRATIONS`. It runs once on next boot. Never edit/reorder a shipped migration.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm test` — 73 passed
- [x] `npm run build` — succeeds (build-phase in-memory migrate path exercised)
- [ ] CI `verify` job green on this PR

https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk)_