### PR TITLE
Run 8: Add a structured server logger

### DIFF
--- a/src/app/api/events/route.ts
+++ b/src/app/api/events/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { db } from "@/lib/db";
+import { log } from "@/lib/log";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -19,7 +20,7 @@ export async function GET(req: Request) {
 
     return NextResponse.json({ events });
   } catch (err) {
-    console.error("/api/events failed:", err);
+    log.error("/api/events failed", err);
     return NextResponse.json({ events: [] });
   }
 }

--- a/src/app/api/graph/route.ts
+++ b/src/app/api/graph/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { buildGraphData, type PromptRow } from "@/lib/graph";
+import { log } from "@/lib/log";
 import type { SessionRow, ToolCallRow } from "@/lib/types";
 
 export const runtime = "nodejs";
@@ -12,7 +13,7 @@ export async function GET(req: Request) {
   try {
     return buildGraph(req);
   } catch (err) {
-    console.error("/api/graph failed:", err);
+    log.error("/api/graph failed", err);
     return NextResponse.json({ nodes: [], links: [] });
   }
 }

--- a/src/app/api/ingest/route.ts
+++ b/src/app/api/ingest/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { ingest } from "@/lib/ingest";
 import { parseHookPayload } from "@/lib/hook-schema";
+import { log } from "@/lib/log";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -50,6 +51,7 @@ export async function POST(req: Request) {
     const { event } = ingest(headerEvent, payload);
     return NextResponse.json({ ok: true, id: event.id });
   } catch (err) {
+    log.error("/api/ingest failed", err);
     return NextResponse.json(
       { ok: false, error: err instanceof Error ? err.message : "ingest failed" },
       { status: 500 },

--- a/src/app/api/sessions/route.ts
+++ b/src/app/api/sessions/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { db } from "@/lib/db";
+import { log } from "@/lib/log";
 import type { SessionRow } from "@/lib/types";
 
 export const runtime = "nodejs";
@@ -42,7 +43,7 @@ export async function GET() {
 
     return NextResponse.json({ sessions });
   } catch (err) {
-    console.error("/api/sessions failed:", err);
+    log.error("/api/sessions failed", err);
     return NextResponse.json({ sessions: [] });
   }
 }

--- a/src/lib/log.test.ts
+++ b/src/lib/log.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { formatRecord, log, normalizeContext } from "@/lib/log";
+
+const ENV = { ...process.env };
+afterEach(() => {
+  vi.restoreAllMocks();
+  process.env = { ...ENV };
+});
+
+describe("normalizeContext", () => {
+  it("returns undefined for null/undefined", () => {
+    expect(normalizeContext(null)).toBeUndefined();
+    expect(normalizeContext(undefined)).toBeUndefined();
+  });
+
+  it("extracts message and stack from an Error", () => {
+    const n = normalizeContext(new Error("boom"));
+    expect(n).toMatchObject({ error: "boom" });
+    expect(typeof n!.stack).toBe("string");
+  });
+
+  it("passes a plain object through and wraps primitives", () => {
+    expect(normalizeContext({ a: 1 })).toEqual({ a: 1 });
+    expect(normalizeContext("x")).toEqual({ detail: "x" });
+  });
+});
+
+describe("formatRecord", () => {
+  it("builds a record with time, level, msg and merged context", () => {
+    const r = formatRecord("error", "failed", { code: 42 }, "2026-01-01T00:00:00Z");
+    expect(r).toEqual({
+      time: "2026-01-01T00:00:00Z",
+      level: "error",
+      msg: "failed",
+      code: 42,
+    });
+  });
+});
+
+describe("log emit", () => {
+  it("writes an error as a JSON line to console.error", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    log.error("oops", new Error("bad"));
+    expect(spy).toHaveBeenCalledOnce();
+    const record = JSON.parse(spy.mock.calls[0][0] as string);
+    expect(record).toMatchObject({ level: "error", msg: "oops", error: "bad" });
+  });
+
+  it("suppresses debug below the default (info) threshold", () => {
+    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+    log.debug("quiet");
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("emits debug when MC_LOG_LEVEL=debug", () => {
+    process.env.MC_LOG_LEVEL = "debug";
+    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+    log.debug("loud");
+    expect(spy).toHaveBeenCalledOnce();
+  });
+
+  it("appends a JSON line to MC_LOG_FILE when set", () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "mc-log-test-"));
+    const file = path.join(dir, "log.jsonl");
+    process.env.MC_LOG_FILE = file;
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      log.warn("to file", { n: 1 });
+      const line = readFileSync(file, "utf8").trim();
+      expect(JSON.parse(line)).toMatchObject({ level: "warn", msg: "to file", n: 1 });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/lib/log.ts
+++ b/src/lib/log.ts
@@ -1,0 +1,59 @@
+import { appendFileSync } from "node:fs";
+
+// Tiny structured logger for the server (API routes). Emits one JSON line per
+// record to the console, and — when MC_LOG_FILE is set — appends the same line to
+// that file. The minimum level is MC_LOG_LEVEL (default "info"). Server-only:
+// never import this from a client component (it uses node:fs).
+
+export type LogLevel = "debug" | "info" | "warn" | "error";
+
+const ORDER: Record<LogLevel, number> = { debug: 10, info: 20, warn: 30, error: 40 };
+
+function threshold(): number {
+  const lvl = (process.env.MC_LOG_LEVEL || "info").toLowerCase() as LogLevel;
+  return ORDER[lvl] ?? ORDER.info;
+}
+
+// Turn an arbitrary log context into plain fields. Errors keep message + stack.
+export function normalizeContext(ctx: unknown): Record<string, unknown> | undefined {
+  if (ctx == null) return undefined;
+  if (ctx instanceof Error) return { error: ctx.message, stack: ctx.stack };
+  if (typeof ctx === "object") return ctx as Record<string, unknown>;
+  return { detail: ctx };
+}
+
+export interface LogRecord {
+  time: string;
+  level: LogLevel;
+  msg: string;
+  [key: string]: unknown;
+}
+
+export function formatRecord(level: LogLevel, msg: string, ctx?: unknown, now?: string): LogRecord {
+  return { time: now ?? new Date().toISOString(), level, msg, ...normalizeContext(ctx) };
+}
+
+function emit(level: LogLevel, msg: string, ctx?: unknown): void {
+  if (ORDER[level] < threshold()) return;
+  const line = JSON.stringify(formatRecord(level, msg, ctx));
+
+  if (level === "error") console.error(line);
+  else if (level === "warn") console.warn(line);
+  else console.log(line);
+
+  const file = process.env.MC_LOG_FILE;
+  if (file) {
+    try {
+      appendFileSync(file, line + "\n");
+    } catch {
+      /* logging must never throw */
+    }
+  }
+}
+
+export const log = {
+  debug: (msg: string, ctx?: unknown) => emit("debug", msg, ctx),
+  info: (msg: string, ctx?: unknown) => emit("info", msg, ctx),
+  warn: (msg: string, ctx?: unknown) => emit("warn", msg, ctx),
+  error: (msg: string, ctx?: unknown) => emit("error", msg, ctx),
+};


### PR DESCRIPTION
## Summary

Roadmap **Run 8 — Structured server logging.** Replaces the ad-hoc `console.error` calls in the API routes with a small, tested logger.

- **New `src/lib/log.ts`** — `log.{debug,info,warn,error}(msg, ctx?)` emits one **JSON line per record** (`time`, `level`, `msg`, plus context) to the console. Minimum level via `MC_LOG_LEVEL` (default `info`); when `MC_LOG_FILE` is set it also appends the same line to that file. `Error` context keeps `message` + `stack`. Logging never throws. Server-only (uses `node:fs`).
- **Routes updated** — `graph`, `sessions`, `events` now call `log.error(...)`; the previously **silent** failure in the `/api/ingest` write path is now logged too.
- **Client untouched** — the React error boundaries (`error-boundary.tsx`, `error.tsx`) keep using `console` (browser, no fs).
- **New `src/lib/log.test.ts`** (8 tests) — context normalization (Error/object/primitive/null), record formatting, threshold filtering (debug suppressed at default, emitted at `MC_LOG_LEVEL=debug`), console output, and `MC_LOG_FILE` append.

84 tests pass total (8 new + 76 existing).

## Test plan

- [x] `npm run lint` — clean
- [x] `npm test` — 84 passed
- [x] `npm run build` — compiles
- [ ] CI `verify` job green on this PR

https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk)_