### PR TITLE
Run 46: Add Sankey flow widget (project → tool → resource)

### DIFF
--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -43,8 +43,8 @@ test("dashboard renders all four widgets and connects", async ({ page }) => {
 
   await expect(page.getByRole("heading", { name: "Claude Mission Control" })).toBeVisible();
 
-  // Twelve widget panels (+ model-donut).
-  await expect(page.locator("section")).toHaveCount(12);
+  // Thirteen widget panels (+ sankey-flow).
+  await expect(page.locator("section")).toHaveCount(13);
   // Two titles are identical in both locales — safe to assert regardless of language.
   await expect(page.getByText("Sessions", { exact: true })).toBeVisible();
   await expect(page.getByText("Live Stream", { exact: true })).toBeVisible();

--- a/src/app/api/sankey/route.ts
+++ b/src/app/api/sankey/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from "next/server";
+import { db } from "@/lib/db";
+import { describeTarget } from "@/lib/graph";
+import { buildSankey, type SankeyTriple } from "@/lib/sankey";
+import { log } from "@/lib/log";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+// project → tool → resource-kind flow from recent tool calls that touched a resource.
+export async function GET() {
+  try {
+    const rows = db
+      .prepare(
+        `SELECT COALESCE(NULLIF(s.project_name, ''), '(unknown)') AS project,
+                tc.tool_name AS tool, tc.target AS target
+         FROM tool_calls tc
+         JOIN sessions s ON s.id = tc.session_id
+         WHERE tc.target IS NOT NULL
+         ORDER BY tc.id DESC
+         LIMIT 5000`,
+      )
+      .all() as { project: string; tool: string; target: string }[];
+    const triples: SankeyTriple[] = rows.map((r) => ({
+      project: r.project,
+      tool: r.tool,
+      kind: describeTarget(r.tool, r.target).kind,
+    }));
+    return NextResponse.json(buildSankey(triples));
+  } catch (err) {
+    log.error("/api/sankey failed", err);
+    return NextResponse.json({ nodes: [], links: [] });
+  }
+}

--- a/src/lib/demo.ts
+++ b/src/lib/demo.ts
@@ -4,6 +4,7 @@
 // LiveProvider to read from here. Pure client-safe (no node imports).
 
 import { latencyStats } from "./latency";
+import { buildSankey, type SankeyTriple } from "./sankey";
 import type { EventRow, SessionRow, StreamMessage } from "./types";
 
 export const DEMO =
@@ -479,6 +480,20 @@ export function demoErrors() {
   };
 }
 
+export function demoSankey() {
+  const projects = ["my_dash", "shopify-bot"];
+  const tools = ["Read", "Edit", "Bash", "Grep", "WebFetch"];
+  const kinds = ["file", "command", "url", "pattern"];
+  const triples: SankeyTriple[] = [];
+  for (let i = 0; i < 400; i++) {
+    const tool = tools[Math.floor(Math.random() * tools.length)];
+    const kind =
+      tool === "Bash" ? "command" : tool === "WebFetch" ? "url" : tool === "Grep" ? "pattern" : "file";
+    triples.push({ project: projects[i % projects.length], tool, kind: kinds.includes(kind) ? kind : "file" });
+  }
+  return buildSankey(triples);
+}
+
 export function demoSubscribe(fn: (m: StreamMessage) => void) {
   listeners.add(fn);
   return () => listeners.delete(fn);
@@ -510,6 +525,7 @@ export function installDemoBackend() {
     if (path.endsWith("/api/activity")) return json(demoActivity());
     if (path.endsWith("/api/tools/latency")) return json(demoLatency());
     if (path.endsWith("/api/errors")) return json(demoErrors());
+    if (path.endsWith("/api/sankey")) return json(demoSankey());
     if (path.endsWith("/api/tools")) return json(demoTools());
     if (path.endsWith("/api/files")) return json(demoFiles());
     if (path.includes("/api/events")) {

--- a/src/lib/i18n.tsx
+++ b/src/lib/i18n.tsx
@@ -122,6 +122,9 @@ const DE: Record<string, string> = {
   "donut.empty": "Noch keine Modelldaten.",
   "donut.total": "gesamt",
   "donut.other": "Andere",
+  "sankey.title": "Fluss",
+  "sankey.info": "Fluss von Projekt → Tool → Ressourcentyp aus den Tool-Aufrufen.",
+  "sankey.empty": "Noch keine Tool-Ziele.",
 
   "search.label": "Sessions und Events durchsuchen",
   "search.placeholder": "Suchen…",
@@ -307,6 +310,9 @@ const EN: Record<string, string> = {
   "donut.empty": "No model data yet.",
   "donut.total": "total",
   "donut.other": "Other",
+  "sankey.title": "Flow",
+  "sankey.info": "Flow of project → tool → resource kind from tool calls.",
+  "sankey.empty": "No tool targets yet.",
 
   "search.label": "Search sessions and events",
   "search.placeholder": "Search…",

--- a/src/lib/sankey.test.ts
+++ b/src/lib/sankey.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { buildSankey, OTHER, type SankeyTriple } from "@/lib/sankey";
+
+const t = (project: string, tool: string, kind: string): SankeyTriple => ({ project, tool, kind });
+
+describe("buildSankey", () => {
+  it("builds project→tool→kind nodes and aggregates link values", () => {
+    const { nodes, links } = buildSankey([
+      t("A", "Read", "file"),
+      t("A", "Read", "file"),
+      t("A", "Bash", "command"),
+    ]);
+    const name = (i: number) => nodes[i].name;
+    // A→Read should have value 2, Read→file value 2.
+    const aRead = links.find((l) => name(l.source) === "A" && name(l.target) === "Read");
+    expect(aRead?.value).toBe(2);
+    const readFile = links.find((l) => name(l.source) === "Read" && name(l.target) === "file");
+    expect(readFile?.value).toBe(2);
+  });
+
+  it("keeps a project and a tool with the same name as distinct nodes", () => {
+    // tool index must differ from project index even with identical names.
+    const { nodes } = buildSankey([t("X", "X", "file")]);
+    expect(nodes.filter((n) => n.name === "X")).toHaveLength(2);
+  });
+
+  it("merges projects/tools beyond the max into Other", () => {
+    const rows: SankeyTriple[] = [];
+    for (let i = 0; i < 10; i++) rows.push(t(`p${i}`, `tool${i}`, "file"));
+    const { nodes } = buildSankey(rows, 3, 4);
+    expect(nodes.some((n) => n.name === OTHER)).toBe(true);
+  });
+
+  it("returns empty data for no rows", () => {
+    expect(buildSankey([])).toEqual({ nodes: [], links: [] });
+  });
+});

--- a/src/lib/sankey.ts
+++ b/src/lib/sankey.ts
@@ -1,0 +1,66 @@
+// Build a 3-tier Sankey (project → tool → resource-kind) from classified tool
+// calls. Keeps the top projects/tools and merges the rest into "Other" so the
+// flow shows dominant paths rather than every sliver. Output is recharts-shaped:
+// links reference node indices.
+export const OTHER = "Other";
+
+export interface SankeyTriple {
+  project: string;
+  tool: string;
+  kind: string; // file | command | url | pattern
+}
+
+export interface SankeyData {
+  nodes: { name: string }[];
+  links: { source: number; target: number; value: number }[];
+}
+
+function topKeys(counts: Map<string, number>, max: number): Set<string> {
+  return new Set(
+    [...counts.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, max)
+      .map((e) => e[0]),
+  );
+}
+
+export function buildSankey(rows: SankeyTriple[], maxProjects = 5, maxTools = 8): SankeyData {
+  const projCount = new Map<string, number>();
+  const toolCount = new Map<string, number>();
+  for (const r of rows) {
+    projCount.set(r.project, (projCount.get(r.project) ?? 0) + 1);
+    toolCount.set(r.tool, (toolCount.get(r.tool) ?? 0) + 1);
+  }
+  const keepProj = topKeys(projCount, maxProjects);
+  const keepTool = topKeys(toolCount, maxTools);
+
+  const nodes: { name: string }[] = [];
+  const ids = new Map<string, number>(); // "tier:name" -> index (tier keeps same names distinct)
+  const nodeId = (tier: string, name: string): number => {
+    const key = `${tier}:${name}`;
+    let i = ids.get(key);
+    if (i === undefined) {
+      i = nodes.length;
+      nodes.push({ name });
+      ids.set(key, i);
+    }
+    return i;
+  };
+
+  const linkValue = new Map<string, number>();
+  const addLink = (s: number, t: number) => linkValue.set(`${s}>${t}`, (linkValue.get(`${s}>${t}`) ?? 0) + 1);
+
+  for (const r of rows) {
+    const p = nodeId("p", keepProj.has(r.project) ? r.project : OTHER);
+    const t = nodeId("t", keepTool.has(r.tool) ? r.tool : OTHER);
+    const k = nodeId("k", r.kind);
+    addLink(p, t);
+    addLink(t, k);
+  }
+
+  const links = [...linkValue.entries()].map(([key, value]) => {
+    const [source, target] = key.split(">").map(Number);
+    return { source, target, value };
+  });
+  return { nodes, links };
+}

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -12,6 +12,7 @@ import { SessionTimeline } from "./session-timeline/widget";
 import { Latency } from "./latency/widget";
 import { ErrorRate } from "./error-rate/widget";
 import { ModelDonut } from "./model-donut/widget";
+import { SankeyFlow } from "./sankey-flow/widget";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // PLUGIN REGISTRY
@@ -124,5 +125,12 @@ export const widgets: Widget[] = [
     span: "lg:col-span-3",
     height: "h-[360px] min-[2560px]:h-[480px] min-[3840px]:h-[660px]",
     component: ModelDonut,
+  },
+  {
+    id: "sankey-flow",
+    title: "Fluss",
+    span: "lg:col-span-3",
+    height: "h-[360px] min-[2560px]:h-[480px] min-[3840px]:h-[660px]",
+    component: SankeyFlow,
   },
 ];

--- a/src/plugins/sankey-flow/widget.tsx
+++ b/src/plugins/sankey-flow/widget.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { ResponsiveContainer, Sankey, Tooltip } from "recharts";
+import { Workflow } from "lucide-react";
+import { Panel } from "@/components/panel";
+import { WidgetState } from "@/components/widget-state";
+import { useLive } from "@/components/live-provider";
+import { useT } from "@/lib/i18n";
+import type { SankeyData } from "@/lib/sankey";
+
+// Tier colors: project (blue), tool (purple), kind (green) — color-blind safe.
+const TIER_COLOR = ["#0072B2", "#CC79A7", "#009E73"];
+
+interface NodeProps {
+  x?: number;
+  y?: number;
+  width?: number;
+  height?: number;
+  payload?: { name?: string; value?: number; depth?: number };
+}
+
+function SankeyNode({ x = 0, y = 0, width = 0, height = 0, payload = {} }: NodeProps) {
+  const depth = payload.depth ?? 0;
+  const labelLeft = depth === 0;
+  return (
+    <g>
+      <rect x={x} y={y} width={width} height={Math.max(1, height)} rx={2} fill={TIER_COLOR[Math.min(depth, 2)]} />
+      <text
+        x={labelLeft ? x - 6 : x + width + 6}
+        y={y + height / 2}
+        textAnchor={labelLeft ? "end" : "start"}
+        dominantBaseline="middle"
+        fill="#aab3c5"
+        fontSize={10}
+      >
+        {payload.name}
+        {payload.value != null ? ` (${payload.value})` : ""}
+      </text>
+    </g>
+  );
+}
+
+export function SankeyFlow() {
+  const { t } = useT();
+  const { tick } = useLive();
+  const [data, setData] = useState<SankeyData | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = () =>
+      fetch("/api/sankey")
+        .then((r) => r.json())
+        .then((d: SankeyData) => {
+          if (!cancelled) setData(d);
+        })
+        .catch(() => {});
+    load();
+    const poll = setInterval(load, 30_000);
+    return () => {
+      cancelled = true;
+      clearInterval(poll);
+    };
+  }, [tick]);
+
+  return (
+    <Panel title={t("sankey.title")} icon={<Workflow className="h-4 w-4 text-accent" />} info={t("sankey.info")}>
+      {!data ? (
+        <WidgetState icon={Workflow} title={t("common.loading")} loading />
+      ) : data.links.length === 0 ? (
+        <WidgetState icon={Workflow} title={t("sankey.empty")} />
+      ) : (
+        <div className="h-full w-full p-2">
+          <ResponsiveContainer width="100%" height="100%">
+            <Sankey
+              data={data}
+              node={<SankeyNode />}
+              nodePadding={18}
+              nodeWidth={10}
+              link={{ stroke: "#2b3444", strokeOpacity: 0.35 }}
+              margin={{ left: 70, right: 80, top: 8, bottom: 8 }}
+            >
+              <Tooltip
+                contentStyle={{ background: "#0e1219", border: "1px solid #1c2230", borderRadius: 8, fontSize: 12 }}
+              />
+            </Sankey>
+          </ResponsiveContainer>
+        </div>
+      )}
+    </Panel>
+  );
+}


### PR DESCRIPTION
## Summary

Roadmap **Run 46 — Sankey flow** (Phase D), complementing the 3D graph.

Design pass: left→right flow, value-labeled nodes, tier colors, **merge small flows into "Other"** ([react-graph-gallery Sankey](https://www.react-graph-gallery.com/sankey-diagram), [recharts Sankey](https://recharts.github.io/en-US/api/Sankey/)).

- **New `sankey-flow` widget** — recharts `<Sankey>` showing **project → tool → resource-kind**, left→right, with tier colors (color-blind safe: blue/purple/green), **value-labeled nodes**, and small flows merged into **Other**.
- **New `src/lib/sankey.ts`** — pure `buildSankey(triples)`: top projects/tools (+ Other), distinct nodes per tier, aggregated links as recharts node-index pairs.
- **New `GET /api/sankey`** — classifies tool targets via `describeTarget` (reuses Run 3). Wired into the **demo**.
- **E2E** updated: now asserts **13** widget sections.
- **Tests** (+4): link aggregation, same-name nodes stay distinct across tiers, Other grouping, empty.

**Verified**: lint, 216 unit tests, build, E2E (2 passed, 13 widgets).

## Test plan
- [x] `npm run lint` / `npm test` (216) / `npm run build` / `npm run test:e2e` (2 passed)
- [ ] CI `verify` + `e2e` green

https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk)_