### PR TITLE
Run 41: Add file-hotspots treemap widget

### DIFF
--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -43,8 +43,8 @@ test("dashboard renders all four widgets and connects", async ({ page }) => {
 
   await expect(page.getByRole("heading", { name: "Claude Mission Control" })).toBeVisible();
 
-  // Seven widget panels (kanban, live-stream, token-chart, tool-graph, budget-gauge, heatmap, tool-frequency).
-  await expect(page.locator("section")).toHaveCount(7);
+  // Eight widget panels (+ file-hotspots).
+  await expect(page.locator("section")).toHaveCount(8);
   // Two titles are identical in both locales — safe to assert regardless of language.
   await expect(page.getByText("Sessions", { exact: true })).toBeVisible();
   await expect(page.getByText("Live Stream", { exact: true })).toBeVisible();

--- a/src/app/api/files/route.ts
+++ b/src/app/api/files/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from "next/server";
+import { db } from "@/lib/db";
+import { fileHotspots } from "@/lib/files";
+import { log } from "@/lib/log";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+// Most-touched files, optionally within the last ?days=N (0/absent = all time).
+export async function GET(req: Request) {
+  const url = new URL(req.url);
+  const limit = Math.min(Math.max(Math.trunc(Number(url.searchParams.get("limit")) || 40), 1), 200);
+  const days = Math.trunc(Number(url.searchParams.get("days")) || 0);
+  const sinceIso =
+    days > 0 ? new Date(Date.now() - days * 86_400_000).toISOString().replace("T", " ").slice(0, 19) : null;
+  try {
+    return NextResponse.json({ files: fileHotspots(db, limit, sinceIso) });
+  } catch (err) {
+    log.error("/api/files failed", err);
+    return NextResponse.json({ files: [] });
+  }
+}

--- a/src/lib/demo.ts
+++ b/src/lib/demo.ts
@@ -421,6 +421,30 @@ export function demoTools() {
   return { tools };
 }
 
+export function demoFiles() {
+  const raw: [string, number, number, number][] = [
+    ["src/lib/ingest.ts", 14, 320, 180],
+    ["src/components/dashboard.tsx", 9, 210, 90],
+    ["src/lib/ccusage.ts", 7, 160, 60],
+    ["src/plugins/tool-graph/widget.tsx", 6, 140, 70],
+    ["src/app/api/ingest/route.ts", 5, 80, 30],
+    ["README.md", 4, 60, 20],
+    ["src/lib/types.ts", 4, 50, 10],
+    ["src/lib/db.ts", 3, 40, 25],
+    ["package.json", 3, 20, 8],
+    ["src/lib/format.ts", 2, 30, 12],
+  ];
+  const files = raw.map(([path, edits, added, removed]) => ({
+    path,
+    name: path.split("/").pop() ?? path,
+    edits,
+    added,
+    removed,
+    churn: added + removed,
+  }));
+  return { files };
+}
+
 export function demoSubscribe(fn: (m: StreamMessage) => void) {
   listeners.add(fn);
   return () => listeners.delete(fn);
@@ -451,6 +475,7 @@ export function installDemoBackend() {
     if (path.endsWith("/api/stats")) return json(demoStats());
     if (path.endsWith("/api/activity")) return json(demoActivity());
     if (path.endsWith("/api/tools")) return json(demoTools());
+    if (path.endsWith("/api/files")) return json(demoFiles());
     if (path.includes("/api/events")) {
       const u = new URL(raw, window.location.href);
       const limit = Number(u.searchParams.get("limit")) || 100;

--- a/src/lib/files.test.ts
+++ b/src/lib/files.test.ts
@@ -1,0 +1,47 @@
+import Database from "better-sqlite3";
+import { afterEach, describe, expect, it } from "vitest";
+import { fileHotspots } from "@/lib/files";
+import { migrate } from "@/lib/migrations";
+
+let open: Database.Database | null = null;
+afterEach(() => {
+  open?.close();
+  open = null;
+});
+
+function seed(): Database.Database {
+  const db = (open = new Database(":memory:"));
+  migrate(db);
+  const ins = db.prepare(
+    `INSERT INTO file_edits (session_id, path, added, removed, created_at) VALUES ('s', ?, ?, ?, ?)`,
+  );
+  ins.run("/a/big.ts", 100, 50, "2026-05-23 10:00:00");
+  ins.run("/a/big.ts", 20, 10, "2026-05-23 11:00:00");
+  ins.run("/a/small.ts", 5, 1, "2026-05-23 10:00:00");
+  ins.run("/a/old.ts", 200, 0, "2026-05-01 10:00:00");
+  return db;
+}
+
+describe("fileHotspots", () => {
+  it("aggregates churn per path, sorted by churn, with name + counts", () => {
+    const rows = fileHotspots(seed());
+    expect(rows.map((r) => r.path)).toEqual(["/a/old.ts", "/a/big.ts", "/a/small.ts"]);
+    const big = rows.find((r) => r.path === "/a/big.ts")!;
+    expect(big.edits).toBe(2);
+    expect(big.added).toBe(120);
+    expect(big.removed).toBe(60);
+    expect(big.churn).toBe(180);
+    expect(big.name).toBe("big.ts");
+  });
+
+  it("filters by the since window", () => {
+    const rows = fileHotspots(seed(), 40, "2026-05-23 00:00:00");
+    // old.ts (May 1) is excluded -> big.ts is the top hotspot.
+    expect(rows[0].path).toBe("/a/big.ts");
+    expect(rows.some((r) => r.path === "/a/old.ts")).toBe(false);
+  });
+
+  it("respects the limit", () => {
+    expect(fileHotspots(seed(), 1)).toHaveLength(1);
+  });
+});

--- a/src/lib/files.ts
+++ b/src/lib/files.ts
@@ -1,0 +1,39 @@
+import type Database from "better-sqlite3";
+
+// Most-touched files (hotspots) from file_edits: edit count + line churn. Treemap
+// data — size by churn, color by churn.
+export interface FileHotspot {
+  path: string;
+  name: string; // last path segment
+  edits: number;
+  added: number;
+  removed: number;
+  churn: number; // added + removed
+}
+
+export function fileHotspots(
+  db: Database.Database,
+  limit = 40,
+  sinceIso: string | null = null,
+): FileHotspot[] {
+  const cond = sinceIso ? "WHERE created_at >= ?" : "";
+  const params = sinceIso ? [sinceIso, limit] : [limit];
+  const rows = db
+    .prepare(
+      `SELECT path,
+              COUNT(*)     AS edits,
+              SUM(added)   AS added,
+              SUM(removed) AS removed
+       FROM file_edits
+       ${cond}
+       GROUP BY path
+       ORDER BY SUM(added) + SUM(removed) DESC, edits DESC
+       LIMIT ?`,
+    )
+    .all(...params) as { path: string; edits: number; added: number; removed: number }[];
+  return rows.map((r) => ({
+    ...r,
+    name: r.path.split("/").filter(Boolean).pop() ?? r.path,
+    churn: r.added + r.removed,
+  }));
+}

--- a/src/lib/i18n.tsx
+++ b/src/lib/i18n.tsx
@@ -98,6 +98,10 @@ const DE: Record<string, string> = {
   "tools.range7d": "7T",
   "tools.range30d": "30T",
   "tools.rangeAll": "Alle",
+  "files.title": "Datei-Hotspots",
+  "files.info": "Meistbearbeitete Dateien (Fläche & Farbe = geänderte Zeilen) im Zeitraum.",
+  "files.empty": "Noch keine Datei-Änderungen.",
+  "files.edits": "Bearbeitungen",
 
   "search.label": "Sessions und Events durchsuchen",
   "search.placeholder": "Suchen…",
@@ -259,6 +263,10 @@ const EN: Record<string, string> = {
   "tools.range7d": "7d",
   "tools.range30d": "30d",
   "tools.rangeAll": "All",
+  "files.title": "File hotspots",
+  "files.info": "Most-edited files (area & color = changed lines) in the range.",
+  "files.empty": "No file changes yet.",
+  "files.edits": "edits",
 
   "search.label": "Search sessions and events",
   "search.placeholder": "Search…",

--- a/src/plugins/file-hotspots/widget.tsx
+++ b/src/plugins/file-hotspots/widget.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { ResponsiveContainer, Tooltip, Treemap } from "recharts";
+import { FileCode2 } from "lucide-react";
+import { Panel } from "@/components/panel";
+import { WidgetState } from "@/components/widget-state";
+import { useLive } from "@/components/live-provider";
+import { useT } from "@/lib/i18n";
+import type { FileHotspot } from "@/lib/files";
+
+type Range = "7" | "30" | "0";
+const RANGES: Range[] = ["7", "30", "0"];
+const RANGE_LABEL: Record<Range, string> = {
+  "7": "tools.range7d",
+  "30": "tools.range30d",
+  "0": "tools.rangeAll",
+};
+
+function clip(s: string, n: number): string {
+  return s.length > n ? s.slice(0, n - 1) + "…" : s;
+}
+
+function FileCell({
+  x = 0,
+  y = 0,
+  width = 0,
+  height = 0,
+  name = "",
+  value = 0,
+  max = 1,
+}: {
+  x?: number;
+  y?: number;
+  width?: number;
+  height?: number;
+  name?: string;
+  value?: number;
+  max?: number;
+}) {
+  const intensity = max > 0 ? value / max : 0;
+  const fill = `rgba(79,140,255,${0.22 + 0.68 * intensity})`;
+  const showLabel = width > 56 && height > 18;
+  return (
+    <g>
+      <rect x={x} y={y} width={width} height={height} fill={fill} stroke="#0e1219" strokeWidth={1} rx={2} />
+      {showLabel && (
+        <text x={x + 5} y={y + 14} fill="#e5e7eb" fontSize={11}>
+          {clip(name, Math.max(3, Math.floor(width / 7)))}
+        </text>
+      )}
+      {showLabel && height > 32 && (
+        <text x={x + 5} y={y + 28} fill="#aab3c5" fontSize={10}>
+          {value}
+        </text>
+      )}
+    </g>
+  );
+}
+
+function HotspotTooltip({
+  active,
+  payload,
+}: {
+  active?: boolean;
+  payload?: { payload: FileHotspot }[];
+}) {
+  const { t } = useT();
+  if (!active || !payload?.length) return null;
+  const d = payload[0].payload;
+  return (
+    <div className="rounded-md border border-panel-border bg-[#0e1219] px-2.5 py-1.5 text-xs shadow-lg">
+      <div className="max-w-xs truncate font-mono text-foreground">{d.path}</div>
+      <div className="text-muted">
+        {d.edits}× {t("files.edits")} · <span className="text-emerald-400">+{d.added}</span>{" "}
+        <span className="text-red-400">−{d.removed}</span>
+      </div>
+    </div>
+  );
+}
+
+export function FileHotspots() {
+  const { t } = useT();
+  const { tick } = useLive();
+  const [range, setRange] = useState<Range>("30");
+  const [files, setFiles] = useState<FileHotspot[] | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = () =>
+      fetch(`/api/files?days=${range}&limit=60`)
+        .then((r) => r.json())
+        .then((d: { files: FileHotspot[] }) => {
+          if (!cancelled) setFiles(d.files);
+        })
+        .catch(() => {});
+    load();
+    const poll = setInterval(load, 30_000);
+    return () => {
+      cancelled = true;
+      clearInterval(poll);
+    };
+  }, [range, tick]);
+
+  const data = useMemo(() => (files ?? []).map((f) => ({ ...f, size: Math.max(1, f.churn) })), [files]);
+  const max = useMemo(() => Math.max(1, ...data.map((d) => d.size)), [data]);
+
+  return (
+    <Panel
+      title={t("files.title")}
+      icon={<FileCode2 className="h-4 w-4 text-accent" />}
+      info={t("files.info")}
+      right={
+        <div className="flex rounded-md border border-panel-border text-xs">
+          {RANGES.map((r) => (
+            <button
+              key={r}
+              onClick={() => setRange(r)}
+              className={`px-2 py-1 ${range === r ? "bg-accent/20 text-accent" : "text-muted hover:text-foreground"}`}
+            >
+              {t(RANGE_LABEL[r])}
+            </button>
+          ))}
+        </div>
+      }
+    >
+      {!files ? (
+        <WidgetState icon={FileCode2} title={t("common.loading")} loading />
+      ) : data.length === 0 ? (
+        <WidgetState icon={FileCode2} title={t("files.empty")} />
+      ) : (
+        <div className="h-full w-full p-2">
+          <ResponsiveContainer width="100%" height="100%">
+            <Treemap data={data} dataKey="size" stroke="#0e1219" content={<FileCell max={max} />}>
+              <Tooltip content={<HotspotTooltip />} />
+            </Treemap>
+          </ResponsiveContainer>
+        </div>
+      )}
+    </Panel>
+  );
+}

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -7,6 +7,7 @@ import { BudgetGauge } from "./budget-gauge/widget";
 import { KpiBar } from "./kpi-bar/widget";
 import { Heatmap } from "./heatmap/widget";
 import { ToolFrequency } from "./tool-frequency/widget";
+import { FileHotspots } from "./file-hotspots/widget";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // PLUGIN REGISTRY
@@ -84,5 +85,12 @@ export const widgets: Widget[] = [
     span: "lg:col-span-2",
     height: "h-[360px] min-[2560px]:h-[480px] min-[3840px]:h-[660px]",
     component: ToolFrequency,
+  },
+  {
+    id: "file-hotspots",
+    title: "Datei-Hotspots",
+    span: "lg:col-span-3",
+    height: "h-[360px] min-[2560px]:h-[480px] min-[3840px]:h-[660px]",
+    component: FileHotspots,
   },
 ];


### PR DESCRIPTION
## Summary

Roadmap **Run 41 — File-hotspots treemap** (Phase D).

Here a treemap *is* the right tool — part-of-whole churn across many files; design pass confirmed squarified layout, single-hue color intensity, and smart labels only on large cells ([treemap best practices](https://www.juiceanalytics.com/writing/10-lessons-treemap-design)), via recharts' built-in `<Treemap>` ([custom content](https://recharts.github.io/en-US/examples/CustomContentTreemap/)).

- **New `file-hotspots` widget** — a recharts **Treemap** of the most-touched files from `file_edits`, **sized & colored by line churn** (single-hue blue ramp), **smart labels** only on large cells, a custom tooltip (path · edits · +added/−removed), the built-in **grow animation**, and a **7d/30d/all** range toggle.
- **New `src/lib/files.ts`** — `fileHotspots(db, limit, sinceIso)` (`GROUP BY path`: edits, added, removed, churn, name; optional window).
- **New `GET /api/files`**; wired into the **demo**; de/en strings.
- **E2E** updated: now asserts **8** widget sections.
- **Tests** (+3): churn aggregation + sort + name/counts, since-window, limit.

**Verified**: lint, 195 unit tests, build, E2E (2 passed, 8 widgets).

## Test plan
- [x] `npm run lint` / `npm test` (195) / `npm run build` / `npm run test:e2e` (2 passed)
- [ ] CI `verify` + `e2e` green

https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk)_