### PR TITLE
Run 10: SSE hardening — Last-Event-ID resume + connection cap

### DIFF
--- a/src/app/api/events/route.ts
+++ b/src/app/api/events/route.ts
@@ -1,22 +1,35 @@
 import { NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { log } from "@/lib/log";
+import { parseLastEventId } from "@/lib/sse";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-// Recent events for the live stream's initial backlog (SSE takes over for new ones).
+// Backlog for the live stream. Default: the most recent events (newest first).
+// With ?since=<id>: only events newer than that id (oldest first) — the resume
+// path so a reconnecting client can fetch exactly the gap it missed.
 export async function GET(req: Request) {
   const url = new URL(req.url);
   const sessionId = url.searchParams.get("session");
+  const since = parseLastEventId(url.searchParams.get("since"));
   const limit = Math.min(Math.max(Math.trunc(Number(url.searchParams.get("limit")) || 100), 1), 500);
 
   try {
-    const events = sessionId
-      ? db
-          .prepare(`SELECT * FROM events WHERE session_id = ? ORDER BY id DESC LIMIT ?`)
-          .all(sessionId, limit)
-      : db.prepare(`SELECT * FROM events ORDER BY id DESC LIMIT ?`).all(limit);
+    let events: unknown[];
+    if (since != null) {
+      events = sessionId
+        ? db
+            .prepare(`SELECT * FROM events WHERE id > ? AND session_id = ? ORDER BY id ASC LIMIT ?`)
+            .all(since, sessionId, limit)
+        : db.prepare(`SELECT * FROM events WHERE id > ? ORDER BY id ASC LIMIT ?`).all(since, limit);
+    } else {
+      events = sessionId
+        ? db
+            .prepare(`SELECT * FROM events WHERE session_id = ? ORDER BY id DESC LIMIT ?`)
+            .all(sessionId, limit)
+        : db.prepare(`SELECT * FROM events ORDER BY id DESC LIMIT ?`).all(limit);
+    }
 
     return NextResponse.json({ events });
   } catch (err) {

--- a/src/app/api/stream/route.ts
+++ b/src/app/api/stream/route.ts
@@ -1,40 +1,88 @@
+import { db } from "@/lib/db";
 import { subscribe } from "@/lib/bus";
+import { eventsSince, parseLastEventId, sseFrame } from "@/lib/sse";
 import type { StreamMessage } from "@/lib/types";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-// Server-Sent Events: pushes every ingested event to connected dashboards in real time.
+// Cap concurrent SSE clients so a runaway tab-loop can't exhaust handles.
+function maxClients(): number {
+  const n = Number(process.env.MC_MAX_SSE_CLIENTS);
+  return Number.isFinite(n) && n > 0 ? Math.trunc(n) : 64;
+}
+// How many missed events a single reconnect will replay.
+const REPLAY_LIMIT = 1000;
+
+const globalForSse = globalThis as unknown as { __mcSseCount?: number };
+
+// Server-Sent Events: pushes every ingested event to connected dashboards in real
+// time. On (re)connect it replays anything newer than Last-Event-ID so a gap
+// (server restart, sleep, dropped connection) never loses events.
 export async function GET(req: Request) {
+  const active = globalForSse.__mcSseCount ?? 0;
+  if (active >= maxClients()) {
+    return new Response("too many connections", { status: 503 });
+  }
+  globalForSse.__mcSseCount = active + 1;
+
   const encoder = new TextEncoder();
+  const url = new URL(req.url);
+  // EventSource resends the id via the Last-Event-ID header on auto-reconnect; a
+  // manual reconnect passes it as a query param instead.
+  const lastEventId =
+    parseLastEventId(req.headers.get("last-event-id")) ??
+    parseLastEventId(url.searchParams.get("lastEventId"));
 
   const stream = new ReadableStream({
     start(controller) {
-      let active = true;
+      let open = true;
+      // Highest id sent so far; lets replay and live delivery dedup against
+      // each other without a race.
+      let lastSent = lastEventId ?? 0;
+
       // Safe enqueue: never throws if the client already disconnected.
       const send = (data: string) => {
-        if (!active) return;
+        if (!open) return;
         try {
           controller.enqueue(encoder.encode(data));
         } catch {
-          active = false;
+          open = false;
         }
       };
 
       // Initial comment so the browser marks the connection open immediately.
       send(": connected\n\n");
 
+      // Subscribe first so no event published during replay is missed; the
+      // lastSent guard drops anything already covered by the replay.
       const unsubscribe = subscribe((msg: StreamMessage) => {
-        send(`data: ${JSON.stringify(msg)}\n\n`);
+        if (msg.event.id <= lastSent) return;
+        lastSent = msg.event.id;
+        send(sseFrame(msg.event.id, msg));
       });
+
+      // Replay the gap (synchronous DB read — no live event can interleave).
+      if (lastEventId) {
+        try {
+          for (const e of eventsSince(db, lastEventId, REPLAY_LIMIT)) {
+            if (e.id <= lastSent) continue;
+            lastSent = e.id;
+            send(sseFrame(e.id, { event: e }));
+          }
+        } catch {
+          /* a replay failure shouldn't tear down the live stream */
+        }
+      }
 
       // Keep-alive ping so proxies/browsers don't drop an idle connection.
       const ping = setInterval(() => send(": ping\n\n"), 25_000);
 
       const close = () => {
-        active = false;
+        open = false;
         clearInterval(ping);
         unsubscribe();
+        globalForSse.__mcSseCount = Math.max(0, (globalForSse.__mcSseCount ?? 1) - 1);
         try {
           controller.close();
         } catch {

--- a/src/components/live-provider.tsx
+++ b/src/components/live-provider.tsx
@@ -26,10 +26,12 @@ export function LiveProvider({ children }: { children: React.ReactNode }) {
     let es: EventSource | null = null;
     let retry: ReturnType<typeof setTimeout> | null = null;
     let backoff = 1000; // grows to a 15s ceiling so a down server is retried gently
+    let lastId = 0; // highest event id seen → resume point for a manual reconnect
 
     const ingestEvent = (e: EventRow) => {
       if (seen.current.has(e.id)) return;
       seen.current.add(e.id);
+      if (e.id > lastId) lastId = e.id;
       if (seen.current.size > MAX_EVENTS * 4) {
         seen.current = new Set([...seen.current].slice(-MAX_EVENTS));
       }
@@ -61,7 +63,9 @@ export function LiveProvider({ children }: { children: React.ReactNode }) {
 
     const connect = () => {
       if (closed) return;
-      es = new EventSource("/api/stream");
+      // On a manual reconnect, ask the server to replay anything we missed. (The
+      // browser's own auto-reconnect uses the Last-Event-ID header instead.)
+      es = new EventSource(lastId > 0 ? `/api/stream?lastEventId=${lastId}` : "/api/stream");
       es.onopen = () => {
         if (closed) return;
         setConnected(true);

--- a/src/lib/sse.test.ts
+++ b/src/lib/sse.test.ts
@@ -1,0 +1,50 @@
+import Database from "better-sqlite3";
+import { afterEach, describe, expect, it } from "vitest";
+import { migrate } from "@/lib/migrations";
+import { eventsSince, parseLastEventId, sseFrame } from "@/lib/sse";
+
+describe("parseLastEventId", () => {
+  it("returns null for missing or invalid values", () => {
+    expect(parseLastEventId(null)).toBeNull();
+    expect(parseLastEventId("")).toBeNull();
+    expect(parseLastEventId("abc")).toBeNull();
+    expect(parseLastEventId("0")).toBeNull();
+    expect(parseLastEventId("-5")).toBeNull();
+    expect(parseLastEventId("1.5")).toBeNull();
+  });
+
+  it("parses a positive integer id", () => {
+    expect(parseLastEventId("42")).toBe(42);
+  });
+});
+
+describe("sseFrame", () => {
+  it("includes an id line when given an id", () => {
+    expect(sseFrame(7, { a: 1 })).toBe('id: 7\ndata: {"a":1}\n\n');
+  });
+
+  it("omits the id line when id is null", () => {
+    expect(sseFrame(null, { a: 1 })).toBe('data: {"a":1}\n\n');
+  });
+});
+
+describe("eventsSince", () => {
+  let open: Database.Database | null = null;
+  afterEach(() => {
+    open?.close();
+    open = null;
+  });
+
+  it("returns only events newer than the given id, oldest first, capped", () => {
+    const db = (open = new Database(":memory:"));
+    migrate(db);
+    const ins = db.prepare("INSERT INTO events (session_id, event_type, payload_json) VALUES ('s','E','{}')");
+    for (let i = 0; i < 5; i++) ins.run(); // ids 1..5
+
+    const rows = eventsSince(db, 2, 10);
+    expect(rows.map((r) => r.id)).toEqual([3, 4, 5]);
+
+    expect(eventsSince(db, 2, 2).map((r) => r.id)).toEqual([3, 4]); // limit respected
+    expect(eventsSince(db, 5, 10)).toEqual([]); // nothing newer
+  });
+});

--- a/src/lib/sse.ts
+++ b/src/lib/sse.ts
@@ -1,0 +1,25 @@
+import type Database from "better-sqlite3";
+import type { EventRow } from "./types";
+
+// Parse a Last-Event-ID header (or ?lastEventId= query) into a positive integer
+// event id, or null when absent/invalid.
+export function parseLastEventId(value: string | null | undefined): number | null {
+  if (!value) return null;
+  const n = Number(value);
+  return Number.isInteger(n) && n > 0 ? n : null;
+}
+
+// One SSE frame. Including an `id:` line lets the browser send Last-Event-ID on
+// automatic reconnect so the server can replay the gap.
+export function sseFrame(id: number | null, data: unknown): string {
+  const idLine = id != null ? `id: ${id}\n` : "";
+  return `${idLine}data: ${JSON.stringify(data)}\n\n`;
+}
+
+// Events newer than `sinceId`, oldest-first, capped. Used to replay the gap after
+// a reconnect (both the SSE stream and the /api/events backlog).
+export function eventsSince(db: Database.Database, sinceId: number, limit: number): EventRow[] {
+  return db
+    .prepare(`SELECT * FROM events WHERE id > ? ORDER BY id ASC LIMIT ?`)
+    .all(sinceId, limit) as EventRow[];
+}


### PR DESCRIPTION
## Summary

Roadmap **Run 10 — SSE hardening: Last-Event-ID resume + connection cap.** Reconnects no longer drop events.

- **New `src/lib/sse.ts`** (pure, tested) — `parseLastEventId`, `sseFrame(id, data)` (emits an `id:` line), and `eventsSince(db, sinceId, limit)` (events newer than id, oldest first, capped).
- **`/api/stream`** now:
  - emits an `id:` line per frame, so the browser sends `Last-Event-ID` on auto-reconnect;
  - on (re)connect, **replays every event newer than Last-Event-ID** (header) or `?lastEventId=` (manual reconnect). Subscribe happens *before* the synchronous DB replay and a `lastSent` guard dedups the overlap — no race, no double-send;
  - **caps concurrent clients** via `MC_MAX_SSE_CLIENTS` (default 64) → `503` beyond it, decremented on disconnect.
- **`/api/events`** gains `?since=<id>` (events newer than id, oldest first; respects the optional `session` filter) — the matching resume path for the backlog fetch. Default behavior unchanged.
- **Client (`live-provider.tsx`)** tracks the highest event id seen and passes `?lastEventId=` on a manual reconnect, so that path is lossless too. The browser's own auto-reconnect uses the header. Backlog fetch unchanged (still dedups).

100 tests pass total (5 new + 95 existing).

## Test plan

- [x] `npm run lint` — clean
- [x] `npm test` — 100 passed
- [x] `npm run build` — compiles; `/api/stream` + `/api/events` registered
- [ ] CI `verify` job green on this PR

https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk)_