### PR TITLE
Run 22: Make context compactions queryable

### DIFF
--- a/src/app/api/compactions/route.ts
+++ b/src/app/api/compactions/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from "next/server";
+import { db } from "@/lib/db";
+import { recentCompactions } from "@/lib/compaction";
+import { log } from "@/lib/log";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+// Recent context-compaction events (newest first) for the compaction timeline.
+export async function GET(req: Request) {
+  const url = new URL(req.url);
+  const limit = Math.min(Math.max(Math.trunc(Number(url.searchParams.get("limit")) || 100), 1), 500);
+  try {
+    return NextResponse.json({ compactions: recentCompactions(db, limit) });
+  } catch (err) {
+    log.error("/api/compactions failed", err);
+    return NextResponse.json({ compactions: [] });
+  }
+}

--- a/src/lib/compaction.test.ts
+++ b/src/lib/compaction.test.ts
@@ -1,0 +1,59 @@
+import Database from "better-sqlite3";
+import { afterEach, describe, expect, it } from "vitest";
+import { parseCompaction, recentCompactions } from "@/lib/compaction";
+import { migrate } from "@/lib/migrations";
+import type { EventRow } from "@/lib/types";
+
+function event(over: Partial<EventRow> = {}): EventRow {
+  return {
+    id: 1,
+    session_id: "s1",
+    event_type: "PreCompact",
+    tool_name: null,
+    model: null,
+    summary: "compacting",
+    payload_json: "{}",
+    created_at: "2026-05-23 10:00:00",
+    ...over,
+  };
+}
+
+describe("parseCompaction", () => {
+  it("extracts the trigger and custom instructions from the payload", () => {
+    const c = parseCompaction(
+      event({ payload_json: '{"trigger":"manual","custom_instructions":"keep the plan"}' }),
+    );
+    expect(c.trigger).toBe("manual");
+    expect(c.customInstructions).toBe("keep the plan");
+  });
+
+  it("defaults the trigger to auto and tolerates a bad payload", () => {
+    expect(parseCompaction(event({ payload_json: "{}" })).trigger).toBe("auto");
+    expect(parseCompaction(event({ payload_json: "not json" })).trigger).toBe("auto");
+    expect(parseCompaction(event()).customInstructions).toBeNull();
+  });
+});
+
+describe("recentCompactions", () => {
+  let open: Database.Database | null = null;
+  afterEach(() => {
+    open?.close();
+    open = null;
+  });
+
+  it("returns only PreCompact events, newest first, parsed", () => {
+    const db = (open = new Database(":memory:"));
+    migrate(db);
+    const ins = db.prepare(
+      "INSERT INTO events (session_id, event_type, payload_json) VALUES (?, ?, ?)",
+    );
+    ins.run("s1", "PreCompact", '{"trigger":"auto"}');
+    ins.run("s1", "PostToolUse", "{}");
+    ins.run("s2", "PreCompact", '{"trigger":"manual"}');
+
+    const list = recentCompactions(db, 10);
+    expect(list).toHaveLength(2);
+    expect(list[0].trigger).toBe("manual"); // newest first
+    expect(list[1].trigger).toBe("auto");
+  });
+});

--- a/src/lib/compaction.ts
+++ b/src/lib/compaction.ts
@@ -1,0 +1,39 @@
+import type Database from "better-sqlite3";
+import type { EventRow } from "./types";
+
+// Context compaction. PreCompact hooks carry the trigger (auto|manual) and any
+// custom instructions, but not the context size, so that's what we surface. These
+// are already stored as events; this just makes them queryable for the timeline.
+export interface Compaction {
+  id: number;
+  session_id: string;
+  trigger: string;
+  customInstructions: string | null;
+  created_at: string;
+}
+
+export function parseCompaction(event: EventRow): Compaction {
+  let trigger = "auto";
+  let customInstructions: string | null = null;
+  try {
+    const p = JSON.parse(event.payload_json) as Record<string, unknown>;
+    if (typeof p.trigger === "string") trigger = p.trigger;
+    if (typeof p.custom_instructions === "string") customInstructions = p.custom_instructions;
+  } catch {
+    /* keep defaults */
+  }
+  return {
+    id: event.id,
+    session_id: event.session_id,
+    trigger,
+    customInstructions,
+    created_at: event.created_at,
+  };
+}
+
+export function recentCompactions(db: Database.Database, limit: number): Compaction[] {
+  const rows = db
+    .prepare(`SELECT * FROM events WHERE event_type = 'PreCompact' ORDER BY id DESC LIMIT ?`)
+    .all(limit) as EventRow[];
+  return rows.map(parseCompaction);
+}


### PR DESCRIPTION
## Summary

Roadmap **Run 22 — Compaction tracking.** `PreCompact` events are already stored; this makes them queryable for the timeline.

- **New `src/lib/compaction.ts`** — `parseCompaction(event)` extracts the `trigger` (auto|manual, default `auto`) and `custom_instructions` from the payload (tolerates bad JSON); `recentCompactions(db, limit)` returns parsed `PreCompact` events, newest first.
- **New `GET /api/compactions`** — recent compactions across sessions for the upcoming timeline widget.
- **Tests** (+3): parser (trigger + custom instructions, defaults/bad payload) and the query (only `PreCompact`, newest first).

Note: hook `PreCompact` payloads carry the trigger but **not** context size, so only the trigger is surfaced (honest to the available data). Feeds the compaction timeline (Run 53). 132 tests pass total.

## Test plan

- [x] `npm run lint` / `npm test` (132) / `npm run build` (`/api/compactions` registered)
- [ ] CI `verify` + `e2e` green

https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk)_