### PR TITLE
Run 34: Add budget gauge widget

### DIFF
--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -43,8 +43,8 @@ test("dashboard renders all four widgets and connects", async ({ page }) => {
 
   await expect(page.getByRole("heading", { name: "Claude Mission Control" })).toBeVisible();
 
-  // Four widget panels are rendered (kanban, live-stream, token-chart, tool-graph).
-  await expect(page.locator("section")).toHaveCount(4);
+  // Five widget panels (kanban, live-stream, token-chart, tool-graph, budget-gauge).
+  await expect(page.locator("section")).toHaveCount(5);
   // Two titles are identical in both locales — safe to assert regardless of language.
   await expect(page.getByText("Sessions", { exact: true })).toBeVisible();
   await expect(page.getByText("Live Stream", { exact: true })).toBeVisible();

--- a/src/lib/demo.ts
+++ b/src/lib/demo.ts
@@ -352,6 +352,21 @@ export function demoUsage() {
   return { days, months, blocks, burn, models, totals, available: true };
 }
 
+export function demoBudget() {
+  const u = demoUsage();
+  const today = new Date().toISOString().slice(0, 10);
+  const month = new Date().toISOString().slice(0, 7);
+  const dSpent = u.days.find((d) => d.date === today)?.costUsd ?? 0;
+  const mSpent = u.months.find((m) => m.date === month)?.costUsd ?? 0;
+  const dailyUsd = 15;
+  const monthlyUsd = 300;
+  const gauge = (spentUsd: number, budgetUsd: number) => ({ budgetUsd, spentUsd, pct: spentUsd / budgetUsd });
+  return {
+    budgets: { dailyUsd, monthlyUsd },
+    status: { daily: gauge(dSpent, dailyUsd), monthly: gauge(mSpent, monthlyUsd) },
+  };
+}
+
 export function demoSubscribe(fn: (m: StreamMessage) => void) {
   listeners.add(fn);
   return () => listeners.delete(fn);
@@ -378,6 +393,7 @@ export function installDemoBackend() {
     if (path.endsWith("/api/sessions")) return json({ sessions: demoSessions() });
     if (path.endsWith("/api/graph")) return json(demoGraph());
     if (path.endsWith("/api/usage")) return json(demoUsage());
+    if (path.endsWith("/api/budget")) return json(demoBudget());
     if (path.includes("/api/events")) {
       const u = new URL(raw, window.location.href);
       const limit = Number(u.searchParams.get("limit")) || 100;

--- a/src/lib/i18n.tsx
+++ b/src/lib/i18n.tsx
@@ -133,6 +133,12 @@ const DE: Record<string, string> = {
   "tokens.output": "Output",
   "tokens.cache": "Cache",
 
+  "budget.title": "Budget",
+  "budget.info": "Heutige & monatliche Ausgaben gegen dein Budget (USD), mit Hochrechnung.",
+  "budget.daily": "Heute",
+  "budget.monthly": "Dieser Monat",
+  "budget.projected": "Hochrechnung",
+  "budget.none": "Kein Budget gesetzt.",
   "graph.title": "Tool-Graph (3D)",
   "graph.info":
     "Beziehungen Session → Tool → Ziel (Datei, Befehl, URL, Muster). Gleiche Ziele über Sessions hinweg teilen sich einen Knoten. Aktive Sessions leuchten. Knoten anklicken für Details, Vollbild oben rechts.",
@@ -271,6 +277,12 @@ const EN: Record<string, string> = {
   "tokens.output": "Output",
   "tokens.cache": "Cache",
 
+  "budget.title": "Budget",
+  "budget.info": "Today's & this month's spend against your budget (USD), with a projection.",
+  "budget.daily": "Today",
+  "budget.monthly": "This month",
+  "budget.projected": "Projected",
+  "budget.none": "No budget set.",
   "graph.title": "Tool Graph (3D)",
   "graph.info":
     "Relationships session → tool → target (file, command, URL, pattern). Equal targets across sessions share a node. Active sessions glow. Click a node for details; fullscreen top-right.",

--- a/src/plugins/budget-gauge/widget.tsx
+++ b/src/plugins/budget-gauge/widget.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Wallet } from "lucide-react";
+import { Panel } from "@/components/panel";
+import { WidgetState } from "@/components/widget-state";
+import { useT } from "@/lib/i18n";
+import { formatMoney } from "@/lib/format";
+
+interface BudgetUsage {
+  budgetUsd: number | null;
+  spentUsd: number;
+  pct: number | null;
+}
+interface BudgetResponse {
+  budgets: { dailyUsd: number | null; monthlyUsd: number | null };
+  status: { daily: BudgetUsage; monthly: BudgetUsage };
+}
+
+// Linear projection of the period's spend from how much of it has elapsed.
+function project(usage: BudgetUsage, period: "day" | "month"): number | null {
+  if (usage.budgetUsd == null || usage.spentUsd <= 0) return null;
+  const now = new Date();
+  let fraction: number;
+  if (period === "day") {
+    fraction = (now.getHours() + now.getMinutes() / 60) / 24;
+  } else {
+    const daysInMonth = new Date(now.getFullYear(), now.getMonth() + 1, 0).getDate();
+    fraction = (now.getDate() - 1 + now.getHours() / 24) / daysInMonth;
+  }
+  return fraction > 0 ? usage.spentUsd / fraction : null;
+}
+
+export function BudgetGauge() {
+  const { t } = useT();
+  const [data, setData] = useState<BudgetResponse | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = () =>
+      fetch("/api/budget")
+        .then((r) => r.json())
+        .then((d: BudgetResponse) => {
+          if (!cancelled) setData(d);
+        })
+        .catch(() => {});
+    load();
+    const poll = setInterval(load, 30_000);
+    return () => {
+      cancelled = true;
+      clearInterval(poll);
+    };
+  }, []);
+
+  const hasBudget = !!(data && (data.status.daily.budgetUsd || data.status.monthly.budgetUsd));
+
+  return (
+    <Panel title={t("budget.title")} icon={<Wallet className="h-4 w-4 text-accent" />} info={t("budget.info")}>
+      {!data ? (
+        <WidgetState icon={Wallet} title={t("common.loading")} loading />
+      ) : !hasBudget ? (
+        <WidgetState
+          icon={Wallet}
+          title={t("budget.none")}
+          description={<code className="text-accent">MC_BUDGET_DAILY</code>}
+        />
+      ) : (
+        <div className="flex h-full flex-col justify-center gap-6 p-5">
+          <Gauge label={t("budget.daily")} usage={data.status.daily} projected={project(data.status.daily, "day")} />
+          <Gauge
+            label={t("budget.monthly")}
+            usage={data.status.monthly}
+            projected={project(data.status.monthly, "month")}
+          />
+        </div>
+      )}
+    </Panel>
+  );
+}
+
+function Gauge({
+  label,
+  usage,
+  projected,
+}: {
+  label: string;
+  usage: BudgetUsage;
+  projected: number | null;
+}) {
+  const { t } = useT();
+  if (usage.budgetUsd == null) return null;
+  const pct = usage.pct ?? 0;
+  const color = pct >= 1 ? "bg-red-500" : pct >= 0.75 ? "bg-amber-500" : "bg-emerald-500";
+  const projectedOver = projected != null && projected > usage.budgetUsd;
+
+  return (
+    <div>
+      <div className="mb-1 flex items-center justify-between text-xs">
+        <span className="font-semibold text-foreground">{label}</span>
+        <span className="tabular-nums text-muted">
+          {formatMoney(usage.spentUsd, "USD")} / {formatMoney(usage.budgetUsd, "USD")} ·{" "}
+          {Math.round(pct * 100)}%
+        </span>
+      </div>
+      <div className="h-2.5 w-full overflow-hidden rounded-full bg-background/70">
+        <div
+          className={`h-full rounded-full ${color} transition-all duration-500`}
+          style={{ width: `${Math.min(pct, 1) * 100}%` }}
+        />
+      </div>
+      {projected != null && (
+        <p className={`mt-1 text-[11px] ${projectedOver ? "text-red-400" : "text-muted"}`}>
+          {t("budget.projected")}: {formatMoney(projected, "USD")}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -3,6 +3,7 @@ import { LiveStream } from "./live-stream/widget";
 import { Kanban } from "./kanban/widget";
 import { TokenChart } from "./token-chart/widget";
 import { ToolGraph } from "./tool-graph/widget";
+import { BudgetGauge } from "./budget-gauge/widget";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // PLUGIN REGISTRY
@@ -52,5 +53,12 @@ export const widgets: Widget[] = [
     span: "lg:col-span-3",
     height: "h-[360px] min-[2560px]:h-[480px] min-[3840px]:h-[660px]",
     component: ToolGraph,
+  },
+  {
+    id: "budget-gauge",
+    title: "Budget",
+    span: "lg:col-span-2",
+    height: "h-[360px] min-[2560px]:h-[480px] min-[3840px]:h-[660px]",
+    component: BudgetGauge,
   },
 ];


### PR DESCRIPTION
## Summary

Roadmap **Run 34 — Budget gauge widget** (first new visualization).

- **New `budget-gauge` plugin** — two colored progress bars (Today / This month) showing **spend vs budget** (green/amber/red by % used) plus a **linear end-of-period projection** (turns red when the projected spend would exceed the budget). Fetches `/api/budget` (polls 30s).
- **States** — loading spinner; a clear "no budget set" hint pointing at `MC_BUDGET_DAILY` when none is configured (e.g. CI/no ccusage).
- **Registered** in the dashboard grid (`lg:col-span-2`), wired into the **demo backend** (`/api/budget` → `demoBudget()`), with de/en strings.
- **E2E** updated: now asserts **5** widgets render.

**Verified**: lint, 176 unit tests, build, and the E2E smoke (2 passed — the gauge renders as the 5th widget).

## Test plan

- [x] `npm run lint` / `npm test` (176) / `npm run build` / `npm run test:e2e` (2 passed, 5 widgets)
- [ ] CI `verify` + `e2e` green

https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk)_