### PR TITLE
Run 14: Local security pass — headers, ingest security model, env docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,10 +4,27 @@ MC_PORT=3000
 # USD -> EUR conversion factor for cost display (ccusage reports USD). Offline-first: set manually.
 EUR_PER_USD=0.92
 
-# Optional shared secret. If set, the dashboard rejects ingest requests without this header,
-# and the hook forwards it. Leave empty for a pure-local single-user setup.
+# Optional shared secret for the ingest endpoint. The server binds to 127.0.0.1, so
+# /api/ingest is local-only and takes no cookies (classic CSRF doesn't apply). Set
+# this to additionally require an X-Hook-Token header — the hook forwarder sends it —
+# so no other local process can post events. Leave empty for a single-user setup.
 MC_HOOK_TOKEN=
 
 # Where Claude Code stores its data (transcripts + usage). Defaults to ~/.claude.
 # CLAUDE_DIR=/home/youruser/.claude
+
+# --- Optional operational knobs (sensible defaults; uncomment to override) ---
+# Where the dashboard DB lives (Electron sets this per-user). Default: ./data
+# MC_DATA_DIR=./data
+# Server logging: level (debug|info|warn|error, default info) and optional file.
+# MC_LOG_LEVEL=info
+# MC_LOG_FILE=./mission-control.log
+# Retention caps for the high-volume tables (<=0 disables). Default 100000 each.
+# MC_MAX_EVENTS=100000
+# MC_MAX_TOOL_CALLS=100000
+# Max concurrent live (SSE) dashboard connections. Default 64.
+# MC_MAX_SSE_CLIENTS=64
+# Database snapshots: how many to keep and where. Defaults: 14, ./backups
+# MC_BACKUP_KEEP=14
+# MC_BACKUP_DIR=./backups
 

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -35,7 +35,11 @@ test.beforeAll(async () => {
 });
 
 test("dashboard renders all four widgets and connects", async ({ page }) => {
-  await page.goto("/");
+  const response = await page.goto("/");
+
+  // Security headers are served by the local server.
+  expect(response?.headers()["x-content-type-options"]).toBe("nosniff");
+  expect(response?.headers()["x-frame-options"]).toBe("DENY");
 
   await expect(page.getByRole("heading", { name: "Claude Mission Control" })).toBeVisible();
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -7,6 +7,17 @@ import type { NextConfig } from "next";
 const isDemo = process.env.MC_DEMO === "1";
 const basePath = isDemo ? process.env.MC_BASE_PATH ?? "/My_Dash" : undefined;
 
+// Conservative, non-breaking security headers for the local server. (No CSP: the
+// 3D graph/charts pull in inline styles, blob workers and WebGL, so a strict
+// policy would need careful nonce work — out of scope for a 127.0.0.1-only tool.)
+const securityHeaders = [
+  { key: "X-Content-Type-Options", value: "nosniff" },
+  { key: "X-Frame-Options", value: "DENY" },
+  { key: "Referrer-Policy", value: "no-referrer" },
+  { key: "X-DNS-Prefetch-Control", value: "off" },
+  { key: "Permissions-Policy", value: "camera=(), microphone=(), geolocation=()" },
+];
+
 const nextConfig: NextConfig = isDemo
   ? {
       output: "export",
@@ -22,6 +33,10 @@ const nextConfig: NextConfig = isDemo
       output: "standalone",
       // better-sqlite3 is a native module — keep it out of the bundle so it loads via require() at runtime.
       serverExternalPackages: ["better-sqlite3"],
+      // Applied by the server (the static demo export ignores headers()).
+      async headers() {
+        return [{ source: "/:path*", headers: securityHeaders }];
+      },
     };
 
 export default nextConfig;

--- a/src/app/api/ingest/route.ts
+++ b/src/app/api/ingest/route.ts
@@ -7,6 +7,12 @@ export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 // The ONLY write path. Fed exclusively by Claude Code hooks (machine events), never by an LLM.
+//
+// Security model: the server binds to 127.0.0.1, so this endpoint is only reachable
+// from the local machine. It takes no cookies/ambient credentials, so classic CSRF
+// (a browser auto-attaching a session) doesn't apply — the only caller is the hook
+// forwarder. Set MC_HOOK_TOKEN to additionally require a shared secret (X-Hook-Token)
+// and reject any other local process from posting events.
 export async function POST(req: Request) {
   const requiredToken = process.env.MC_HOOK_TOKEN;
   if (requiredToken && req.headers.get("x-hook-token") !== requiredToken) {


### PR DESCRIPTION
## Summary

Roadmap **Run 14 — Local security pass.** Final run of Phase A (foundation hardening).

- **Binding audit (no change needed)** — confirmed `127.0.0.1`-only everywhere: `next dev`/`next start` use `-H 127.0.0.1`, Electron spawns the server with `HOSTNAME=127.0.0.1` and loads `http://127.0.0.1`, and the hook forwarder posts to `127.0.0.1`.
- **Security headers** — added to the **server** config via `next.config` `headers()`: `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, `Referrer-Policy: no-referrer`, `X-DNS-Prefetch-Control: off`, `Permissions-Policy`. The static demo (`output: export`) is unaffected. **No CSP** yet — the 3D graph/charts rely on inline styles, blob workers and WebGL, so a strict policy needs nonce work and would risk breaking the live dashboard (documented in-code as a deliberate omission).
- **Ingest security note** — documents the threat model at the boundary: local-only, no ambient credentials (so classic CSRF doesn't apply), `MC_HOOK_TOKEN` as an optional shared secret.
- **`.env.example`** — sharpened the `MC_HOOK_TOKEN` note and documented the operational knobs added this phase (`MC_DATA_DIR`, `MC_LOG_LEVEL`/`MC_LOG_FILE`, `MC_MAX_EVENTS`/`MC_MAX_TOOL_CALLS`, `MC_MAX_SSE_CLIENTS`, `MC_BACKUP_KEEP`/`MC_BACKUP_DIR`).
- **E2E** — the smoke test now asserts the headers are actually served.

**Verified locally**: lint, build, 100 unit tests, 2 E2E pass (incl. header assertions), and a `curl` check confirming all five headers on pages and API routes.

## Test plan

- [x] `npm run lint` / `npm test` / `npm run build`
- [x] `npm run test:e2e` — 2 passed (asserts headers)
- [x] `curl -D-` shows headers on `/` and `/api/health`
- [ ] CI `verify` + `e2e` green

## Phase A complete

Runs 1–14 done: CI gate, ingest/graph/ccusage tests, Zod validation, migrations, health endpoint, structured logging, ingest retention + bus isolation, SSE resume + cap, unified widget states, Playwright smoke E2E, backup/restore, and this security pass. Foundation is hardened — next is Phase B (capture more data).

https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk)_