### PR TITLE
Add project leaderboard widget

### DIFF
--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -43,8 +43,8 @@ test("dashboard renders all four widgets and connects", async ({ page }) => {
 
   await expect(page.getByRole("heading", { name: "Claude Mission Control" })).toBeVisible();
 
-  // Thirteen widget panels (+ sankey-flow).
-  await expect(page.locator("section")).toHaveCount(13);
+  // Fourteen widget panels (+ project-leaderboard).
+  await expect(page.locator("section")).toHaveCount(14);
   // Two titles are identical in both locales — safe to assert regardless of language.
   await expect(page.getByText("Sessions", { exact: true })).toBeVisible();
   await expect(page.getByText("Live Stream", { exact: true })).toBeVisible();

--- a/src/lib/demo.ts
+++ b/src/lib/demo.ts
@@ -5,6 +5,7 @@
 
 import { latencyStats } from "./latency";
 import { buildSankey, type SankeyTriple } from "./sankey";
+import type { ProjectUsage } from "./projects";
 import type { EventRow, SessionRow, StreamMessage } from "./types";
 
 export const DEMO =
@@ -494,6 +495,29 @@ export function demoSankey() {
   return buildSankey(triples);
 }
 
+export function demoProjects() {
+  const seed = [
+    { project: "my_dash", sessions: 42, tools: 318, costUsd: 24.7 },
+    { project: "shopify-bot", sessions: 28, tools: 211, costUsd: 18.3 },
+    { project: "infra-scripts", sessions: 17, tools: 96, costUsd: 7.1 },
+    { project: "docs-site", sessions: 9, tools: 41, costUsd: 2.8 },
+    { project: "(unknown)", sessions: 4, tools: 12, costUsd: 0.4 },
+  ];
+  const projects: ProjectUsage[] = seed.map((s) => {
+    const tokenInput = s.tools * 1800;
+    const tokenOutput = s.tools * 4200;
+    const tokenCache = s.tools * 90_000;
+    return {
+      ...s,
+      tokenInput,
+      tokenOutput,
+      tokenCache,
+      totalTokens: tokenInput + tokenOutput + tokenCache,
+    };
+  });
+  return { projects };
+}
+
 export function demoSubscribe(fn: (m: StreamMessage) => void) {
   listeners.add(fn);
   return () => listeners.delete(fn);
@@ -519,6 +543,7 @@ export function installDemoBackend() {
     }
     if (path.endsWith("/api/sessions")) return json({ sessions: demoSessions() });
     if (path.endsWith("/api/graph")) return json(demoGraph());
+    if (path.endsWith("/api/usage/projects")) return json(demoProjects());
     if (path.endsWith("/api/usage")) return json(demoUsage());
     if (path.endsWith("/api/budget")) return json(demoBudget());
     if (path.endsWith("/api/stats")) return json(demoStats());

--- a/src/lib/i18n.tsx
+++ b/src/lib/i18n.tsx
@@ -126,6 +126,15 @@ const DE: Record<string, string> = {
   "sankey.info": "Fluss von Projekt → Tool → Ressourcentyp aus den Tool-Aufrufen.",
   "sankey.empty": "Noch keine Tool-Ziele.",
 
+  "leaderboard.title": "Projekt-Rangliste",
+  "leaderboard.info": "Projekte nach Kosten, Sessions, Tools und Tokens. Spalte klicken zum Sortieren.",
+  "leaderboard.empty": "Noch keine Projekte.",
+  "leaderboard.project": "Projekt",
+  "leaderboard.sessions": "Sessions",
+  "leaderboard.tools": "Tools",
+  "leaderboard.tokens": "Tokens",
+  "leaderboard.cost": "Kosten",
+
   "search.label": "Sessions und Events durchsuchen",
   "search.placeholder": "Suchen…",
   "search.clear": "Suche löschen",
@@ -313,6 +322,15 @@ const EN: Record<string, string> = {
   "sankey.title": "Flow",
   "sankey.info": "Flow of project → tool → resource kind from tool calls.",
   "sankey.empty": "No tool targets yet.",
+
+  "leaderboard.title": "Project leaderboard",
+  "leaderboard.info": "Projects by cost, sessions, tools and tokens. Click a column to sort.",
+  "leaderboard.empty": "No projects yet.",
+  "leaderboard.project": "Project",
+  "leaderboard.sessions": "Sessions",
+  "leaderboard.tools": "Tools",
+  "leaderboard.tokens": "Tokens",
+  "leaderboard.cost": "Cost",
 
   "search.label": "Search sessions and events",
   "search.placeholder": "Search…",

--- a/src/lib/projects.test.ts
+++ b/src/lib/projects.test.ts
@@ -20,6 +20,11 @@ function seed(): Database.Database {
   ins.run("a2", "A", 2, 100, 10, 0);
   ins.run("b1", "B", 8, 50, 5, 5);
   ins.run("u1", null, 0, 0, 0, 0);
+  const tc = db.prepare(`INSERT INTO tool_calls (session_id, tool_name) VALUES (?, ?)`);
+  tc.run("a1", "Read");
+  tc.run("a2", "Bash");
+  tc.run("a2", "Edit");
+  tc.run("b1", "Read");
   return db;
 }
 
@@ -33,6 +38,13 @@ describe("projectUsage", () => {
     expect(a.costUsd).toBe(5);
     expect(a.tokenInput).toBe(200);
     expect(a.totalTokens).toBe(220); // 200 + 20 + 0
+    expect(a.tools).toBe(3); // 1 in a1 + 2 in a2
+  });
+
+  it("counts tool calls per project, zero when none", () => {
+    const rows = projectUsage(seed());
+    expect(rows.find((r) => r.project === "B")!.tools).toBe(1);
+    expect(rows.find((r) => r.project === "(unknown)")!.tools).toBe(0);
   });
 
   it("groups null/empty project names under (unknown)", () => {

--- a/src/lib/projects.ts
+++ b/src/lib/projects.ts
@@ -1,9 +1,10 @@
 import type Database from "better-sqlite3";
 
-// Per-project rollup over the sessions table (cost, tokens, session count).
+// Per-project rollup over sessions (cost, tokens, session count) plus tool calls.
 export interface ProjectUsage {
   project: string;
   sessions: number;
+  tools: number;
   costUsd: number;
   tokenInput: number;
   tokenOutput: number;
@@ -25,9 +26,24 @@ export function projectUsage(db: Database.Database, limit = 100): ProjectUsage[]
        ORDER BY costUsd DESC, sessions DESC
        LIMIT ?`,
     )
-    .all(limit) as Omit<ProjectUsage, "totalTokens">[];
+    .all(limit) as Omit<ProjectUsage, "totalTokens" | "tools">[];
+
+  // Tool calls per project (joined via session), merged in.
+  const toolMap = new Map(
+    (
+      db
+        .prepare(
+          `SELECT COALESCE(NULLIF(s.project_name, ''), '(unknown)') AS project, COUNT(*) AS tools
+           FROM tool_calls tc JOIN sessions s ON s.id = tc.session_id
+           GROUP BY project`,
+        )
+        .all() as { project: string; tools: number }[]
+    ).map((r) => [r.project, r.tools] as const),
+  );
+
   return rows.map((r) => ({
     ...r,
+    tools: toolMap.get(r.project) ?? 0,
     totalTokens: r.tokenInput + r.tokenOutput + r.tokenCache,
   }));
 }

--- a/src/plugins/project-leaderboard/widget.tsx
+++ b/src/plugins/project-leaderboard/widget.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Trophy } from "lucide-react";
+import { Panel } from "@/components/panel";
+import { WidgetState } from "@/components/widget-state";
+import { useLive } from "@/components/live-provider";
+import { useT } from "@/lib/i18n";
+import { formatCompact, formatMoney } from "@/lib/format";
+import type { ProjectUsage } from "@/lib/projects";
+
+type SortKey = "costUsd" | "sessions" | "tools" | "totalTokens";
+
+const COLUMNS: { key: SortKey; label: string }[] = [
+  { key: "sessions", label: "leaderboard.sessions" },
+  { key: "tools", label: "leaderboard.tools" },
+  { key: "totalTokens", label: "leaderboard.tokens" },
+  { key: "costUsd", label: "leaderboard.cost" },
+];
+
+const MEDAL = ["🥇", "🥈", "🥉"];
+
+export function ProjectLeaderboard() {
+  const { t } = useT();
+  const { tick } = useLive();
+  const [projects, setProjects] = useState<ProjectUsage[] | null>(null);
+  const [sort, setSort] = useState<SortKey>("costUsd");
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = () =>
+      fetch("/api/usage/projects")
+        .then((r) => r.json())
+        .then((d: { projects: ProjectUsage[] }) => {
+          if (!cancelled) setProjects(d.projects);
+        })
+        .catch(() => {});
+    load();
+    const poll = setInterval(load, 15_000);
+    return () => {
+      cancelled = true;
+      clearInterval(poll);
+    };
+  }, [tick]);
+
+  const sorted = [...(projects ?? [])].sort((a, b) => b[sort] - a[sort]);
+
+  const cell = (p: ProjectUsage, key: SortKey) =>
+    key === "costUsd"
+      ? formatMoney(p.costUsd, "USD")
+      : key === "totalTokens"
+        ? formatCompact(p.totalTokens)
+        : String(p[key]);
+
+  return (
+    <Panel title={t("leaderboard.title")} icon={<Trophy className="h-4 w-4 text-accent" />} info={t("leaderboard.info")}>
+      {!projects ? (
+        <WidgetState icon={Trophy} title={t("common.loading")} loading />
+      ) : sorted.length === 0 ? (
+        <WidgetState icon={Trophy} title={t("leaderboard.empty")} />
+      ) : (
+        <div className="h-full overflow-auto">
+          <table className="w-full text-xs">
+            <thead className="sticky top-0 bg-panel/95 text-muted backdrop-blur">
+              <tr>
+                <th className="px-2 py-2 text-left font-medium">#</th>
+                <th className="px-2 py-2 text-left font-medium">{t("leaderboard.project")}</th>
+                {COLUMNS.map((c) => (
+                  <th key={c.key} className="px-2 py-2 text-right font-medium">
+                    <button
+                      onClick={() => setSort(c.key)}
+                      className={`tabular-nums hover:text-foreground ${sort === c.key ? "text-accent" : ""}`}
+                    >
+                      {t(c.label)}
+                      {sort === c.key ? " ↓" : ""}
+                    </button>
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {sorted.map((p, i) => (
+                <tr key={p.project} className="border-t border-panel-border/50 transition-colors hover:bg-white/[0.03]">
+                  <td className="px-2 py-1.5 tabular-nums text-muted">{MEDAL[i] ?? i + 1}</td>
+                  <td className="max-w-[10rem] truncate px-2 py-1.5 text-foreground" title={p.project}>
+                    {p.project}
+                  </td>
+                  {COLUMNS.map((c) => (
+                    <td
+                      key={c.key}
+                      className={`px-2 py-1.5 text-right tabular-nums ${sort === c.key ? "text-foreground" : "text-muted"}`}
+                    >
+                      {cell(p, c.key)}
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </Panel>
+  );
+}

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -13,6 +13,7 @@ import { Latency } from "./latency/widget";
 import { ErrorRate } from "./error-rate/widget";
 import { ModelDonut } from "./model-donut/widget";
 import { SankeyFlow } from "./sankey-flow/widget";
+import { ProjectLeaderboard } from "./project-leaderboard/widget";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // PLUGIN REGISTRY
@@ -132,5 +133,12 @@ export const widgets: Widget[] = [
     span: "lg:col-span-3",
     height: "h-[360px] min-[2560px]:h-[480px] min-[3840px]:h-[660px]",
     component: SankeyFlow,
+  },
+  {
+    id: "project-leaderboard",
+    title: "Projekt-Rangliste",
+    span: "lg:col-span-3",
+    height: "h-[360px] min-[2560px]:h-[480px] min-[3840px]:h-[660px]",
+    component: ProjectLeaderboard,
   },
 ];


### PR DESCRIPTION
## Summary
- New **Projekt-Rangliste / Project leaderboard** widget: a sortable ranked table of projects by cost, sessions, tool calls and tokens, with medals for the top three and clickable column headers (active column highlighted, `↓` direction indicator).
- Extends `projectUsage` with a per-project `tools` count (merged grouped query over `tool_calls`), served via the existing `/api/usage/projects` route.
- Adds demo data source (`demoProjects()` + fetch patch) so the static demo renders the widget, plus de/en i18n keys.

## Test plan
- [x] `npm run lint` — clean
- [x] `npx vitest run` — 217 tests pass (new `tools` assertions in `projects.test.ts`)
- [x] `npm run build` — succeeds (`/api/usage/projects` route present)
- [x] `npm run test:e2e` — 2 pass, widget `<section>` count bumped 13 → 14

https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk)_