### PR TITLE
Run 7: Add /api/health status endpoint

### DIFF
--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from "next/server";
+import { db } from "@/lib/db";
+import { collectHealth } from "@/lib/health";
+import pkg from "../../../../package.json";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+// Liveness/status probe: DB reachability, schema version, row counts, uptime and
+// app version. Used by Electron's startup wait and any future monitoring. 503 when
+// the database can't be read.
+export async function GET() {
+  const report = collectHealth(db, {
+    version: pkg.version,
+    uptimeSec: Math.round(process.uptime()),
+  });
+  return NextResponse.json(report, { status: report.ok ? 200 : 503 });
+}

--- a/src/lib/health.test.ts
+++ b/src/lib/health.test.ts
@@ -1,0 +1,51 @@
+import Database from "better-sqlite3";
+import { afterEach, describe, expect, it } from "vitest";
+import { collectHealth } from "@/lib/health";
+import { MIGRATIONS, migrate } from "@/lib/migrations";
+
+let open: Database.Database | null = null;
+const fresh = () => (open = new Database(":memory:"));
+
+afterEach(() => {
+  open?.close();
+  open = null;
+});
+
+describe("collectHealth", () => {
+  it("reports ok with schema version and row counts on a migrated db", () => {
+    const db = fresh();
+    migrate(db);
+    db.prepare("INSERT INTO sessions (id) VALUES (?)").run("s1");
+    db.prepare("INSERT INTO events (session_id, event_type, payload_json) VALUES (?, ?, ?)").run(
+      "s1",
+      "SessionStart",
+      "{}",
+    );
+
+    const r = collectHealth(db, { version: "9.9.9", uptimeSec: 42, now: "2026-01-01T00:00:00Z" });
+    expect(r).toEqual({
+      ok: true,
+      db: "ok",
+      schemaVersion: MIGRATIONS.length,
+      sessions: 1,
+      events: 1,
+      toolCalls: 0,
+      version: "9.9.9",
+      uptimeSec: 42,
+      now: "2026-01-01T00:00:00Z",
+    });
+  });
+
+  it("reports a db error (no counts) when the schema is missing", () => {
+    const db = fresh(); // never migrated -> tables don't exist
+    const r = collectHealth(db, { version: "1.0.0", uptimeSec: 1, now: "t" });
+    expect(r).toEqual({ ok: false, db: "error", version: "1.0.0", uptimeSec: 1, now: "t" });
+  });
+
+  it("defaults now to the current time when omitted", () => {
+    const db = fresh();
+    migrate(db);
+    const r = collectHealth(db, { version: "1.0.0", uptimeSec: 0 });
+    expect(Number.isNaN(Date.parse(r.now))).toBe(false);
+  });
+});

--- a/src/lib/health.ts
+++ b/src/lib/health.ts
@@ -1,0 +1,42 @@
+import type Database from "better-sqlite3";
+
+export interface HealthReport {
+  ok: boolean;
+  db: "ok" | "error";
+  schemaVersion?: number;
+  sessions?: number;
+  events?: number;
+  toolCalls?: number;
+  uptimeSec: number;
+  version: string;
+  now: string;
+}
+
+// Snapshot of the dashboard's liveness: DB reachability, schema version and row
+// counts. Pure (takes the db handle) so it can be unit-tested; the route wraps it.
+export function collectHealth(
+  db: Database.Database,
+  opts: { version: string; uptimeSec: number; now?: string },
+): HealthReport {
+  const base = {
+    version: opts.version,
+    uptimeSec: opts.uptimeSec,
+    now: opts.now ?? new Date().toISOString(),
+  };
+  try {
+    const schemaVersion = db.pragma("user_version", { simple: true }) as number;
+    const count = (table: "sessions" | "events" | "tool_calls") =>
+      (db.prepare(`SELECT COUNT(*) AS n FROM ${table}`).get() as { n: number }).n;
+    return {
+      ok: true,
+      db: "ok",
+      schemaVersion,
+      sessions: count("sessions"),
+      events: count("events"),
+      toolCalls: count("tool_calls"),
+      ...base,
+    };
+  } catch {
+    return { ok: false, db: "error", ...base };
+  }
+}


### PR DESCRIPTION
## Summary

Roadmap **Run 7 — Health & status endpoint.** Adds `GET /api/health` for liveness/monitoring.

- **New `src/app/api/health/route.ts`** — returns DB reachability (`db: "ok" | "error"`), schema version (`PRAGMA user_version`), row counts (`sessions`/`events`/`toolCalls`), process `uptimeSec`, app `version` (read from `package.json`), and `now`. Returns **200** when healthy, **503** when the database can't be read. `runtime=nodejs`, `force-dynamic`.
- **New `src/lib/health.ts`** — the pure `collectHealth(db, opts)` does the work, so it's unit-tested; the route is a thin wrapper.
- **New `src/lib/health.test.ts`** (3 tests) — ok report with schema version + counts on a migrated DB, error report (no counts) when the schema is missing, and `now` defaulting.

This gives Electron's startup wait (`waitForServer`) and any future monitoring a real probe instead of a bare root ping. 76 tests pass total (3 new + 73 existing).

## Test plan

- [x] `npm run lint` — clean
- [x] `npm test` — 76 passed
- [x] `npm run build` — succeeds; `/api/health` route registered
- [ ] CI `verify` job green on this PR

https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk)_