### PR TITLE
Run 11: Unify widget empty/loading/error states

### DIFF
--- a/src/components/widget-state.tsx
+++ b/src/components/widget-state.tsx
@@ -1,0 +1,35 @@
+import { Loader2, type LucideIcon } from "lucide-react";
+import { cn } from "@/lib/cn";
+
+// Shared centered placeholder for a widget's empty / no-results / loading / error
+// states, so every panel looks and behaves the same. Lives inside a Panel's body.
+export function WidgetState({
+  icon: Icon,
+  title,
+  description,
+  loading = false,
+  className,
+}: {
+  icon?: LucideIcon;
+  title: string;
+  description?: React.ReactNode;
+  loading?: boolean;
+  className?: string;
+}) {
+  return (
+    <div
+      className={cn(
+        "flex h-full flex-col items-center justify-center gap-2 p-6 text-center text-sm text-muted",
+        className,
+      )}
+    >
+      {loading ? (
+        <Loader2 className="h-6 w-6 animate-spin opacity-60" aria-hidden />
+      ) : (
+        Icon && <Icon className="h-6 w-6 opacity-50" aria-hidden />
+      )}
+      <p className="max-w-xs">{title}</p>
+      {description && <div className="max-w-xs text-xs">{description}</div>}
+    </div>
+  );
+}

--- a/src/lib/i18n.tsx
+++ b/src/lib/i18n.tsx
@@ -80,6 +80,7 @@ const DE: Record<string, string> = {
   "common.close": "Schließen",
   "common.retry": "Erneut versuchen",
   "common.noResults": "Keine Treffer.",
+  "common.loading": "Lädt…",
 
   "search.label": "Sessions und Events durchsuchen",
   "search.placeholder": "Suchen…",
@@ -216,6 +217,7 @@ const EN: Record<string, string> = {
   "common.close": "Close",
   "common.retry": "Retry",
   "common.noResults": "No matches.",
+  "common.loading": "Loading…",
 
   "search.label": "Search sessions and events",
   "search.placeholder": "Search…",

--- a/src/plugins/live-stream/widget.tsx
+++ b/src/plugins/live-stream/widget.tsx
@@ -15,6 +15,7 @@ import {
   type LucideIcon,
 } from "lucide-react";
 import { Panel } from "@/components/panel";
+import { WidgetState } from "@/components/widget-state";
 import { useLive } from "@/components/live-provider";
 import { useSearch, matchesQuery } from "@/components/search";
 import { useT } from "@/lib/i18n";
@@ -64,9 +65,19 @@ export function LiveStream() {
       }
     >
       {events.length === 0 ? (
-        <Empty />
+        <WidgetState
+          icon={Activity}
+          title={t("stream.emptyTitle")}
+          description={
+            <>
+              {t("stream.emptyPre")}
+              <code className="text-accent">npm run seed</code>
+              {t("stream.emptyPost")}
+            </>
+          }
+        />
       ) : filtered.length === 0 ? (
-        <NoResults />
+        <WidgetState icon={Activity} title={t("common.noResults")} />
       ) : (
         <ul role="log" aria-live="polite" aria-label={t("stream.title")} className="divide-y divide-panel-border/60">
           {filtered.map((e) => {
@@ -93,30 +104,5 @@ export function LiveStream() {
         </ul>
       )}
     </Panel>
-  );
-}
-
-function Empty() {
-  const { t } = useT();
-  return (
-    <div className="flex h-full flex-col items-center justify-center gap-2 p-6 text-center text-sm text-muted">
-      <Activity className="h-6 w-6 opacity-50" />
-      <p>{t("stream.emptyTitle")}</p>
-      <p className="text-xs">
-        {t("stream.emptyPre")}
-        <code className="text-accent">npm run seed</code>
-        {t("stream.emptyPost")}
-      </p>
-    </div>
-  );
-}
-
-function NoResults() {
-  const { t } = useT();
-  return (
-    <div className="flex h-full flex-col items-center justify-center gap-2 p-6 text-center text-sm text-muted">
-      <Activity className="h-6 w-6 opacity-50" />
-      <p>{t("common.noResults")}</p>
-    </div>
   );
 }

--- a/src/plugins/token-chart/widget.tsx
+++ b/src/plugins/token-chart/widget.tsx
@@ -14,6 +14,7 @@ import {
 } from "recharts";
 import { Coins } from "lucide-react";
 import { Panel } from "@/components/panel";
+import { WidgetState } from "@/components/widget-state";
 import { useT } from "@/lib/i18n";
 import type { UsageReport } from "@/lib/ccusage";
 import { formatCompact, formatMoney } from "@/lib/format";
@@ -105,8 +106,10 @@ export function TokenChart() {
         </div>
       }
     >
-      {!usage || !usage.available || data.length === 0 ? (
-        <Empty available={usage?.available ?? true} range={range} />
+      {!usage ? (
+        <WidgetState icon={Coins} title={t("common.loading")} loading />
+      ) : !usage.available || data.length === 0 ? (
+        <WidgetState icon={Coins} title={emptyMessage(t, usage.available, range)} />
       ) : (
         <div className="h-full w-full p-2">
           <ResponsiveContainer width="100%" height="100%">
@@ -175,17 +178,7 @@ const tooltipStyle = {
   fontSize: 12,
 } as const;
 
-function Empty({ available, range }: { available: boolean; range: Range }) {
-  const { t } = useT();
-  const msg = !available
-    ? t("tokens.emptyUnavailable")
-    : range === "24h"
-      ? t("tokens.empty24h")
-      : t("tokens.emptyNone");
-  return (
-    <div className="flex h-full flex-col items-center justify-center gap-2 p-6 text-center text-sm text-muted">
-      <Coins className="h-6 w-6 opacity-50" />
-      <p>{msg}</p>
-    </div>
-  );
+function emptyMessage(t: (key: string) => string, available: boolean, range: Range): string {
+  if (!available) return t("tokens.emptyUnavailable");
+  return range === "24h" ? t("tokens.empty24h") : t("tokens.emptyNone");
 }

--- a/src/plugins/tool-graph/widget.tsx
+++ b/src/plugins/tool-graph/widget.tsx
@@ -5,6 +5,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { forceCollide } from "d3-force-3d";
 import { Boxes, Maximize2, Minimize2, X } from "lucide-react";
 import { Panel } from "@/components/panel";
+import { WidgetState } from "@/components/widget-state";
 import { useLive } from "@/components/live-provider";
 import { useT } from "@/lib/i18n";
 import { relativeTime, STATUS_META } from "@/lib/format";
@@ -401,15 +402,9 @@ export function ToolGraph() {
       >
         <div ref={wrapRef} className="relative h-full w-full">
           {!webglOk ? (
-            <div className="flex h-full flex-col items-center justify-center gap-2 p-6 text-center text-sm text-muted">
-              <Boxes className="h-6 w-6 opacity-50" />
-              <p className="max-w-xs">{t("graph.noWebgl")}</p>
-            </div>
+            <WidgetState icon={Boxes} title={t("graph.noWebgl")} />
           ) : data.nodes.length === 0 ? (
-            <div className="flex h-full flex-col items-center justify-center gap-2 p-6 text-center text-sm text-muted">
-              <Boxes className="h-6 w-6 opacity-50" />
-              <p>{t("graph.empty")}</p>
-            </div>
+            <WidgetState icon={Boxes} title={t("graph.empty")} />
           ) : dims.w > 0 ? (
             <>
               <ForceGraph3D
@@ -476,7 +471,9 @@ export function ToolGraph() {
                 ))}
               </div>
             </>
-          ) : null}
+          ) : (
+            <WidgetState icon={Boxes} title={t("common.loading")} loading />
+          )}
         </div>
       </Panel>
     </div>


### PR DESCRIPTION
## Summary

Roadmap **Run 11 — Unified widget states.** Replaces the duplicated centered empty/no-results/loading blocks across the widgets with one shared component.

- **New `src/components/widget-state.tsx`** — `<WidgetState icon title description? loading? />`: a centered icon + title (+ optional description), or a spinner when `loading`. Lives inside a `Panel` body.
- **Rolled out:**
  - `live-stream` — empty + no-results (kept the `npm run seed` hint as `description`).
  - `token-chart` — empty state, **plus a real loading state** while usage is being fetched (previously the empty message showed during load).
  - `tool-graph` — no-WebGL, empty, and the brief measuring gap (was a blank `null`) now show a consistent state.
- **i18n** — adds `common.loading` (de: "Lädt…", en: "Loading…").

Pure presentational refactor — no behavior change beyond consistent states (and the new loading affordances). Consistent with the repo convention that UI components are verified by lint + type-check rather than unit tests; lib test suite unchanged at 100 passing.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm test` — 100 passed
- [x] `npm run build` — compiles
- [ ] CI `verify` job green on this PR

https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk)_