### PR TITLE
Run 30: Add per-model usage breakdown to the usage report

### DIFF
--- a/src/lib/ccusage.test.ts
+++ b/src/lib/ccusage.test.ts
@@ -5,6 +5,7 @@ import {
   eurRate,
   mapBlockRows,
   mapDailyRows,
+  mapModelBreakdown,
   mapSessionRows,
   type CcusageBlock,
   type CcusageDaily,
@@ -110,6 +111,7 @@ describe("buildReport", () => {
     expect(report.available).toBe(true);
     expect(report.days).toHaveLength(2);
     expect(report.blocks).toHaveLength(1);
+    expect(report.models).toEqual([]); // no modelBreakdowns in the fixture
     expect(report.totals).toMatchObject({
       inputTokens: 5,
       outputTokens: 10,
@@ -137,6 +139,42 @@ describe("buildReport", () => {
       costUsd: 0,
       costEur: 0,
     });
+  });
+});
+
+describe("mapModelBreakdown", () => {
+  it("aggregates per-model breakdowns across days, sorted by cost", () => {
+    const daily: CcusageDaily[] = [
+      {
+        period: "d1",
+        modelBreakdowns: [
+          { modelName: "opus", inputTokens: 100, outputTokens: 10, cost: 5 },
+          { modelName: "sonnet", inputTokens: 50, outputTokens: 5, cost: 1 },
+        ],
+      },
+      {
+        period: "d2",
+        modelBreakdowns: [
+          { modelName: "opus", inputTokens: 200, cacheReadTokens: 40, cost: 3 },
+        ],
+      },
+    ];
+    const models = mapModelBreakdown(daily, 0.5);
+    expect(models.map((m) => m.model)).toEqual(["opus", "sonnet"]); // opus first (higher cost)
+    const opus = models[0];
+    expect(opus.inputTokens).toBe(300);
+    expect(opus.outputTokens).toBe(10);
+    expect(opus.cacheTokens).toBe(40);
+    expect(opus.totalTokens).toBe(350);
+    expect(opus.costUsd).toBe(8);
+    expect(opus.costEur).toBe(4);
+  });
+
+  it("falls back to `model` field and tolerates missing breakdowns", () => {
+    expect(mapModelBreakdown([{ period: "d" }], 1)).toEqual([]);
+    expect(mapModelBreakdown([{ modelBreakdowns: [{ model: "x", totalCost: 2 }] }], 1)[0]).toMatchObject(
+      { model: "x", costUsd: 2 },
+    );
   });
 });
 

--- a/src/lib/ccusage.ts
+++ b/src/lib/ccusage.ts
@@ -26,9 +26,21 @@ export interface UsageBlock {
   costEur: number;
 }
 
+// Aggregated usage for one model across the reporting window.
+export interface UsageModel {
+  model: string;
+  inputTokens: number;
+  outputTokens: number;
+  cacheTokens: number;
+  totalTokens: number;
+  costUsd: number;
+  costEur: number;
+}
+
 export interface UsageReport {
   days: UsageDay[];
   blocks: UsageBlock[]; // last 24h, 5h buckets
+  models: UsageModel[]; // per-model totals (from --breakdown)
   totals: {
     inputTokens: number;
     outputTokens: number;
@@ -53,6 +65,17 @@ export interface UsageSession {
   lastActivity: string | null;
 }
 
+export interface CcusageModelBreakdown {
+  modelName?: string;
+  model?: string;
+  inputTokens?: number;
+  outputTokens?: number;
+  cacheCreationTokens?: number;
+  cacheReadTokens?: number;
+  cost?: number;
+  totalCost?: number;
+}
+
 export interface CcusageDaily {
   period?: string;
   inputTokens?: number;
@@ -61,6 +84,7 @@ export interface CcusageDaily {
   cacheReadTokens?: number;
   totalTokens?: number;
   totalCost?: number;
+  modelBreakdowns?: CcusageModelBreakdown[];
 }
 
 export interface CcusageBlock {
@@ -105,6 +129,7 @@ export function empty(): UsageReport {
   return {
     days: [],
     blocks: [],
+    models: [],
     totals: { inputTokens: 0, outputTokens: 0, cacheTokens: 0, totalTokens: 0, costUsd: 0, costEur: 0 },
     available: false,
   };
@@ -126,6 +151,35 @@ export function mapDailyRows(rows: CcusageDaily[], rate: number): UsageDay[] {
       costEur: costUsd * rate,
     };
   });
+}
+
+// Aggregate the per-day model breakdowns into per-model totals, sorted by cost.
+export function mapModelBreakdown(daily: CcusageDaily[], rate: number): UsageModel[] {
+  const byModel = new Map<string, UsageModel>();
+  for (const d of daily) {
+    for (const b of d.modelBreakdowns ?? []) {
+      const model = b.modelName ?? b.model ?? "unknown";
+      const m =
+        byModel.get(model) ??
+        ({
+          model,
+          inputTokens: 0,
+          outputTokens: 0,
+          cacheTokens: 0,
+          totalTokens: 0,
+          costUsd: 0,
+          costEur: 0,
+        } satisfies UsageModel);
+      m.inputTokens += b.inputTokens ?? 0;
+      m.outputTokens += b.outputTokens ?? 0;
+      m.cacheTokens += (b.cacheCreationTokens ?? 0) + (b.cacheReadTokens ?? 0);
+      m.costUsd += b.cost ?? b.totalCost ?? 0;
+      m.totalTokens = m.inputTokens + m.outputTokens + m.cacheTokens;
+      m.costEur = m.costUsd * rate;
+      byModel.set(model, m);
+    }
+  }
+  return [...byModel.values()].sort((a, b) => b.costUsd - a.costUsd);
 }
 
 // Keep only non-gap blocks whose end falls within the 24h before `now`.
@@ -196,7 +250,13 @@ export function buildReport(
     },
     { inputTokens: 0, outputTokens: 0, cacheTokens: 0, totalTokens: 0, costUsd: 0, costEur: 0 },
   );
-  return { days, blocks: blocks ? mapBlockRows(blocks, rate, now) : [], totals, available: true };
+  return {
+    days,
+    blocks: blocks ? mapBlockRows(blocks, rate, now) : [],
+    models: mapModelBreakdown(daily, rate),
+    totals,
+    available: true,
+  };
 }
 
 export async function getUsage(): Promise<UsageReport> {
@@ -204,13 +264,13 @@ export async function getUsage(): Promise<UsageReport> {
 
   const rate = eurRate();
   const bin = path.join(process.cwd(), "node_modules", ".bin", "ccusage");
-  const run = (cmd: string) =>
-    execFileAsync(bin, [cmd, "--json"], { timeout: 20_000, maxBuffer: 16 * 1024 * 1024 });
+  const run = (cmd: string, ...args: string[]) =>
+    execFileAsync(bin, [cmd, "--json", ...args], { timeout: 20_000, maxBuffer: 16 * 1024 * 1024 });
 
   try {
-    // Daily (multi-day chart) + blocks (last-24h view) in parallel. Blocks are
-    // best-effort — a failure there still yields the daily report.
-    const [dailyRes, blocksRes] = await Promise.allSettled([run("daily"), run("blocks")]);
+    // Daily (multi-day chart, with per-model breakdown) + blocks (last-24h view)
+    // in parallel. Blocks are best-effort — a failure still yields the daily report.
+    const [dailyRes, blocksRes] = await Promise.allSettled([run("daily", "--breakdown"), run("blocks")]);
 
     if (dailyRes.status !== "fulfilled") throw new Error("ccusage daily failed");
 

--- a/src/lib/demo.ts
+++ b/src/lib/demo.ts
@@ -322,7 +322,20 @@ export function demoUsage() {
     },
     { inputTokens: 0, outputTokens: 0, cacheTokens: 0, totalTokens: 0, costUsd: 0, costEur: 0 },
   );
-  return { days, blocks, totals, available: true };
+  const models = [
+    { model: "claude-opus-4-7", share: 0.7 },
+    { model: "claude-sonnet-4-6", share: 0.3 },
+  ].map((m) => ({
+    model: m.model,
+    inputTokens: Math.round(totals.inputTokens * m.share),
+    outputTokens: Math.round(totals.outputTokens * m.share),
+    cacheTokens: Math.round(totals.cacheTokens * m.share),
+    totalTokens: Math.round(totals.totalTokens * m.share),
+    costUsd: +(totals.costUsd * m.share).toFixed(2),
+    costEur: +(totals.costEur * m.share).toFixed(2),
+  }));
+
+  return { days, blocks, models, totals, available: true };
 }
 
 export function demoSubscribe(fn: (m: StreamMessage) => void) {


### PR DESCRIPTION
## Summary

Roadmap **Run 30 — Per-model breakdown.**

- **`ccusage.ts`** — `getUsage` now runs `ccusage daily --breakdown`. New pure `mapModelBreakdown(daily, rate)` aggregates the per-day `modelBreakdowns` into **per-model totals**, sorted by cost, defensive across field variants (`modelName`/`model`, `cost`/`totalCost`).
- **`UsageReport`** gains a `models: UsageModel[]` field, so **`/api/usage`** now returns per-model token/cost splits. `empty()` and the demo backend provide it too (the demo splits totals across opus/sonnet so the donut has data).
- **Tests** (+2): aggregation across days + sort-by-cost + cache summation + EUR; `model` fallback and missing-breakdowns; plus a `buildReport` `models` assertion.

Feeds the model-usage donut (Run 45). 165 tests pass total.

## Test plan

- [x] `npm run lint` / `npm test` (165) / `npm run build`
- [ ] CI `verify` + `e2e` green

https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk)_