### PR TITLE
Run 33: Add budget configuration and usage computation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,4 +27,7 @@ MC_HOOK_TOKEN=
 # Database snapshots: how many to keep and where. Defaults: 14, ./backups
 # MC_BACKUP_KEEP=14
 # MC_BACKUP_DIR=./backups
+# Spend budgets in USD (drives the budget gauge + alerts). Unset = no budget.
+# MC_BUDGET_DAILY=10
+# MC_BUDGET_MONTHLY=200
 

--- a/src/app/api/budget/route.ts
+++ b/src/app/api/budget/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from "next/server";
+import { db } from "@/lib/db";
+import { getUsage } from "@/lib/ccusage";
+import { computeBudget, getBudgets } from "@/lib/budget";
+import { log } from "@/lib/log";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+// Daily/monthly budget limits and how much of each is used so far.
+export async function GET() {
+  try {
+    const report = await getUsage();
+    const budgets = getBudgets(db);
+    return NextResponse.json({ budgets, status: computeBudget(report, budgets) });
+  } catch (err) {
+    log.error("/api/budget failed", err);
+    const empty = { budgetUsd: null, spentUsd: 0, pct: null };
+    return NextResponse.json({
+      budgets: { dailyUsd: null, monthlyUsd: null },
+      status: { daily: empty, monthly: empty },
+    });
+  }
+}

--- a/src/lib/budget.test.ts
+++ b/src/lib/budget.test.ts
@@ -1,0 +1,75 @@
+import Database from "better-sqlite3";
+import { afterEach, describe, expect, it } from "vitest";
+import { computeBudget, getBudgets } from "@/lib/budget";
+import { setConfig } from "@/lib/config";
+import { migrate } from "@/lib/migrations";
+import type { UsageReport } from "@/lib/ccusage";
+
+const ENV = { ...process.env };
+let open: Database.Database | null = null;
+afterEach(() => {
+  open?.close();
+  open = null;
+  process.env = { ...ENV };
+});
+
+function report(over: Partial<UsageReport> = {}): UsageReport {
+  return {
+    days: [],
+    months: [],
+    blocks: [],
+    burn: null,
+    models: [],
+    totals: { inputTokens: 0, outputTokens: 0, cacheTokens: 0, totalTokens: 0, costUsd: 0, costEur: 0 },
+    available: true,
+    ...over,
+  };
+}
+
+const day = (date: string, costUsd: number) => ({
+  date,
+  inputTokens: 0,
+  outputTokens: 0,
+  cacheTokens: 0,
+  totalTokens: 0,
+  costUsd,
+  costEur: 0,
+});
+
+describe("getBudgets", () => {
+  it("reads from env and prefers config when set", () => {
+    const db = (open = new Database(":memory:"));
+    migrate(db);
+    process.env.MC_BUDGET_DAILY = "5";
+    process.env.MC_BUDGET_MONTHLY = "100";
+    expect(getBudgets(db)).toEqual({ dailyUsd: 5, monthlyUsd: 100 });
+
+    setConfig(db, "budget.daily", "8");
+    expect(getBudgets(db).dailyUsd).toBe(8); // config overrides env
+  });
+
+  it("treats unset/invalid values as null", () => {
+    const db = (open = new Database(":memory:"));
+    migrate(db);
+    delete process.env.MC_BUDGET_DAILY;
+    process.env.MC_BUDGET_MONTHLY = "-5";
+    expect(getBudgets(db)).toEqual({ dailyUsd: null, monthlyUsd: null });
+  });
+});
+
+describe("computeBudget", () => {
+  const now = new Date("2026-05-23T12:00:00Z");
+
+  it("computes % used from today's and this month's spend", () => {
+    const r = report({ days: [day("2026-05-23", 2)], months: [day("2026-05", 40)] });
+    const status = computeBudget(r, { dailyUsd: 5, monthlyUsd: 100 }, now);
+    expect(status.daily).toEqual({ budgetUsd: 5, spentUsd: 2, pct: 0.4 });
+    expect(status.monthly).toEqual({ budgetUsd: 100, spentUsd: 40, pct: 0.4 });
+  });
+
+  it("reports null pct when no budget is set and zero spend when no rows", () => {
+    const status = computeBudget(report(), { dailyUsd: null, monthlyUsd: null }, now);
+    expect(status.daily).toEqual({ budgetUsd: null, spentUsd: 0, pct: null });
+    expect(status.monthly).toEqual({ budgetUsd: null, spentUsd: 0, pct: null });
+  });
+});

--- a/src/lib/budget.ts
+++ b/src/lib/budget.ts
@@ -1,0 +1,57 @@
+import type Database from "better-sqlite3";
+import type { UsageReport } from "./ccusage";
+import { getConfig } from "./config";
+
+// Spend budgets in USD (ccusage reports USD; the UI converts to EUR for display).
+// Configured via the config table (budget.daily / budget.monthly), falling back to
+// MC_BUDGET_DAILY / MC_BUDGET_MONTHLY.
+export interface Budgets {
+  dailyUsd: number | null;
+  monthlyUsd: number | null;
+}
+
+export interface BudgetUsage {
+  budgetUsd: number | null;
+  spentUsd: number;
+  pct: number | null; // 0..1, null when no budget set
+}
+
+export interface BudgetStatus {
+  daily: BudgetUsage;
+  monthly: BudgetUsage;
+}
+
+function positive(s: string | null | undefined): number | null {
+  if (s == null) return null;
+  const n = Number(s);
+  return Number.isFinite(n) && n > 0 ? n : null;
+}
+
+export function getBudgets(db: Database.Database): Budgets {
+  return {
+    dailyUsd: positive(getConfig(db, "budget.daily") ?? process.env.MC_BUDGET_DAILY),
+    monthlyUsd: positive(getConfig(db, "budget.monthly") ?? process.env.MC_BUDGET_MONTHLY),
+  };
+}
+
+const usage = (spentUsd: number, budgetUsd: number | null): BudgetUsage => ({
+  budgetUsd,
+  spentUsd,
+  pct: budgetUsd && budgetUsd > 0 ? spentUsd / budgetUsd : null,
+});
+
+// % of budget used = today's spend vs daily budget, this month's vs monthly.
+export function computeBudget(
+  report: UsageReport,
+  budgets: Budgets,
+  now: Date = new Date(),
+): BudgetStatus {
+  const today = now.toISOString().slice(0, 10);
+  const month = now.toISOString().slice(0, 7);
+  const todaySpent = report.days.find((d) => d.date === today)?.costUsd ?? 0;
+  const monthSpent = report.months.find((m) => m.date === month)?.costUsd ?? 0;
+  return {
+    daily: usage(todaySpent, budgets.dailyUsd),
+    monthly: usage(monthSpent, budgets.monthlyUsd),
+  };
+}

--- a/src/lib/config.test.ts
+++ b/src/lib/config.test.ts
@@ -1,0 +1,27 @@
+import Database from "better-sqlite3";
+import { afterEach, describe, expect, it } from "vitest";
+import { getConfig, setConfig } from "@/lib/config";
+import { migrate } from "@/lib/migrations";
+
+let open: Database.Database | null = null;
+afterEach(() => {
+  open?.close();
+  open = null;
+});
+
+describe("config", () => {
+  it("returns null for an unset key", () => {
+    const db = (open = new Database(":memory:"));
+    migrate(db);
+    expect(getConfig(db, "nope")).toBeNull();
+  });
+
+  it("sets and upserts a value", () => {
+    const db = (open = new Database(":memory:"));
+    migrate(db);
+    setConfig(db, "budget.daily", "5");
+    expect(getConfig(db, "budget.daily")).toBe("5");
+    setConfig(db, "budget.daily", "10");
+    expect(getConfig(db, "budget.daily")).toBe("10");
+  });
+});

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,0 +1,17 @@
+import type Database from "better-sqlite3";
+
+// Generic key/value app config (e.g. budget limits). Plugin settings live in their
+// own table later; this is for first-class app settings.
+export function getConfig(db: Database.Database, key: string): string | null {
+  const row = db.prepare(`SELECT value FROM config WHERE key = ?`).get(key) as
+    | { value: string }
+    | undefined;
+  return row ? row.value : null;
+}
+
+export function setConfig(db: Database.Database, key: string, value: string): void {
+  db.prepare(
+    `INSERT INTO config (key, value) VALUES (?, ?)
+     ON CONFLICT(key) DO UPDATE SET value = excluded.value`,
+  ).run(key, value);
+}

--- a/src/lib/migrations-sql.mjs
+++ b/src/lib/migrations-sql.mjs
@@ -136,4 +136,12 @@ export const MIGRATIONS = [
     PRIMARY KEY (bucket, event_type)
   );
   `,
+
+  // v11 — generic app config (key/value), e.g. budget limits.
+  `
+  CREATE TABLE IF NOT EXISTS config (
+    key   TEXT PRIMARY KEY,
+    value TEXT
+  );
+  `,
 ];

--- a/src/lib/migrations.test.ts
+++ b/src/lib/migrations.test.ts
@@ -31,6 +31,7 @@ describe("migrate", () => {
         "prompts",
         "file_edits",
         "activity_buckets",
+        "config",
       ]),
     );
   });


### PR DESCRIPTION
## Summary

Roadmap **Run 33 — Budget configuration.**

- **Migration v11** — a generic `config` key/value table, with `getConfig`/`setConfig` (`src/lib/config.ts`).
- **New `src/lib/budget.ts`** — `getBudgets(db)` reads daily/monthly **USD** limits from config (`budget.daily`/`budget.monthly`), falling back to `MC_BUDGET_DAILY`/`MC_BUDGET_MONTHLY`; `computeBudget(report, budgets, now)` derives **% used** from today's spend (vs daily) and this month's spend (vs monthly) in the usage report (`pct = null` when no budget).
- **New `GET /api/budget`** — `{ budgets, status }`.
- **`.env.example`** documents the budget env vars.
- **Tests** (+6): config get/set/upsert; `getBudgets` env + config-override + invalid→null; `computeBudget` %-used + null-budget/zero-spend.

Feeds the budget gauge (Run 34) and cost alerts (Run 87). 176 tests pass total.

## Test plan

- [x] `npm run lint` / `npm test` (176) / `npm run build` (`/api/budget` registered)
- [ ] CI `verify` + `e2e` green

https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk)_