### PR TITLE
Run 36: Add per-project usage aggregation

### DIFF
--- a/src/app/api/usage/projects/route.ts
+++ b/src/app/api/usage/projects/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from "next/server";
+import { db } from "@/lib/db";
+import { projectUsage } from "@/lib/projects";
+import { log } from "@/lib/log";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+// Cost/tokens/sessions aggregated by project.
+export async function GET(req: Request) {
+  const url = new URL(req.url);
+  const limit = Math.min(Math.max(Math.trunc(Number(url.searchParams.get("limit")) || 100), 1), 500);
+  try {
+    return NextResponse.json({ projects: projectUsage(db, limit) });
+  } catch (err) {
+    log.error("/api/usage/projects failed", err);
+    return NextResponse.json({ projects: [] });
+  }
+}

--- a/src/lib/projects.test.ts
+++ b/src/lib/projects.test.ts
@@ -1,0 +1,46 @@
+import Database from "better-sqlite3";
+import { afterEach, describe, expect, it } from "vitest";
+import { migrate } from "@/lib/migrations";
+import { projectUsage } from "@/lib/projects";
+
+let open: Database.Database | null = null;
+afterEach(() => {
+  open?.close();
+  open = null;
+});
+
+function seed(): Database.Database {
+  const db = (open = new Database(":memory:"));
+  migrate(db);
+  const ins = db.prepare(
+    `INSERT INTO sessions (id, project_name, cost_usd, token_input, token_output, token_cache)
+     VALUES (?, ?, ?, ?, ?, ?)`,
+  );
+  ins.run("a1", "A", 3, 100, 10, 0);
+  ins.run("a2", "A", 2, 100, 10, 0);
+  ins.run("b1", "B", 8, 50, 5, 5);
+  ins.run("u1", null, 0, 0, 0, 0);
+  return db;
+}
+
+describe("projectUsage", () => {
+  it("aggregates cost/tokens/sessions per project, sorted by cost", () => {
+    const rows = projectUsage(seed());
+    expect(rows.map((r) => r.project)).toEqual(["B", "A", "(unknown)"]);
+
+    const a = rows.find((r) => r.project === "A")!;
+    expect(a.sessions).toBe(2);
+    expect(a.costUsd).toBe(5);
+    expect(a.tokenInput).toBe(200);
+    expect(a.totalTokens).toBe(220); // 200 + 20 + 0
+  });
+
+  it("groups null/empty project names under (unknown)", () => {
+    const rows = projectUsage(seed());
+    expect(rows.find((r) => r.project === "(unknown)")!.sessions).toBe(1);
+  });
+
+  it("respects the limit", () => {
+    expect(projectUsage(seed(), 1)).toHaveLength(1);
+  });
+});

--- a/src/lib/projects.ts
+++ b/src/lib/projects.ts
@@ -1,0 +1,33 @@
+import type Database from "better-sqlite3";
+
+// Per-project rollup over the sessions table (cost, tokens, session count).
+export interface ProjectUsage {
+  project: string;
+  sessions: number;
+  costUsd: number;
+  tokenInput: number;
+  tokenOutput: number;
+  tokenCache: number;
+  totalTokens: number;
+}
+
+export function projectUsage(db: Database.Database, limit = 100): ProjectUsage[] {
+  const rows = db
+    .prepare(
+      `SELECT COALESCE(NULLIF(project_name, ''), '(unknown)') AS project,
+              COUNT(*)            AS sessions,
+              SUM(cost_usd)       AS costUsd,
+              SUM(token_input)    AS tokenInput,
+              SUM(token_output)   AS tokenOutput,
+              SUM(token_cache)    AS tokenCache
+       FROM sessions
+       GROUP BY project
+       ORDER BY costUsd DESC, sessions DESC
+       LIMIT ?`,
+    )
+    .all(limit) as Omit<ProjectUsage, "totalTokens">[];
+  return rows.map((r) => ({
+    ...r,
+    totalTokens: r.tokenInput + r.tokenOutput + r.tokenCache,
+  }));
+}


### PR DESCRIPTION
## Summary

Roadmap **Run 36 — Per-project cost aggregation.**

- **New `src/lib/projects.ts`** — `projectUsage(db, limit)` groups the `sessions` table by `project_name` (null/empty → `"(unknown)"`), summing cost, tokens (input/output/cache + total) and session count, sorted by cost.
- **New `GET /api/usage/projects`** — exposes the rollup.
- **Tests** (+3): aggregation + sort-by-cost, `(unknown)` grouping, limit.

Feeds the project leaderboard (Run 47). 179 tests pass total.

## Test plan

- [x] `npm run lint` / `npm test` (179) / `npm run build` (`/api/usage/projects` registered)
- [ ] CI `verify` + `e2e` green

https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk)_