### PR TITLE
Run 37: Reconcile per-session cost against ccusage

### DIFF
--- a/src/app/api/usage/reconcile/route.ts
+++ b/src/app/api/usage/reconcile/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from "next/server";
+import { db } from "@/lib/db";
+import { getSessionUsage } from "@/lib/ccusage";
+import { reconcileSessions } from "@/lib/reconcile";
+import { log } from "@/lib/log";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+// Per-session cost reconciled against ccusage (preferred when available), with the
+// transcript estimate and the discrepancy alongside.
+export async function GET() {
+  try {
+    const sessions = db
+      .prepare(`SELECT id, cost_usd FROM sessions ORDER BY datetime(last_seen) DESC LIMIT 500`)
+      .all() as { id: string; cost_usd: number }[];
+    const usage = await getSessionUsage();
+    return NextResponse.json({
+      sessions: reconcileSessions(sessions, usage.sessions),
+      ccusageAvailable: usage.available,
+    });
+  } catch (err) {
+    log.error("/api/usage/reconcile failed", err);
+    return NextResponse.json({ sessions: [], ccusageAvailable: false });
+  }
+}

--- a/src/lib/reconcile.test.ts
+++ b/src/lib/reconcile.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { reconcileSession, reconcileSessions } from "@/lib/reconcile";
+import type { UsageSession } from "@/lib/ccusage";
+
+const ccSession = (sessionId: string, costUsd: number): UsageSession => ({
+  sessionId,
+  models: [],
+  inputTokens: 0,
+  outputTokens: 0,
+  cacheTokens: 0,
+  totalTokens: 0,
+  costUsd,
+  costEur: 0,
+  lastActivity: null,
+});
+
+describe("reconcileSession", () => {
+  it("prefers ccusage and reports the discrepancy", () => {
+    expect(reconcileSession("s1", 0.8, 1.0)).toEqual({
+      sessionId: "s1",
+      transcriptUsd: 0.8,
+      ccusageUsd: 1.0,
+      costUsd: 1.0,
+      source: "ccusage",
+      discrepancyUsd: expect.closeTo(0.2, 5),
+    });
+  });
+
+  it("falls back to the transcript estimate when ccusage is absent", () => {
+    expect(reconcileSession("s1", 0.8, null)).toEqual({
+      sessionId: "s1",
+      transcriptUsd: 0.8,
+      ccusageUsd: null,
+      costUsd: 0.8,
+      source: "transcript",
+      discrepancyUsd: null,
+    });
+  });
+});
+
+describe("reconcileSessions", () => {
+  it("joins sessions to ccusage by id", () => {
+    const sessions = [
+      { id: "s1", cost_usd: 0.8 },
+      { id: "s2", cost_usd: 0.5 },
+    ];
+    const result = reconcileSessions(sessions, [ccSession("s1", 1.0)]);
+    expect(result[0]).toMatchObject({ source: "ccusage", costUsd: 1.0 });
+    expect(result[1]).toMatchObject({ source: "transcript", costUsd: 0.5, ccusageUsd: null });
+  });
+});

--- a/src/lib/reconcile.ts
+++ b/src/lib/reconcile.ts
@@ -1,0 +1,50 @@
+import type { UsageSession } from "./ccusage";
+
+// Reconcile the transcript-derived per-session cost (a local estimate) against
+// ccusage's authoritative per-session cost: prefer ccusage when present, and
+// surface the discrepancy so the estimate can be sanity-checked.
+export type CostSource = "ccusage" | "transcript";
+
+export interface SessionCost {
+  sessionId: string;
+  transcriptUsd: number;
+  ccusageUsd: number | null;
+  costUsd: number; // preferred figure
+  source: CostSource;
+  discrepancyUsd: number | null; // ccusage - transcript, null when ccusage absent
+}
+
+export function reconcileSession(
+  sessionId: string,
+  transcriptUsd: number,
+  ccusageUsd: number | null,
+): SessionCost {
+  if (ccusageUsd != null) {
+    return {
+      sessionId,
+      transcriptUsd,
+      ccusageUsd,
+      costUsd: ccusageUsd,
+      source: "ccusage",
+      discrepancyUsd: ccusageUsd - transcriptUsd,
+    };
+  }
+  return {
+    sessionId,
+    transcriptUsd,
+    ccusageUsd: null,
+    costUsd: transcriptUsd,
+    source: "transcript",
+    discrepancyUsd: null,
+  };
+}
+
+export function reconcileSessions(
+  sessions: { id: string; cost_usd: number }[],
+  ccusage: UsageSession[],
+): SessionCost[] {
+  const byId = new Map(ccusage.map((s) => [s.sessionId, s.costUsd]));
+  return sessions.map((s) =>
+    reconcileSession(s.id, s.cost_usd, byId.has(s.id) ? (byId.get(s.id) as number) : null),
+  );
+}


### PR DESCRIPTION
## Summary

Roadmap **Run 37 — Cost reconciliation** (last run of Phase C).

- **New `src/lib/reconcile.ts`** — `reconcileSession(id, transcriptUsd, ccusageUsd)` **prefers ccusage** when present (else the transcript estimate) and reports the **discrepancy** (`ccusage − transcript`, `null` when absent). `reconcileSessions` joins DB sessions to the ccusage session report by id.
- **New `GET /api/usage/reconcile`** — returns the reconciled per-session costs (`transcriptUsd`, `ccusageUsd`, preferred `costUsd`, `source`, `discrepancyUsd`) + `ccusageAvailable`.
- **Tests** (+3): prefer-ccusage + discrepancy, transcript fallback, join-by-id.

Makes the displayed cost trustworthy (the transcript figure is an estimate; ccusage is authoritative). 182 tests pass total.

## Phase C complete
Runs 29–37: per-session report, per-model breakdown, monthly view, burn rate, budget config + gauge, per-card cost, per-project cost, and reconciliation.

## Test plan

- [x] `npm run lint` / `npm test` (182) / `npm run build` (`/api/usage/reconcile` registered)
- [ ] CI `verify` + `e2e` green

https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk)_