### PR TITLE
Run 45: Add model-usage donut widget

### DIFF
--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -43,8 +43,8 @@ test("dashboard renders all four widgets and connects", async ({ page }) => {
 
   await expect(page.getByRole("heading", { name: "Claude Mission Control" })).toBeVisible();
 
-  // Eleven widget panels (+ error-rate).
-  await expect(page.locator("section")).toHaveCount(11);
+  // Twelve widget panels (+ model-donut).
+  await expect(page.locator("section")).toHaveCount(12);
   // Two titles are identical in both locales — safe to assert regardless of language.
   await expect(page.getByText("Sessions", { exact: true })).toBeVisible();
   await expect(page.getByText("Live Stream", { exact: true })).toBeVisible();

--- a/src/lib/i18n.tsx
+++ b/src/lib/i18n.tsx
@@ -117,6 +117,11 @@ const DE: Record<string, string> = {
   "errors.failures": "Fehler",
   "errors.topTools": "Fehleranfälligste Tools",
   "errors.none": "Keine Fehler im Zeitraum. 🎉",
+  "donut.title": "Modelle",
+  "donut.info": "Anteil pro Modell an Tokens bzw. Kosten.",
+  "donut.empty": "Noch keine Modelldaten.",
+  "donut.total": "gesamt",
+  "donut.other": "Andere",
 
   "search.label": "Sessions und Events durchsuchen",
   "search.placeholder": "Suchen…",
@@ -297,6 +302,11 @@ const EN: Record<string, string> = {
   "errors.failures": "failed",
   "errors.topTools": "Most failure-prone tools",
   "errors.none": "No errors in range. 🎉",
+  "donut.title": "Models",
+  "donut.info": "Share per model of tokens or cost.",
+  "donut.empty": "No model data yet.",
+  "donut.total": "total",
+  "donut.other": "Other",
 
   "search.label": "Search sessions and events",
   "search.placeholder": "Search…",

--- a/src/lib/model-usage.test.ts
+++ b/src/lib/model-usage.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { modelShare, OTHER, shortModel } from "@/lib/model-usage";
+import type { UsageModel } from "@/lib/ccusage";
+
+function model(name: string, costUsd: number, totalTokens: number): UsageModel {
+  return {
+    model: name,
+    inputTokens: 0,
+    outputTokens: 0,
+    cacheTokens: 0,
+    totalTokens,
+    costUsd,
+    costEur: 0,
+  };
+}
+
+describe("shortModel", () => {
+  it("strips the claude- prefix", () => {
+    expect(shortModel("claude-opus-4-7")).toBe("opus-4-7");
+    expect(shortModel("gpt-x")).toBe("gpt-x");
+  });
+});
+
+describe("modelShare", () => {
+  it("computes value/pct per model by mode, sorted, filtering zeros", () => {
+    const models = [model("claude-opus-4-7", 8, 100), model("claude-sonnet-4-6", 2, 300), model("z", 0, 0)];
+    const { slices, total } = modelShare(models, "cost");
+    expect(total).toBe(10);
+    expect(slices.map((s) => s.name)).toEqual(["opus-4-7", "sonnet-4-6"]); // sorted by cost, zero filtered
+    expect(slices[0].pct).toBeCloseTo(0.8, 5);
+  });
+
+  it("ranks by tokens in tokens mode", () => {
+    const models = [model("claude-opus-4-7", 8, 100), model("claude-sonnet-4-6", 2, 300)];
+    expect(modelShare(models, "tokens").slices[0].name).toBe("sonnet-4-6");
+  });
+
+  it("groups beyond the max into Other", () => {
+    const models = Array.from({ length: 8 }, (_, i) => model(`m${i}`, 8 - i, 0));
+    const { slices } = modelShare(models, "cost", 6);
+    expect(slices).toHaveLength(6);
+    const other = slices[slices.length - 1];
+    expect(other.full).toBe(OTHER);
+    expect(other.value).toBe(3 + 2 + 1); // m5+m6+m7 costs
+  });
+
+  it("returns no slices for empty input", () => {
+    expect(modelShare([], "cost")).toEqual({ slices: [], total: 0 });
+  });
+});

--- a/src/lib/model-usage.ts
+++ b/src/lib/model-usage.ts
@@ -1,0 +1,42 @@
+import type { UsageModel } from "./ccusage";
+
+// Donut slices for per-model token/cost share. Keeps the top models and groups the
+// rest into "Other" (donuts read best with <= ~6 slices).
+export const OTHER = "__other__";
+
+export interface ModelSlice {
+  name: string; // shortened model id (or OTHER)
+  full: string; // original model id (or OTHER)
+  value: number;
+  pct: number; // 0..1
+}
+
+export function shortModel(model: string): string {
+  return model.replace(/^claude-/, "") || model;
+}
+
+export function modelShare(
+  models: UsageModel[],
+  mode: "cost" | "tokens",
+  max = 6,
+): { slices: ModelSlice[]; total: number } {
+  const vals = models
+    .map((m) => ({ full: m.model, value: mode === "cost" ? m.costUsd : m.totalTokens }))
+    .filter((v) => v.value > 0)
+    .sort((a, b) => b.value - a.value);
+  const total = vals.reduce((a, v) => a + v.value, 0);
+
+  let top = vals;
+  if (vals.length > max) {
+    const rest = vals.slice(max - 1).reduce((a, v) => a + v.value, 0);
+    top = [...vals.slice(0, max - 1), { full: OTHER, value: rest }];
+  }
+
+  const slices = top.map((v) => ({
+    name: v.full === OTHER ? OTHER : shortModel(v.full),
+    full: v.full,
+    value: v.value,
+    pct: total ? v.value / total : 0,
+  }));
+  return { slices, total };
+}

--- a/src/plugins/model-donut/widget.tsx
+++ b/src/plugins/model-donut/widget.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Cell, Pie, PieChart, ResponsiveContainer, Tooltip } from "recharts";
+import { PieChart as PieIcon } from "lucide-react";
+import { Panel } from "@/components/panel";
+import { WidgetState } from "@/components/widget-state";
+import { useT } from "@/lib/i18n";
+import { formatCompact, formatMoney } from "@/lib/format";
+import { modelShare, OTHER, type ModelSlice } from "@/lib/model-usage";
+import type { UsageReport } from "@/lib/ccusage";
+
+type Mode = "cost" | "tokens";
+
+// Wong color-blind-safe palette; "Other" is neutral grey.
+const PALETTE = ["#0072B2", "#E69F00", "#009E73", "#CC79A7", "#56B4E9", "#D55E00"];
+const OTHER_COLOR = "#6b7280";
+
+const colorFor = (s: ModelSlice, i: number) => (s.full === OTHER ? OTHER_COLOR : PALETTE[i % PALETTE.length]);
+
+export function ModelDonut() {
+  const { t } = useT();
+  const [usage, setUsage] = useState<UsageReport | null>(null);
+  const [mode, setMode] = useState<Mode>("cost");
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = () =>
+      fetch("/api/usage")
+        .then((r) => r.json())
+        .then((d: UsageReport) => {
+          if (!cancelled) setUsage(d);
+        })
+        .catch(() => {});
+    load();
+    const poll = setInterval(load, 30_000);
+    return () => {
+      cancelled = true;
+      clearInterval(poll);
+    };
+  }, []);
+
+  const { slices, total } = modelShare(usage?.models ?? [], mode);
+  const fmt = (n: number) => (mode === "cost" ? formatMoney(n, "EUR") : formatCompact(n));
+  const label = (s: ModelSlice) => (s.full === OTHER ? t("donut.other") : s.name);
+
+  return (
+    <Panel
+      title={t("donut.title")}
+      icon={<PieIcon className="h-4 w-4 text-accent" />}
+      info={t("donut.info")}
+      right={
+        <div className="flex rounded-md border border-panel-border text-xs">
+          {(["tokens", "cost"] as Mode[]).map((m) => (
+            <button
+              key={m}
+              onClick={() => setMode(m)}
+              className={`px-2 py-1 ${mode === m ? "bg-accent/20 text-accent" : "text-muted hover:text-foreground"}`}
+            >
+              {m === "tokens" ? t("tokens.modeTokens") : t("tokens.modeCost")}
+            </button>
+          ))}
+        </div>
+      }
+    >
+      {!usage ? (
+        <WidgetState icon={PieIcon} title={t("common.loading")} loading />
+      ) : slices.length === 0 ? (
+        <WidgetState icon={PieIcon} title={t("donut.empty")} />
+      ) : (
+        <div className="flex h-full items-center gap-2 p-3">
+          <div className="relative h-full w-1/2 min-w-0">
+            <ResponsiveContainer width="100%" height="100%">
+              <PieChart>
+                <Pie
+                  data={slices}
+                  dataKey="value"
+                  nameKey="name"
+                  innerRadius="62%"
+                  outerRadius="88%"
+                  paddingAngle={2}
+                  stroke="none"
+                >
+                  {slices.map((s, i) => (
+                    <Cell key={s.full} fill={colorFor(s, i)} />
+                  ))}
+                </Pie>
+                <Tooltip
+                  contentStyle={{ background: "#0e1219", border: "1px solid #1c2230", borderRadius: 8, fontSize: 12 }}
+                  formatter={(value, _name, item) => {
+                    const slice = ((item as { payload?: ModelSlice })?.payload ?? slices[0]) as ModelSlice;
+                    return [
+                      `${fmt(Number(value))} · ${Math.round((slice?.pct ?? 0) * 100)}%`,
+                      label(slice),
+                    ];
+                  }}
+                />
+              </PieChart>
+            </ResponsiveContainer>
+            <div className="pointer-events-none absolute inset-0 flex flex-col items-center justify-center">
+              <span className="font-mono text-sm font-semibold tabular-nums text-foreground">{fmt(total)}</span>
+              <span className="text-[10px] text-muted">{t("donut.total")}</span>
+            </div>
+          </div>
+
+          <ul className="flex min-w-0 flex-1 flex-col justify-center gap-1.5 overflow-auto text-xs">
+            {slices.map((s, i) => (
+              <li key={s.full} className="flex items-center justify-between gap-2">
+                <span className="flex min-w-0 items-center gap-1.5">
+                  <span className="h-2.5 w-2.5 shrink-0 rounded-sm" style={{ backgroundColor: colorFor(s, i) }} />
+                  <span className="truncate text-foreground">{label(s)}</span>
+                </span>
+                <span className="shrink-0 tabular-nums text-muted">{Math.round(s.pct * 100)}%</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </Panel>
+  );
+}

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -11,6 +11,7 @@ import { FileHotspots } from "./file-hotspots/widget";
 import { SessionTimeline } from "./session-timeline/widget";
 import { Latency } from "./latency/widget";
 import { ErrorRate } from "./error-rate/widget";
+import { ModelDonut } from "./model-donut/widget";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // PLUGIN REGISTRY
@@ -116,5 +117,12 @@ export const widgets: Widget[] = [
     span: "lg:col-span-3",
     height: "h-[360px] min-[2560px]:h-[480px] min-[3840px]:h-[660px]",
     component: ErrorRate,
+  },
+  {
+    id: "model-donut",
+    title: "Modelle",
+    span: "lg:col-span-3",
+    height: "h-[360px] min-[2560px]:h-[480px] min-[3840px]:h-[660px]",
+    component: ModelDonut,
   },
 ];


### PR DESCRIPTION
## Summary

Roadmap **Run 45 — Model-usage donut** (Phase D).

Design pass: donut for part-to-whole with ≤6 slices (group rest into "Other"), **center total**, direct %, **Wong color-blind-safe palette** ([Wong palette](https://davidmathlogic.com/colorblind/), [PatternFly donut](https://www.patternfly.org/charts/donut-chart/design-guidelines/)).

- **New `model-donut` widget** — a donut of **per-model share** of tokens or cost (toggle), Wong palette, the **total in the center hole**, a legend with per-model %, and recharts' built-in animation. Models beyond 6 group into **Other** (neutral grey).
- **New `src/lib/model-usage.ts`** — pure `modelShare` (value/pct by mode, sort, filter zeros, group→Other) + `shortModel`.
- Consumes `/api/usage` `models` (Run 30) — **demo works unchanged**.
- **E2E** updated: now asserts **12** widget sections.
- **Tests** (+5): cost/tokens modes, pct/sort/filter, Other grouping, empty, `shortModel`.

**Verified**: lint, 212 unit tests, build, E2E (2 passed, 12 widgets).

## Test plan
- [x] `npm run lint` / `npm test` (212) / `npm run build` / `npm run test:e2e` (2 passed)
- [ ] CI `verify` + `e2e` green

https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk)_