### PR TITLE
Run 32: Surface active-block burn rate and projection

### DIFF
--- a/src/lib/ccusage.test.ts
+++ b/src/lib/ccusage.test.ts
@@ -3,6 +3,7 @@ import {
   buildReport,
   empty,
   eurRate,
+  extractBurn,
   mapBlockRows,
   mapDailyRows,
   mapModelBreakdown,
@@ -103,6 +104,41 @@ describe("mapBlockRows", () => {
   });
 });
 
+describe("extractBurn", () => {
+  it("reads burn rate + projection from the active block", () => {
+    const blocks: CcusageBlock[] = [
+      { startTime: "2026-05-23T08:00:00Z" },
+      {
+        startTime: "2026-05-23T11:00:00Z",
+        isActive: true,
+        burnRate: { tokensPerMinute: 1200, costPerHour: 6 },
+        projection: { totalCost: 10, remainingMinutes: 90 },
+      },
+    ];
+    expect(extractBurn(blocks, 0.5)).toEqual({
+      tokensPerMinute: 1200,
+      costPerHour: 6,
+      projectedCostUsd: 10,
+      projectedCostEur: 5,
+      remainingMinutes: 90,
+    });
+  });
+
+  it("returns null when there is no active block", () => {
+    expect(extractBurn([{ startTime: "x" }], 1)).toBeNull();
+  });
+
+  it("defaults missing burn fields to zero", () => {
+    expect(extractBurn([{ startTime: "x", isActive: true }], 1)).toEqual({
+      tokensPerMinute: 0,
+      costPerHour: 0,
+      projectedCostUsd: 0,
+      projectedCostEur: 0,
+      remainingMinutes: 0,
+    });
+  });
+});
+
 describe("buildReport", () => {
   it("sums totals across days and includes mapped blocks", () => {
     const daily: CcusageDaily[] = [
@@ -117,6 +153,7 @@ describe("buildReport", () => {
     expect(report.blocks).toHaveLength(1);
     expect(report.models).toEqual([]); // no modelBreakdowns in the fixture
     expect(report.months).toEqual([]); // no monthly rows passed
+    expect(report.burn).toBeNull(); // no active block in the fixture
     expect(report.totals).toMatchObject({
       inputTokens: 5,
       outputTokens: 10,

--- a/src/lib/ccusage.ts
+++ b/src/lib/ccusage.ts
@@ -37,10 +37,20 @@ export interface UsageModel {
   costEur: number;
 }
 
+// Live spend rate + projection for the active 5-hour block.
+export interface BurnInfo {
+  tokensPerMinute: number;
+  costPerHour: number;
+  projectedCostUsd: number;
+  projectedCostEur: number;
+  remainingMinutes: number;
+}
+
 export interface UsageReport {
   days: UsageDay[];
   months: UsageDay[]; // monthly aggregates (same shape; date = "YYYY-MM")
   blocks: UsageBlock[]; // last 24h, 5h buckets
+  burn: BurnInfo | null; // active-block burn rate / projection
   models: UsageModel[]; // per-model totals (from --breakdown)
   totals: {
     inputTokens: number;
@@ -102,6 +112,8 @@ export interface CcusageBlock {
     cacheCreationInputTokens?: number;
     cacheReadInputTokens?: number;
   };
+  burnRate?: { tokensPerMinute?: number; costPerHour?: number } | null;
+  projection?: { totalTokens?: number; totalCost?: number; remainingMinutes?: number } | null;
 }
 
 export interface CcusageSession {
@@ -132,6 +144,7 @@ export function empty(): UsageReport {
     days: [],
     months: [],
     blocks: [],
+    burn: null,
     models: [],
     totals: { inputTokens: 0, outputTokens: 0, cacheTokens: 0, totalTokens: 0, costUsd: 0, costEur: 0 },
     available: false,
@@ -213,6 +226,22 @@ export function mapBlockRows(rows: CcusageBlock[], rate: number, now: number): U
     });
 }
 
+// Live burn rate + projection from the active (non-gap) block, if any.
+export function extractBurn(blocks: CcusageBlock[], rate: number): BurnInfo | null {
+  const active = blocks.find((b) => b.isActive && !b.isGap);
+  if (!active) return null;
+  const br = active.burnRate ?? {};
+  const pj = active.projection ?? {};
+  const projectedCostUsd = pj.totalCost ?? 0;
+  return {
+    tokensPerMinute: br.tokensPerMinute ?? 0,
+    costPerHour: br.costPerHour ?? 0,
+    projectedCostUsd,
+    projectedCostEur: projectedCostUsd * rate,
+    remainingMinutes: pj.remainingMinutes ?? 0,
+  };
+}
+
 // Per-session rows from `ccusage session` (field names vary by version → defensive).
 export function mapSessionRows(rows: CcusageSession[], rate: number): UsageSession[] {
   return rows.map((r) => {
@@ -258,6 +287,7 @@ export function buildReport(
     days,
     months: mapDailyRows(monthly, rate),
     blocks: blocks ? mapBlockRows(blocks, rate, now) : [],
+    burn: blocks ? extractBurn(blocks, rate) : null,
     models: mapModelBreakdown(daily, rate),
     totals,
     available: true,

--- a/src/lib/demo.ts
+++ b/src/lib/demo.ts
@@ -341,7 +341,15 @@ export function demoUsage() {
     return { ...base, date: `${m.getFullYear()}-${String(m.getMonth() + 1).padStart(2, "0")}` };
   });
 
-  return { days, months, blocks, models, totals, available: true };
+  const burn = {
+    tokensPerMinute: 1800,
+    costPerHour: 4.5,
+    projectedCostUsd: 9,
+    projectedCostEur: +(9 * rate).toFixed(2),
+    remainingMinutes: 95,
+  };
+
+  return { days, months, blocks, burn, models, totals, available: true };
 }
 
 export function demoSubscribe(fn: (m: StreamMessage) => void) {


### PR DESCRIPTION
## Summary

Roadmap **Run 32 — Burn rate & projection** (data layer; the gauge consumes it in Run 34).

- **`ccusage.ts`** — `CcusageBlock` gains optional `burnRate` + `projection`. New pure `extractBurn(blocks, rate)` reads the **active (non-gap) block's** burn rate (tokens/min, cost/hour) and projection (projected cost USD/EUR, remaining minutes), defensive against missing fields → `null` when no active block.
- **`UsageReport.burn`** (`BurnInfo | null`) is populated by `buildReport`, so **`/api/usage`** now exposes it. `empty()` and the demo provide it.
- **Tests** (+3): active block → values, no active block → null, missing fields → zeros; plus a `buildReport` burn assertion.

Feeds the budget gauge (Run 34) and budget alerts (Run 87). 170 tests pass total.

## Test plan

- [x] `npm run lint` / `npm test` (170) / `npm run build`
- [ ] CI `verify` + `e2e` green

https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk)_