### PR TITLE
Run 13: Add database restore + harden backup data-dir handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "test:e2e": "playwright test",
     "seed": "node scripts/seed-demo.mjs",
     "backup": "node scripts/backup.mjs",
+    "restore": "node scripts/restore.mjs",
     "export-log": "node scripts/export-log.mjs",
     "protect": "node scripts/protect.mjs lock",
     "unprotect": "node scripts/protect.mjs unlock",

--- a/scripts/backup.mjs
+++ b/scripts/backup.mjs
@@ -12,8 +12,11 @@ import { mkdirSync, readdirSync, statSync, unlinkSync, existsSync } from "node:f
 import path from "node:path";
 
 const KEEP = Number(process.env.MC_BACKUP_KEEP) > 0 ? Number(process.env.MC_BACKUP_KEEP) : 14;
-const src = path.join(process.cwd(), "data", "mission-control.db");
-const backupDir = path.join(process.cwd(), "backups");
+// Honour the same data location as the app (Electron passes MC_DATA_DIR); the
+// backup directory is overridable too.
+const dataDir = process.env.MC_DATA_DIR || path.join(process.cwd(), "data");
+const src = path.join(dataDir, "mission-control.db");
+const backupDir = process.env.MC_BACKUP_DIR || path.join(process.cwd(), "backups");
 
 if (!existsSync(src)) {
   console.error(`Keine Datenbank gefunden: ${src}\nLäuft das Dashboard schon? (./start.sh)`);

--- a/scripts/restore.mjs
+++ b/scripts/restore.mjs
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+// Restore the dashboard database from a backup snapshot (see scripts/backup.mjs).
+//
+//   npm run restore                 # restore the newest snapshot
+//   npm run restore <file|path>     # restore a specific snapshot (name or path)
+//
+// Stop the dashboard first. Before overwriting, the current database is snapshotted
+// to <backups>/pre-restore-<timestamp>.db, so the restore is itself reversible.
+// Honours MC_DATA_DIR and MC_BACKUP_DIR (same as backup).
+
+import Database from "better-sqlite3";
+import { existsSync, mkdirSync, readdirSync, rmSync, statSync } from "node:fs";
+import path from "node:path";
+
+const dataDir = process.env.MC_DATA_DIR || path.join(process.cwd(), "data");
+const backupDir = process.env.MC_BACKUP_DIR || path.join(process.cwd(), "backups");
+const liveDb = path.join(dataDir, "mission-control.db");
+
+function newestBackup() {
+  if (!existsSync(backupDir)) return null;
+  const files = readdirSync(backupDir)
+    .filter((f) => f.startsWith("mission-control-") && f.endsWith(".db"))
+    .map((f) => ({ f, t: statSync(path.join(backupDir, f)).mtimeMs }))
+    .sort((a, b) => b.t - a.t);
+  return files.length ? path.join(backupDir, files[0].f) : null;
+}
+
+// Accept an explicit path, a bare filename inside the backup dir, or default to
+// the newest snapshot.
+function resolveSource(arg) {
+  if (!arg) return newestBackup();
+  if (existsSync(arg)) return path.resolve(arg);
+  const inDir = path.join(backupDir, arg);
+  return existsSync(inDir) ? inDir : null;
+}
+
+function timestamp() {
+  return new Date().toISOString().replace(/[:T]/g, "-").slice(0, 19);
+}
+
+function isSqlite(file) {
+  try {
+    const db = new Database(file, { fileMustExist: true, readonly: true });
+    db.pragma("schema_version");
+    db.close();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function main() {
+  const arg = process.argv[2];
+  const src = resolveSource(arg);
+  if (!src) {
+    console.error(
+      arg
+        ? `Backup nicht gefunden: ${arg} (gesucht in ${backupDir})`
+        : `Keine Backups in ${backupDir}. Erst "npm run backup" ausführen.`,
+    );
+    process.exit(1);
+  }
+  if (!isSqlite(src)) {
+    console.error(`Keine gültige SQLite-Datenbank: ${src}`);
+    process.exit(1);
+  }
+
+  mkdirSync(dataDir, { recursive: true });
+  mkdirSync(backupDir, { recursive: true });
+
+  // Reversibility: snapshot the current database before replacing it.
+  if (existsSync(liveDb)) {
+    const safety = path.join(backupDir, `pre-restore-${timestamp()}.db`);
+    const cur = new Database(liveDb, { fileMustExist: true });
+    try {
+      await cur.backup(safety);
+      console.log(`✓ Aktuelle DB gesichert: ${path.relative(process.cwd(), safety)}`);
+    } finally {
+      cur.close();
+    }
+  }
+
+  // Write a clean copy of the snapshot to the live path (online backup → a single
+  // consistent file), then drop any stale WAL/SHM sidecars so SQLite doesn't
+  // replay the previous database's WAL over the restored file.
+  const snap = new Database(src, { fileMustExist: true });
+  try {
+    await snap.backup(liveDb);
+  } finally {
+    snap.close();
+  }
+  for (const side of ["-wal", "-shm"]) {
+    const f = liveDb + side;
+    if (existsSync(f)) rmSync(f);
+  }
+
+  console.log(
+    `✓ Wiederhergestellt: ${path.relative(process.cwd(), src)} → ${path.relative(process.cwd(), liveDb)}`,
+  );
+  console.log("Starte das Dashboard neu, um die wiederhergestellten Daten zu sehen.");
+}
+
+main().catch((err) => {
+  console.error("Restore fehlgeschlagen:", err.message);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Roadmap **Run 13 — Backup/restore hardening.**

`backup.mjs` already used SQLite's online-backup API with retention, so this run focuses on the gaps: data-dir portability and the missing restore counterpart.

- **`backup.mjs`** — now honours `MC_DATA_DIR` / `MC_BACKUP_DIR` (matching the app), so it finds the database in packaged/Electron layouts, not just `./data`. Online backup + `MC_BACKUP_KEEP` retention unchanged.
- **New `scripts/restore.mjs`** (`npm run restore [file|path]`):
  - restores the **newest** snapshot, or a named one (path or bare filename in the backup dir);
  - **validates** the source is a real SQLite database before touching the live one;
  - takes a **safety snapshot** of the current DB to `pre-restore-<ts>.db` first, so the restore is itself reversible;
  - writes a clean copy via the online-backup API and **clears stale WAL/SHM sidecars** so the previous database's WAL can't be replayed over the restored file;
  - same `MC_DATA_DIR` / `MC_BACKUP_DIR` handling.
- **`npm run restore`** script added.

**Verified end to end** against a temp database: backup → mutate → restore reverts to the original row, with a `pre-restore` snapshot created and no stale sidecars. (CLI scripts follow the repo convention of being verified by running, not unit-tested.)

## Test plan

- [x] `npm run lint` — clean
- [x] `npm test` — 100 passed
- [x] `npm run build` — compiles
- [x] manual backup → mutate → restore cycle verified
- [ ] CI `verify` + `e2e` jobs green on this PR

https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk)_