### PR TITLE
Run 12: Add Playwright smoke E2E and wire it into CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,3 +41,33 @@ jobs:
       # uses an in-memory database during `next build`, so no data dir is needed).
       - name: Build
         run: npm run build
+
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci
+
+      - name: Install Playwright (chromium)
+        run: npx playwright install --with-deps chromium
+
+      - name: Build
+        run: npm run build
+
+      # Playwright boots `npm run start` (see playwright.config.ts), seeds via the
+      # ingest API and asserts the dashboard renders, connects and populates.
+      - name: Smoke E2E
+        run: npm run test:e2e
+
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: playwright-results
+          path: test-results
+          if-no-files-found: ignore

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@
 
 # testing
 /coverage
+/test-results
+/playwright-report
+/.playwright
 
 # mission-control local database
 /data

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -1,0 +1,66 @@
+import { test, expect, request as playwrightRequest, type APIRequestContext } from "@playwright/test";
+
+const BASE_URL = "http://127.0.0.1:3100";
+const PROJECT = "shopify-bot";
+const TITLE = "E2E smoke prompt";
+
+async function post(ctx: APIRequestContext, event: string, payload: Record<string, unknown>) {
+  const res = await ctx.post("/api/ingest", {
+    headers: { "X-Hook-Event": event, "Content-Type": "application/json" },
+    data: { ...payload, hook_event_name: event },
+  });
+  expect(res.ok(), `${event} should be accepted`).toBeTruthy();
+}
+
+// Drive the only write path (/api/ingest) like a real hook would, so the whole
+// pipeline (ingest -> DB -> sessions/events/SSE) is exercised end to end.
+async function seed(ctx: APIRequestContext) {
+  const base = { session_id: `e2e-${Date.now()}`, cwd: `/home/user/projects/${PROJECT}` };
+  await post(ctx, "SessionStart", { ...base, source: "startup" });
+  await post(ctx, "UserPromptSubmit", { ...base, prompt: TITLE });
+  await post(ctx, "PreToolUse", { ...base, tool_name: "Read", tool_input: { file_path: "/x.ts" } });
+  await post(ctx, "PostToolUse", {
+    ...base,
+    tool_name: "Read",
+    tool_input: { file_path: "/x.ts" },
+    tool_response: { ok: true },
+  });
+  await post(ctx, "Stop", { ...base });
+}
+
+test.beforeAll(async () => {
+  const ctx = await playwrightRequest.newContext({ baseURL: BASE_URL });
+  await seed(ctx);
+  await ctx.dispose();
+});
+
+test("dashboard renders all four widgets and connects", async ({ page }) => {
+  await page.goto("/");
+
+  await expect(page.getByRole("heading", { name: "Claude Mission Control" })).toBeVisible();
+
+  // Four widget panels are rendered (kanban, live-stream, token-chart, tool-graph).
+  await expect(page.locator("section")).toHaveCount(4);
+  // Two titles are identical in both locales — safe to assert regardless of language.
+  await expect(page.getByText("Sessions", { exact: true })).toBeVisible();
+  await expect(page.getByText("Live Stream", { exact: true })).toBeVisible();
+
+  // SSE establishes the live connection.
+  await expect(page.getByTestId("connection-status")).toHaveAttribute("data-state", "connected", {
+    timeout: 15_000,
+  });
+});
+
+test("seeded activity flows into the live stream and kanban", async ({ page }) => {
+  await page.goto("/");
+
+  // Live stream shows the backlog (delivered via /api/events then SSE).
+  await expect(page.getByRole("log").getByRole("listitem").first()).toBeVisible({ timeout: 15_000 });
+
+  // Kanban shows the seeded session card by its prompt-derived title, with the
+  // project name on it. Scope to the card button so we don't match the project
+  // filter's <option> or the live-stream summary.
+  const card = page.getByRole("button").filter({ hasText: TITLE }).first();
+  await expect(card).toBeVisible({ timeout: 15_000 });
+  await expect(card.getByText(PROJECT, { exact: true })).toBeVisible();
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
       },
       "devDependencies": {
         "@electron/rebuild": "^3.7.0",
+        "@playwright/test": "^1.60.0",
         "@tailwindcss/postcss": "^4",
         "@types/better-sqlite3": "^7.6.13",
         "@types/node": "^20",
@@ -2322,6 +2323,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@reduxjs/toolkit": {
@@ -10438,7 +10455,7 @@
       "version": "1.60.0",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
       "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright-core": "1.60.0"
@@ -10457,7 +10474,7 @@
       "version": "1.60.0",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
       "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "lint": "eslint",
     "test": "vitest run",
     "test:watch": "vitest",
+    "test:e2e": "playwright test",
     "seed": "node scripts/seed-demo.mjs",
     "backup": "node scripts/backup.mjs",
     "export-log": "node scripts/export-log.mjs",
@@ -50,6 +51,7 @@
   },
   "devDependencies": {
     "@electron/rebuild": "^3.7.0",
+    "@playwright/test": "^1.60.0",
     "@tailwindcss/postcss": "^4",
     "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^20",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,28 @@
+import { defineConfig, devices } from "@playwright/test";
+
+// Smoke E2E: boots the real production server (its own port + data dir) and checks
+// the dashboard renders, SSE connects and seeded data flows through. Kept minimal
+// and deterministic so it can gate CI without flaking.
+const PORT = 3100;
+const BASE_URL = `http://127.0.0.1:${PORT}`;
+
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  workers: 1,
+  reporter: process.env.CI ? "line" : "list",
+  use: {
+    baseURL: BASE_URL,
+    trace: "on-first-retry",
+  },
+  projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
+  webServer: {
+    command: "npm run start",
+    url: BASE_URL,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+    env: { PORT: String(PORT), MC_DATA_DIR: ".playwright/data" },
+  },
+});

--- a/src/components/dashboard.tsx
+++ b/src/components/dashboard.tsx
@@ -227,6 +227,8 @@ function Header({
           <InfoHint text={t("header.eventsInfo")} align="right" />
         </span>
         <span
+          data-testid="connection-status"
+          data-state={connected ? "connected" : "disconnected"}
           className={`flex items-center gap-1.5 rounded-full border px-2.5 py-1 transition-colors ${
             connected
               ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-400"


### PR DESCRIPTION
## Summary

Roadmap **Run 12 — Playwright smoke E2E, wired into CI.** A real browser test that boots the production server and verifies the whole pipeline end-to-end.

- **Adds `@playwright/test`** + `playwright.config.ts` — boots `npm run start` on a dedicated port (3100) with an **isolated data dir** (`.playwright/data`), 1 retry in CI, traces on first retry.
- **`e2e/smoke.spec.ts`** — seeds the **only write path** (`/api/ingest`) like a real hook (SessionStart → prompt → Pre/PostToolUse → Stop), then asserts:
  1. the dashboard renders all **four widget panels** (4 `<section>`s; "Sessions" + "Live Stream" titles, locale-independent) under the "Claude Mission Control" header;
  2. **SSE connects** (`data-state="connected"` on the connection pill);
  3. seeded activity **flows into the live stream** (backlog list item) and the **kanban** (card matched by its prompt-derived title, with the project name on it).
- **`dashboard.tsx`** — small `data-testid="connection-status"` / `data-state` hook on the connection pill for a language-independent connectivity assertion.
- **CI** — a separate `e2e` job installs Chromium, builds, runs `npm run test:e2e`, and uploads traces on failure. `test:e2e` script added; Playwright artifacts gitignored.

**Verified locally**: both E2E specs pass against a real server (`2 passed`). Unit gates also green: lint clean, 100 unit tests, build compiles.

Note: `next start` logs a cosmetic warning about `output: standalone`; it still serves the full client bundle (hydration, SSE and client fetches all work — the tests prove it).

## Test plan

- [x] `npm run lint` — clean
- [x] `npm test` — 100 passed (vitest ignores `e2e/`)
- [x] `npm run build` — compiles
- [x] `npm run test:e2e` — 2 passed (local, real server)
- [ ] CI `verify` + `e2e` jobs green on this PR

https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk)_