### PR TITLE
Run 23: Add an error feed and error-rate query

### DIFF
--- a/src/app/api/errors/route.ts
+++ b/src/app/api/errors/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from "next/server";
+import { db } from "@/lib/db";
+import { errorStats, recentErrors } from "@/lib/errors";
+import { log } from "@/lib/log";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+// Error rate + recent failures for the error-rate widget and the errors panel.
+export async function GET(req: Request) {
+  const url = new URL(req.url);
+  const limit = Math.min(Math.max(Math.trunc(Number(url.searchParams.get("limit")) || 50), 1), 500);
+  const since = url.searchParams.get("since"); // optional ISO timestamp
+  try {
+    return NextResponse.json({ stats: errorStats(db, since), recent: recentErrors(db, limit) });
+  } catch (err) {
+    log.error("/api/errors failed", err);
+    return NextResponse.json({ stats: { toolCalls: 0, failures: 0, errorRate: 0 }, recent: [] });
+  }
+}

--- a/src/lib/errors.test.ts
+++ b/src/lib/errors.test.ts
@@ -1,0 +1,59 @@
+import Database from "better-sqlite3";
+import { afterEach, describe, expect, it } from "vitest";
+import { errorStats, recentErrors } from "@/lib/errors";
+import { migrate } from "@/lib/migrations";
+
+let open: Database.Database | null = null;
+afterEach(() => {
+  open?.close();
+  open = null;
+});
+
+// Insert a tool call (+ its tool_io) with the given success/error.
+function call(db: Database.Database, tool: string, success: number, errorText: string | null) {
+  const id = Number(
+    db
+      .prepare("INSERT INTO tool_calls (session_id, tool_name, success) VALUES ('s', ?, ?)")
+      .run(tool, success).lastInsertRowid,
+  );
+  db.prepare(
+    "INSERT INTO tool_io (tool_call_id, is_error, error_text) VALUES (?, ?, ?)",
+  ).run(id, success === 0 ? 1 : 0, errorText);
+  return id;
+}
+
+function seeded(): Database.Database {
+  const db = (open = new Database(":memory:"));
+  migrate(db);
+  call(db, "Read", 1, null);
+  call(db, "Bash", 0, "command not found");
+  call(db, "Edit", 1, null);
+  call(db, "Bash", 0, "permission denied");
+  return db;
+}
+
+describe("errorStats", () => {
+  it("computes total, failures and rate", () => {
+    expect(errorStats(seeded())).toEqual({ toolCalls: 4, failures: 2, errorRate: 0.5 });
+  });
+
+  it("returns a zero rate with no tool calls", () => {
+    const db = (open = new Database(":memory:"));
+    migrate(db);
+    expect(errorStats(db)).toEqual({ toolCalls: 0, failures: 0, errorRate: 0 });
+  });
+});
+
+describe("recentErrors", () => {
+  it("returns only failures with their message, newest first", () => {
+    const list = recentErrors(seeded(), 10);
+    expect(list).toHaveLength(2);
+    expect(list[0].error_text).toBe("permission denied"); // newest first
+    expect(list[1].error_text).toBe("command not found");
+    expect(list.every((e) => e.tool_name === "Bash")).toBe(true);
+  });
+
+  it("respects the limit", () => {
+    expect(recentErrors(seeded(), 1)).toHaveLength(1);
+  });
+});

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -1,0 +1,48 @@
+import type Database from "better-sqlite3";
+
+// Error feed + rate, derived from the failure flags captured at ingest time
+// (tool_calls.success = 0, with the message in tool_io.error_text). Permission
+// denials surface here too: they arrive as error tool_responses, so is_error/
+// success already mark them. Powers the error-rate widget and the errors panel.
+
+export interface ErrorStats {
+  toolCalls: number;
+  failures: number;
+  errorRate: number; // 0..1
+}
+
+export interface ErrorItem {
+  id: number; // tool_call id
+  session_id: string;
+  tool_name: string;
+  target: string | null;
+  error_text: string | null;
+  created_at: string;
+}
+
+export function errorStats(db: Database.Database, sinceIso: string | null = null): ErrorStats {
+  const cond = sinceIso ? "created_at >= ?" : "1=1";
+  const args = sinceIso ? [sinceIso] : [];
+  const total = (
+    db.prepare(`SELECT COUNT(*) AS n FROM tool_calls WHERE ${cond}`).get(...args) as { n: number }
+  ).n;
+  const failures = (
+    db
+      .prepare(`SELECT COUNT(*) AS n FROM tool_calls WHERE success = 0 AND ${cond}`)
+      .get(...args) as { n: number }
+  ).n;
+  return { toolCalls: total, failures, errorRate: total ? failures / total : 0 };
+}
+
+export function recentErrors(db: Database.Database, limit: number): ErrorItem[] {
+  return db
+    .prepare(
+      `SELECT tc.id, tc.session_id, tc.tool_name, tc.target, tc.created_at, io.error_text
+       FROM tool_calls tc
+       LEFT JOIN tool_io io ON io.tool_call_id = tc.id
+       WHERE tc.success = 0
+       ORDER BY tc.id DESC
+       LIMIT ?`,
+    )
+    .all(limit) as ErrorItem[];
+}


### PR DESCRIPTION
## Summary

Roadmap **Run 23 — Errors & failures.** Surfaces failures already captured at ingest.

Tool failures are flagged at ingest (Run 16: `tool_calls.success = 0`, message in `tool_io.error_text`) — and **permission-denied** tool responses come through the same `is_error` path. This run adds the query layer:

- **New `src/lib/errors.ts`** — `errorStats(db, sinceIso?)` → `{ toolCalls, failures, errorRate }` (optional time filter); `recentErrors(db, limit)` → recent failed tool calls joined with `tool_io` for the message, newest first.
- **New `GET /api/errors`** — returns `{ stats, recent }` for the error-rate widget and the errors panel.
- **Tests** (+4): stats (total/failures/rate, zero case) and the feed (failures-only, message, newest-first, limit).

Powers the error-rate widget (Run 44) and the "what went wrong" panel (Run 60). 136 tests pass total.

## Test plan

- [x] `npm run lint` / `npm test` (136) / `npm run build` (`/api/errors` registered)
- [ ] CI `verify` + `e2e` green

https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk)_