### PR TITLE
Run 15: Add single-event detail read path (GET /api/events/:id)

### DIFF
--- a/src/app/api/events/[id]/route.ts
+++ b/src/app/api/events/[id]/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from "next/server";
+import { db } from "@/lib/db";
+import { eventById, withParsedPayload } from "@/lib/events";
+import { log } from "@/lib/log";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+// A single event with its payload parsed — the read path behind the drill-down
+// detail views.
+export async function GET(_req: Request, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const eventId = Number(id);
+  if (!Number.isInteger(eventId) || eventId <= 0) {
+    return NextResponse.json({ error: "invalid id" }, { status: 400 });
+  }
+
+  try {
+    const row = eventById(db, eventId);
+    if (!row) return NextResponse.json({ error: "not found" }, { status: 404 });
+    return NextResponse.json({ event: withParsedPayload(row) });
+  } catch (err) {
+    log.error("/api/events/[id] failed", err);
+    return NextResponse.json({ error: "lookup failed" }, { status: 500 });
+  }
+}

--- a/src/lib/events.test.ts
+++ b/src/lib/events.test.ts
@@ -1,0 +1,55 @@
+import Database from "better-sqlite3";
+import { afterEach, describe, expect, it } from "vitest";
+import { eventById, withParsedPayload } from "@/lib/events";
+import { migrate } from "@/lib/migrations";
+import type { EventRow } from "@/lib/types";
+
+function row(over: Partial<EventRow> = {}): EventRow {
+  return {
+    id: 1,
+    session_id: "s1",
+    event_type: "PreToolUse",
+    tool_name: "Read",
+    summary: "Read: /x.ts",
+    payload_json: '{"tool_name":"Read","tool_input":{"file_path":"/x.ts"}}',
+    created_at: "2026-05-23 10:00:00",
+    ...over,
+  };
+}
+
+describe("withParsedPayload", () => {
+  it("parses payload_json into payload and drops the raw string", () => {
+    const detail = withParsedPayload(row());
+    expect(detail.payload).toEqual({ tool_name: "Read", tool_input: { file_path: "/x.ts" } });
+    expect("payload_json" in detail).toBe(false);
+    expect(detail.id).toBe(1);
+    expect(detail.event_type).toBe("PreToolUse");
+  });
+
+  it("tolerates a corrupt payload by yielding null", () => {
+    expect(withParsedPayload(row({ payload_json: "not json" })).payload).toBeNull();
+  });
+});
+
+describe("eventById", () => {
+  let open: Database.Database | null = null;
+  afterEach(() => {
+    open?.close();
+    open = null;
+  });
+
+  it("fetches a stored event by id and returns undefined when missing", () => {
+    const db = (open = new Database(":memory:"));
+    migrate(db);
+    const info = db
+      .prepare("INSERT INTO events (session_id, event_type, payload_json) VALUES (?, ?, ?)")
+      .run("s1", "SessionStart", '{"source":"startup"}');
+    const id = Number(info.lastInsertRowid);
+
+    const found = eventById(db, id);
+    expect(found?.event_type).toBe("SessionStart");
+    expect(withParsedPayload(found!).payload).toEqual({ source: "startup" });
+
+    expect(eventById(db, 99999)).toBeUndefined();
+  });
+});

--- a/src/lib/events.ts
+++ b/src/lib/events.ts
@@ -1,0 +1,24 @@
+import type Database from "better-sqlite3";
+import type { EventRow } from "./types";
+
+// An event with its stored payload parsed back into an object (the raw JSON string
+// is dropped). This is what the single-event detail endpoint returns and what the
+// drill-down viewers consume.
+export interface EventDetail extends Omit<EventRow, "payload_json"> {
+  payload: unknown;
+}
+
+export function withParsedPayload(row: EventRow): EventDetail {
+  const { payload_json, ...rest } = row;
+  let payload: unknown = null;
+  try {
+    payload = JSON.parse(payload_json);
+  } catch {
+    payload = null; // tolerate a corrupt/legacy payload rather than 500
+  }
+  return { ...rest, payload };
+}
+
+export function eventById(db: Database.Database, id: number): EventRow | undefined {
+  return db.prepare(`SELECT * FROM events WHERE id = ?`).get(id) as EventRow | undefined;
+}


### PR DESCRIPTION
## Summary

Roadmap **Run 15 — Single-event detail read path.** First step of Phase B (data depth).

- **New `GET /api/events/:id`** — returns one event with its `payload_json` parsed back into an object (raw string dropped). `400` for a non-positive/invalid id, `404` when not found, `500` (logged) on failure.
- **New `src/lib/events.ts`** — the pure pieces: `withParsedPayload(row)` (parses payload, tolerates corrupt JSON by yielding `null` instead of throwing) and `eventById(db, id)`. The route is a thin wrapper.
- **New `src/lib/events.test.ts`** (3 tests) — payload parsing + raw-string drop, corrupt-payload→null, and `eventById` fetch/missing against an in-memory DB.

This is the read-path foundation the Phase E drill-down/detail viewers build on. 103 tests pass total (3 new + 100 existing).

## Test plan

- [x] `npm run lint` — clean
- [x] `npm test` — 103 passed
- [x] `npm run build` — `/api/events/[id]` registered
- [ ] CI `verify` + `e2e` green

https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk)_