### PR TITLE
Run 29: Add ccusage per-session report

### DIFF
--- a/src/app/api/usage/sessions/route.ts
+++ b/src/app/api/usage/sessions/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from "next/server";
+import { getSessionUsage } from "@/lib/ccusage";
+import { log } from "@/lib/log";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+// Per-session cost/tokens/models from ccusage.
+export async function GET() {
+  try {
+    return NextResponse.json(await getSessionUsage());
+  } catch (err) {
+    log.error("/api/usage/sessions failed", err);
+    return NextResponse.json({ sessions: [], available: false });
+  }
+}

--- a/src/lib/ccusage.test.ts
+++ b/src/lib/ccusage.test.ts
@@ -5,8 +5,10 @@ import {
   eurRate,
   mapBlockRows,
   mapDailyRows,
+  mapSessionRows,
   type CcusageBlock,
   type CcusageDaily,
+  type CcusageSession,
 } from "@/lib/ccusage";
 
 const NOW = Date.parse("2026-05-23T12:00:00Z");
@@ -135,6 +137,53 @@ describe("buildReport", () => {
       costUsd: 0,
       costEur: 0,
     });
+  });
+});
+
+describe("mapSessionRows", () => {
+  it("maps a session row and converts cost to EUR", () => {
+    const rows: CcusageSession[] = [
+      {
+        sessionId: "s1",
+        models: ["claude-opus-4-7"],
+        inputTokens: 100,
+        outputTokens: 50,
+        cacheCreationTokens: 10,
+        cacheReadTokens: 20,
+        totalTokens: 180,
+        totalCost: 4,
+        lastActivity: "2026-05-23",
+      },
+    ];
+    expect(mapSessionRows(rows, 0.5)).toEqual([
+      {
+        sessionId: "s1",
+        models: ["claude-opus-4-7"],
+        inputTokens: 100,
+        outputTokens: 50,
+        cacheTokens: 30,
+        totalTokens: 180,
+        costUsd: 4,
+        costEur: 2,
+        lastActivity: "2026-05-23",
+      },
+    ]);
+  });
+
+  it("falls back across field-name variants and defaults", () => {
+    const [s] = mapSessionRows([{ costUSD: 1, modelsUsed: ["m"] }], 1);
+    expect(s).toMatchObject({
+      sessionId: "",
+      models: ["m"],
+      costUsd: 1,
+      costEur: 1,
+      lastActivity: null,
+      cacheTokens: 0,
+    });
+  });
+
+  it("returns an empty array for no rows", () => {
+    expect(mapSessionRows([], 0.92)).toEqual([]);
   });
 });
 

--- a/src/lib/ccusage.ts
+++ b/src/lib/ccusage.ts
@@ -40,6 +40,19 @@ export interface UsageReport {
   available: boolean; // false when ccusage couldn't run (offline / no data)
 }
 
+// Per-conversation usage from `ccusage session`.
+export interface UsageSession {
+  sessionId: string;
+  models: string[];
+  inputTokens: number;
+  outputTokens: number;
+  cacheTokens: number;
+  totalTokens: number;
+  costUsd: number;
+  costEur: number;
+  lastActivity: string | null;
+}
+
 export interface CcusageDaily {
   period?: string;
   inputTokens?: number;
@@ -65,8 +78,23 @@ export interface CcusageBlock {
   };
 }
 
+export interface CcusageSession {
+  sessionId?: string;
+  models?: string[];
+  modelsUsed?: string[];
+  inputTokens?: number;
+  outputTokens?: number;
+  cacheCreationTokens?: number;
+  cacheReadTokens?: number;
+  totalTokens?: number;
+  totalCost?: number;
+  costUSD?: number;
+  lastActivity?: string;
+}
+
 const TTL_MS = 30_000;
 let cache: { at: number; report: UsageReport } | null = null;
+let sessionCache: { at: number; sessions: UsageSession[] } | null = null;
 
 export function eurRate(): number {
   const r = Number(process.env.EUR_PER_USD);
@@ -128,6 +156,25 @@ export function mapBlockRows(rows: CcusageBlock[], rate: number, now: number): U
     });
 }
 
+// Per-session rows from `ccusage session` (field names vary by version → defensive).
+export function mapSessionRows(rows: CcusageSession[], rate: number): UsageSession[] {
+  return rows.map((r) => {
+    const cacheTokens = (r.cacheCreationTokens ?? 0) + (r.cacheReadTokens ?? 0);
+    const costUsd = r.totalCost ?? r.costUSD ?? 0;
+    return {
+      sessionId: r.sessionId ?? "",
+      models: r.models ?? r.modelsUsed ?? [],
+      inputTokens: r.inputTokens ?? 0,
+      outputTokens: r.outputTokens ?? 0,
+      cacheTokens,
+      totalTokens: r.totalTokens ?? 0,
+      costUsd,
+      costEur: costUsd * rate,
+      lastActivity: r.lastActivity ?? null,
+    };
+  });
+}
+
 // Assemble the full report from already-parsed ccusage rows. `blocks === null`
 // means the blocks command was unavailable (best-effort) → empty blocks list.
 export function buildReport(
@@ -181,5 +228,31 @@ export async function getUsage(): Promise<UsageReport> {
     const report = empty();
     cache = { at: Date.now(), report };
     return report;
+  }
+}
+
+export interface SessionUsageReport {
+  sessions: UsageSession[];
+  available: boolean;
+}
+
+// Per-session cost/tokens/models from ccusage. Cached + degrades gracefully.
+export async function getSessionUsage(): Promise<SessionUsageReport> {
+  if (sessionCache && Date.now() - sessionCache.at < TTL_MS) {
+    return { sessions: sessionCache.sessions, available: true };
+  }
+  const rate = eurRate();
+  const bin = path.join(process.cwd(), "node_modules", ".bin", "ccusage");
+  try {
+    const { stdout } = await execFileAsync(bin, ["session", "--json"], {
+      timeout: 20_000,
+      maxBuffer: 16 * 1024 * 1024,
+    });
+    const parsed = JSON.parse(stdout) as { sessions?: CcusageSession[] };
+    const sessions = mapSessionRows(parsed.sessions ?? [], rate);
+    sessionCache = { at: Date.now(), sessions };
+    return { sessions, available: true };
+  } catch {
+    return { sessions: [], available: false };
   }
 }


### PR DESCRIPTION
## Summary

Roadmap **Run 29 — ccusage per-session report.** First run of Phase C (economics).

- **`src/lib/ccusage.ts`** — new `getSessionUsage()` runs `ccusage session --json` (cached with the existing TTL, degrades gracefully to `{ sessions: [], available: false }`), plus a pure `mapSessionRows(rows, rate)` mapper that's **defensive across ccusage field-name variants** (`models`/`modelsUsed`, `totalCost`/`costUSD`), sums cache tokens and converts to EUR. New `UsageSession` + `CcusageSession` types.
- **New `GET /api/usage/sessions`** — per-session cost/tokens/models.
- **Tests** (+3): mapper full-row mapping, field-name fallbacks + defaults, empty.

Feeds the per-card cost surfacing (Run 35) and cost reconciliation (Run 37). 163 tests pass total.

## Test plan

- [x] `npm run lint` / `npm test` (163) / `npm run build` (`/api/usage/sessions` registered)
- [ ] CI `verify` + `e2e` green

https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk)_