### PR TITLE
Run 19: Store per-session cache tokens and an estimated cost

### DIFF
--- a/src/lib/demo.ts
+++ b/src/lib/demo.ts
@@ -114,6 +114,7 @@ function toRow(s: DSession): SessionRow {
     ended_at: s.ended_at,
     token_input: 0,
     token_output: 0,
+    token_cache: 0,
     cost_usd: 0,
   };
 }

--- a/src/lib/ingest.test.ts
+++ b/src/lib/ingest.test.ts
@@ -214,7 +214,7 @@ describe("ingest — model", () => {
 });
 
 describe("ingest — transcript usage sync", () => {
-  it("writes transcript-derived token totals onto the session", async () => {
+  it("writes transcript-derived tokens and an estimated cost onto the session", async () => {
     send("SessionStart", { session_id: "s1" });
     const file = path.join(dataDir, "transcript.jsonl");
     writeFileSync(
@@ -224,7 +224,12 @@ describe("ingest — transcript usage sync", () => {
           role: "assistant",
           model: "claude-opus-4-7",
           content: [{ type: "text", text: "x" }],
-          usage: { input_tokens: 500, output_tokens: 120 },
+          usage: {
+            input_tokens: 500,
+            output_tokens: 120,
+            cache_creation_input_tokens: 100,
+            cache_read_input_tokens: 200,
+          },
         },
       }),
     );
@@ -234,6 +239,8 @@ describe("ingest — transcript usage sync", () => {
     const s = session("s1")!;
     expect(s.token_input).toBe(500);
     expect(s.token_output).toBe(120);
+    expect(s.token_cache).toBe(300); // 100 + 200
+    expect(s.cost_usd).toBeCloseTo(0.018675, 9);
   });
 });
 

--- a/src/lib/migrations.ts
+++ b/src/lib/migrations.ts
@@ -73,6 +73,11 @@ export const MIGRATIONS: string[] = [
   `
   ALTER TABLE events ADD COLUMN model TEXT;
   `,
+
+  // v4 — cached-token total per session (input/output/cost columns already exist).
+  `
+  ALTER TABLE sessions ADD COLUMN token_cache INTEGER DEFAULT 0;
+  `,
 ];
 
 // Apply any migrations the database hasn't seen yet. Each runs in a transaction

--- a/src/lib/pricing.test.ts
+++ b/src/lib/pricing.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { estimateCostUsd, priceFor } from "@/lib/pricing";
+
+describe("priceFor", () => {
+  it("matches the model family", () => {
+    expect(priceFor("claude-opus-4-7").input).toBe(15);
+    expect(priceFor("claude-sonnet-4-6").input).toBe(3);
+    expect(priceFor("claude-haiku-4-5").input).toBe(0.8);
+  });
+
+  it("falls back to Sonnet pricing for null/unknown models", () => {
+    expect(priceFor(null)).toEqual(priceFor("claude-sonnet-4-6"));
+    expect(priceFor("some-future-model")).toEqual(priceFor("claude-sonnet-4-6"));
+  });
+});
+
+describe("estimateCostUsd", () => {
+  it("prices a million input tokens at the per-MTok rate", () => {
+    expect(
+      estimateCostUsd({
+        inputTokens: 1_000_000,
+        outputTokens: 0,
+        cacheCreationTokens: 0,
+        cacheReadTokens: 0,
+        model: "claude-opus-4-7",
+      }),
+    ).toBe(15);
+  });
+
+  it("sums all token classes at their respective rates", () => {
+    // opus: 500*15 + 120*75 + 100*18.75 + 200*1.5 = 18675 (per MTok) -> /1e6
+    expect(
+      estimateCostUsd({
+        inputTokens: 500,
+        outputTokens: 120,
+        cacheCreationTokens: 100,
+        cacheReadTokens: 200,
+        model: "claude-opus-4-7",
+      }),
+    ).toBeCloseTo(0.018675, 9);
+  });
+
+  it("uses the fallback price for an unknown model", () => {
+    // sonnet input rate $3/MTok
+    expect(
+      estimateCostUsd({
+        inputTokens: 1_000_000,
+        outputTokens: 0,
+        cacheCreationTokens: 0,
+        cacheReadTokens: 0,
+        model: null,
+      }),
+    ).toBe(3);
+  });
+});

--- a/src/lib/pricing.ts
+++ b/src/lib/pricing.ts
@@ -1,0 +1,45 @@
+// Approximate per-model pricing (USD per million tokens) for an offline cost
+// estimate from transcript usage. This is a best-effort figure; ccusage remains
+// the source of truth and reconciles it in a later run.
+
+export interface ModelPrice {
+  input: number;
+  output: number;
+  cacheWrite: number; // cache creation
+  cacheRead: number;
+}
+
+const SONNET: ModelPrice = { input: 3, output: 15, cacheWrite: 3.75, cacheRead: 0.3 };
+
+const TABLE: { match: RegExp; price: ModelPrice }[] = [
+  { match: /opus/i, price: { input: 15, output: 75, cacheWrite: 18.75, cacheRead: 1.5 } },
+  { match: /haiku/i, price: { input: 0.8, output: 4, cacheWrite: 1, cacheRead: 0.08 } },
+  { match: /sonnet/i, price: SONNET },
+];
+
+// Match a model id to a price; Sonnet pricing is the sensible default.
+export function priceFor(model: string | null | undefined): ModelPrice {
+  if (model) {
+    for (const { match, price } of TABLE) if (match.test(model)) return price;
+  }
+  return SONNET;
+}
+
+export interface UsageTokens {
+  inputTokens: number;
+  outputTokens: number;
+  cacheCreationTokens: number;
+  cacheReadTokens: number;
+  model?: string | null;
+}
+
+export function estimateCostUsd(u: UsageTokens): number {
+  const p = priceFor(u.model);
+  return (
+    (u.inputTokens * p.input +
+      u.outputTokens * p.output +
+      u.cacheCreationTokens * p.cacheWrite +
+      u.cacheReadTokens * p.cacheRead) /
+    1_000_000
+  );
+}

--- a/src/lib/transcript-sync.ts
+++ b/src/lib/transcript-sync.ts
@@ -1,18 +1,20 @@
 import { db } from "./db";
 import { log } from "./log";
+import { estimateCostUsd } from "./pricing";
 import { summarizeTranscript } from "./transcript";
 
-// Writes the transcript-derived token totals onto the session. Cache tokens and
-// cost are layered on in a later run; here we populate the existing input/output
-// columns so the dashboard shows real per-session usage without ccusage.
-const setSessionUsage = db.prepare<[number, number, string]>(
-  `UPDATE sessions SET token_input = ?, token_output = ? WHERE id = ?`,
+// Writes the transcript-derived token totals + an estimated cost onto the session,
+// so the dashboard shows real per-session usage without ccusage (which reconciles
+// the cost later).
+const setSessionUsage = db.prepare<[number, number, number, number, string]>(
+  `UPDATE sessions SET token_input = ?, token_output = ?, token_cache = ?, cost_usd = ? WHERE id = ?`,
 );
 
 export async function updateSessionUsage(sessionId: string, transcriptPath: string): Promise<void> {
   const summary = await summarizeTranscript(transcriptPath);
   if (!summary || summary.turns === 0) return;
-  setSessionUsage.run(summary.inputTokens, summary.outputTokens, sessionId);
+  const cost = estimateCostUsd(summary);
+  setSessionUsage.run(summary.inputTokens, summary.outputTokens, summary.cacheTokens, cost, sessionId);
 }
 
 // Stop fires after every turn, so re-parsing the whole transcript each time would

--- a/src/lib/transcript.test.ts
+++ b/src/lib/transcript.test.ts
@@ -36,6 +36,8 @@ describe("parseTranscriptUsage", () => {
     expect(s.inputTokens).toBe(300);
     expect(s.outputTokens).toBe(130);
     expect(s.cacheTokens).toBe(60); // 10 + 20 + 30
+    expect(s.cacheCreationTokens).toBe(10);
+    expect(s.cacheReadTokens).toBe(50); // 20 + 30
     expect(s.turns).toBe(2);
     expect(s.model).toBe("claude-opus-4-7");
     expect(s.lastAssistantText).toBe("Done");
@@ -46,6 +48,8 @@ describe("parseTranscriptUsage", () => {
       inputTokens: 0,
       outputTokens: 0,
       cacheTokens: 0,
+      cacheCreationTokens: 0,
+      cacheReadTokens: 0,
       model: null,
       lastAssistantText: null,
       turns: 0,

--- a/src/lib/transcript.ts
+++ b/src/lib/transcript.ts
@@ -7,7 +7,9 @@ import { open, readFile, stat } from "node:fs/promises";
 export interface TranscriptSummary {
   inputTokens: number;
   outputTokens: number;
-  cacheTokens: number;
+  cacheTokens: number; // creation + read (for storage)
+  cacheCreationTokens: number;
+  cacheReadTokens: number;
   model: string | null;
   lastAssistantText: string | null;
   turns: number; // assistant turns that carried usage
@@ -35,7 +37,8 @@ function textOf(content: unknown): string {
 export function parseTranscriptUsage(text: string): TranscriptSummary {
   let inputTokens = 0;
   let outputTokens = 0;
-  let cacheTokens = 0;
+  let cacheCreationTokens = 0;
+  let cacheReadTokens = 0;
   let turns = 0;
   let model: string | null = null;
   let lastAssistantText: string | null = null;
@@ -56,7 +59,8 @@ export function parseTranscriptUsage(text: string): TranscriptSummary {
     if (usage && typeof usage === "object") {
       inputTokens += num(usage.input_tokens);
       outputTokens += num(usage.output_tokens);
-      cacheTokens += num(usage.cache_creation_input_tokens) + num(usage.cache_read_input_tokens);
+      cacheCreationTokens += num(usage.cache_creation_input_tokens);
+      cacheReadTokens += num(usage.cache_read_input_tokens);
       turns++;
     }
     if (typeof msg.model === "string") model = msg.model;
@@ -64,7 +68,16 @@ export function parseTranscriptUsage(text: string): TranscriptSummary {
     if (txt) lastAssistantText = txt;
   }
 
-  return { inputTokens, outputTokens, cacheTokens, model, lastAssistantText, turns };
+  return {
+    inputTokens,
+    outputTokens,
+    cacheTokens: cacheCreationTokens + cacheReadTokens,
+    cacheCreationTokens,
+    cacheReadTokens,
+    model,
+    lastAssistantText,
+    turns,
+  };
 }
 
 const DEFAULT_MAX_BYTES = 8 * 1024 * 1024;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -45,6 +45,7 @@ export interface SessionRow {
   ended_at: string | null;
   token_input: number;
   token_output: number;
+  token_cache: number;
   cost_usd: number;
 }
 


### PR DESCRIPTION
## Summary

Roadmap **Run 19 — Per-session cache tokens + estimated cost.**

- **Migration v4** — `sessions.token_cache` (input/output/cost columns already existed).
- **New `src/lib/pricing.ts`** — approximate per-model USD/MTok rates (`priceFor` with Opus/Sonnet/Haiku + Sonnet fallback) and `estimateCostUsd(usage)`.
- **Transcript parser** — now splits `cacheCreationTokens` vs `cacheReadTokens` (priced differently) while still reporting the `cacheTokens` total.
- **`transcript-sync.ts`** — `updateSessionUsage` now writes `token_cache` and an estimated `cost_usd` alongside input/output.
- These columns already flow through `/api/sessions` (`SELECT s.*`), so the data is available to the dashboard.
- Types/demo updated for `token_cache`.
- **Tests** (+5): pricing (family match, fallback, cost math), the cache split in the transcript parser, and the sync test now asserts `token_cache` + `cost_usd`.

Surfacing on the kanban card is Run 35; ccusage reconciles the cost in Run 37. 120 tests pass total.

## Test plan

- [x] `npm run lint` / `npm test` (120) / `npm run build`
- [ ] CI `verify` + `e2e` green

https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk)_