### PR TITLE
Add prompt history widget

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -294,6 +294,24 @@ README/Docs sind nachgezogen.
      Changelog, Release-Workflow finalisieren, Pages-Demo mit allen Widgets.
      *Ergebnis:* das beste Claude-Code-Observability-Tool — ausgeliefert.
 
+## Phase Z — Abschluss-Check: visuelle & funktionale Gesamtabnahme (nach allen Widgets)
+
+101. 📸 **Voller Widget-Audit per Playwright.** Wenn alle Widgets stehen: das
+     Dashboard end-to-end durchklicken und visuell abnehmen. Konkret:
+     - Mit Playwright **Screenshots von jedem einzelnen Widget** (`section`)
+       sowie ein Full-Page-Bild in De **und** En, Light/Dark, und auf mehreren
+       Breiten (Desktop, 2560px, 3840px, Mobil) aufnehmen.
+     - **Jedes** Widget visuell prüfen: Layout/Format, kein Überlauf, keine
+       abgeschnittenen Texte, Lade-/Leer-/Fehlerzustände, Animationen.
+     - **Alles anklicken**: sortierbare Spalten, Filter, Drilldowns, Tabs,
+       Tooltips/Info-Hints, Sprach- und Theme-Umschalter, Layout-Reset — jede
+       Interaktion einmal auslösen und auf Konsolen-/Hydrations-Fehler achten.
+     - Funktion bestätigen: SSE verbindet, Live-Daten fließen, Suche filtert,
+       jede `/api/*`-Route antwortet, Demo-Modus zeigt alle Widgets.
+     - Bilder als Artefakte sammeln (CI-Upload), Abweichungen als Folge-Fixes
+       notieren. Abnahme erst grün, wenn jedes Widget geprüft, bebildert und
+       fehlerfrei ist.
+
 ---
 
 ## Überblick: Phasen auf einen Blick

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -43,8 +43,8 @@ test("dashboard renders all four widgets and connects", async ({ page }) => {
 
   await expect(page.getByRole("heading", { name: "Claude Mission Control" })).toBeVisible();
 
-  // Fifteen widget panels (+ live-now).
-  await expect(page.locator("section")).toHaveCount(15);
+  // Sixteen widget panels (+ prompt-history).
+  await expect(page.locator("section")).toHaveCount(16);
   // Two titles are identical in both locales — safe to assert regardless of language.
   await expect(page.getByText("Sessions", { exact: true })).toBeVisible();
   await expect(page.getByText("Live Stream", { exact: true })).toBeVisible();

--- a/src/app/api/prompts/route.ts
+++ b/src/app/api/prompts/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from "next/server";
+import { db } from "@/lib/db";
+import { promptHistory } from "@/lib/prompts";
+import { log } from "@/lib/log";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+// Chronological prompt history (redacted at ingest), newest first.
+export async function GET(req: Request) {
+  const url = new URL(req.url);
+  const limit = Math.min(Math.max(Math.trunc(Number(url.searchParams.get("limit")) || 100), 1), 500);
+  try {
+    return NextResponse.json({ prompts: promptHistory(db, limit) });
+  } catch (err) {
+    log.error("/api/prompts failed", err);
+    return NextResponse.json({ prompts: [] });
+  }
+}

--- a/src/lib/demo.ts
+++ b/src/lib/demo.ts
@@ -6,6 +6,7 @@
 import { latencyStats } from "./latency";
 import { buildSankey, type SankeyTriple } from "./sankey";
 import type { ProjectUsage } from "./projects";
+import type { PromptHistoryItem } from "./prompts";
 import type { EventRow, SessionRow, StreamMessage } from "./types";
 
 export const DEMO =
@@ -518,6 +519,25 @@ export function demoProjects() {
   return { projects };
 }
 
+export function demoPrompts() {
+  const items: PromptHistoryItem[] = [];
+  let id = 1;
+  for (const s of sessions) {
+    for (const p of s.prompts) {
+      items.push({
+        id: id++,
+        session_id: s.id,
+        project: s.project,
+        text: p.text,
+        token_estimate: Math.max(1, Math.ceil(p.text.length / 4)),
+        created_at: p.created_at,
+      });
+    }
+  }
+  items.sort((a, b) => (a.created_at < b.created_at ? 1 : -1));
+  return { prompts: items.slice(0, 100) };
+}
+
 export function demoSubscribe(fn: (m: StreamMessage) => void) {
   listeners.add(fn);
   return () => listeners.delete(fn);
@@ -545,6 +565,7 @@ export function installDemoBackend() {
     if (path.endsWith("/api/graph")) return json(demoGraph());
     if (path.endsWith("/api/usage/projects")) return json(demoProjects());
     if (path.endsWith("/api/usage")) return json(demoUsage());
+    if (path.endsWith("/api/prompts")) return json(demoPrompts());
     if (path.endsWith("/api/budget")) return json(demoBudget());
     if (path.endsWith("/api/stats")) return json(demoStats());
     if (path.endsWith("/api/activity")) return json(demoActivity());

--- a/src/lib/i18n.tsx
+++ b/src/lib/i18n.tsx
@@ -147,6 +147,11 @@ const DE: Record<string, string> = {
   "now.noActions": "Noch keine Aktionen in dieser Session.",
   "now.totalTokens": "Tokens gesamt",
 
+  "prompts.title": "Prompt-Verlauf",
+  "prompts.info": "Chronologische, durchsuchbare Liste deiner Prompts (Secrets werden vor dem Speichern entfernt).",
+  "prompts.empty": "Noch keine Prompts.",
+  "prompts.tokens": "Tokens",
+
   "search.label": "Sessions und Events durchsuchen",
   "search.placeholder": "Suchen…",
   "search.clear": "Suche löschen",
@@ -355,6 +360,11 @@ const EN: Record<string, string> = {
   "now.lastActions": "Latest actions",
   "now.noActions": "No actions in this session yet.",
   "now.totalTokens": "Total tokens",
+
+  "prompts.title": "Prompt history",
+  "prompts.info": "Chronological, searchable list of your prompts (secrets are stripped before storage).",
+  "prompts.empty": "No prompts yet.",
+  "prompts.tokens": "tokens",
 
   "search.label": "Search sessions and events",
   "search.placeholder": "Search…",

--- a/src/lib/prompts.test.ts
+++ b/src/lib/prompts.test.ts
@@ -1,0 +1,45 @@
+import Database from "better-sqlite3";
+import { afterEach, describe, expect, it } from "vitest";
+import { migrate } from "@/lib/migrations";
+import { promptHistory } from "@/lib/prompts";
+
+let open: Database.Database | null = null;
+afterEach(() => {
+  open?.close();
+  open = null;
+});
+
+function seed(): Database.Database {
+  const db = (open = new Database(":memory:"));
+  migrate(db);
+  db.prepare(`INSERT INTO sessions (id, project_name) VALUES (?, ?)`).run("s1", "alpha");
+  db.prepare(`INSERT INTO sessions (id, project_name) VALUES (?, ?)`).run("s2", null);
+  const ins = db.prepare(
+    `INSERT INTO prompts (session_id, event_id, text, token_estimate) VALUES (?, ?, ?, ?)`,
+  );
+  ins.run("s1", 1, "first prompt", 3);
+  ins.run("s1", 2, "second prompt", 5);
+  ins.run("s2", 3, "orphan project prompt", 0);
+  return db;
+}
+
+describe("promptHistory", () => {
+  it("returns prompts newest first with the project name", () => {
+    const rows = promptHistory(seed());
+    expect(rows.map((r) => r.text)).toEqual([
+      "orphan project prompt",
+      "second prompt",
+      "first prompt",
+    ]);
+    expect(rows.find((r) => r.text === "first prompt")!.project).toBe("alpha");
+  });
+
+  it("labels null project names as (unknown)", () => {
+    const rows = promptHistory(seed());
+    expect(rows.find((r) => r.text === "orphan project prompt")!.project).toBe("(unknown)");
+  });
+
+  it("respects the limit", () => {
+    expect(promptHistory(seed(), 1)).toHaveLength(1);
+  });
+});

--- a/src/lib/prompts.ts
+++ b/src/lib/prompts.ts
@@ -1,0 +1,30 @@
+import type Database from "better-sqlite3";
+
+// Prompt history: the redacted + capped prompt rows captured at ingest time
+// (one per UserPromptSubmit), newest first, enriched with the project name.
+// Powers the prompt-history widget.
+export interface PromptHistoryItem {
+  id: number;
+  session_id: string;
+  project: string;
+  text: string;
+  token_estimate: number;
+  created_at: string;
+}
+
+export function promptHistory(db: Database.Database, limit = 100): PromptHistoryItem[] {
+  return db
+    .prepare(
+      `SELECT p.id,
+              p.session_id,
+              COALESCE(NULLIF(s.project_name, ''), '(unknown)') AS project,
+              p.text,
+              p.token_estimate,
+              p.created_at
+       FROM prompts p
+       LEFT JOIN sessions s ON s.id = p.session_id
+       ORDER BY p.id DESC
+       LIMIT ?`,
+    )
+    .all(limit) as PromptHistoryItem[];
+}

--- a/src/plugins/prompt-history/widget.tsx
+++ b/src/plugins/prompt-history/widget.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { MessageSquare } from "lucide-react";
+import { Panel } from "@/components/panel";
+import { WidgetState } from "@/components/widget-state";
+import { useLive } from "@/components/live-provider";
+import { useSearch, matchesQuery } from "@/components/search";
+import { useT } from "@/lib/i18n";
+import { formatCompact, relativeTime } from "@/lib/format";
+import type { PromptHistoryItem } from "@/lib/prompts";
+
+export function PromptHistory() {
+  const { tick } = useLive();
+  const { query } = useSearch();
+  const { t, lang } = useT();
+  const [prompts, setPrompts] = useState<PromptHistoryItem[] | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = () =>
+      fetch("/api/prompts?limit=100")
+        .then((r) => r.json())
+        .then((d: { prompts: PromptHistoryItem[] }) => {
+          if (!cancelled) setPrompts(d.prompts);
+        })
+        .catch(() => {});
+    load();
+    const poll = setInterval(load, 15_000);
+    return () => {
+      cancelled = true;
+      clearInterval(poll);
+    };
+  }, [tick]);
+
+  const filtered = (prompts ?? []).filter((p) => matchesQuery(query, p.text, p.project));
+
+  return (
+    <Panel
+      title={t("prompts.title")}
+      icon={<MessageSquare className="h-4 w-4 text-accent" />}
+      info={t("prompts.info")}
+    >
+      {!prompts ? (
+        <WidgetState icon={MessageSquare} title={t("common.loading")} loading />
+      ) : prompts.length === 0 ? (
+        <WidgetState icon={MessageSquare} title={t("prompts.empty")} />
+      ) : filtered.length === 0 ? (
+        <WidgetState icon={MessageSquare} title={t("common.noResults")} />
+      ) : (
+        <ol className="relative ml-4 border-l border-panel-border/70 py-2 pr-4">
+          {filtered.map((p) => (
+            <li key={p.id} className="mc-stream-in relative py-2 pl-5">
+              <span className="absolute -left-[5px] top-3.5 h-2.5 w-2.5 rounded-full border-2 border-panel bg-accent" />
+              <p className="whitespace-pre-wrap break-words text-sm text-foreground">{p.text}</p>
+              <div className="mt-1 flex items-center gap-2 text-[11px] text-muted">
+                <span className="truncate font-mono" title={p.project}>
+                  {p.project}
+                </span>
+                <span aria-hidden>·</span>
+                <span className="whitespace-nowrap">{relativeTime(p.created_at, lang)}</span>
+                {p.token_estimate > 0 && (
+                  <>
+                    <span aria-hidden>·</span>
+                    <span className="whitespace-nowrap tabular-nums">
+                      ~{formatCompact(p.token_estimate)} {t("prompts.tokens")}
+                    </span>
+                  </>
+                )}
+              </div>
+            </li>
+          ))}
+        </ol>
+      )}
+    </Panel>
+  );
+}

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -15,6 +15,7 @@ import { ModelDonut } from "./model-donut/widget";
 import { SankeyFlow } from "./sankey-flow/widget";
 import { ProjectLeaderboard } from "./project-leaderboard/widget";
 import { LiveNow } from "./live-now/widget";
+import { PromptHistory } from "./prompt-history/widget";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // PLUGIN REGISTRY
@@ -148,5 +149,12 @@ export const widgets: Widget[] = [
     span: "lg:col-span-3",
     height: "h-[360px] min-[2560px]:h-[480px] min-[3840px]:h-[660px]",
     component: LiveNow,
+  },
+  {
+    id: "prompt-history",
+    title: "Prompt-Verlauf",
+    span: "lg:col-span-3",
+    height: "h-[360px] min-[2560px]:h-[480px] min-[3840px]:h-[660px]",
+    component: PromptHistory,
   },
 ];


### PR DESCRIPTION
## Summary
- New **Prompt-Verlauf / Prompt history** widget (Run 49): a chronological, searchable timeline of your prompts rendered from the existing `prompts` table (already redacted + capped at ingest). Each entry shows the prompt text, project tag, relative time and an estimated token count, on a vertical timeline rail. Integrates with the dashboard-wide search filter.
- Adds `/api/prompts`, a `promptHistory` lib (+ unit tests), a `demoPrompts()` demo source, and de/en i18n.
- Appends a final **Phase Z** task (#101) to `ROADMAP.md`: a full end-of-roadmap Playwright audit — screenshot every widget (de/en, light/dark, multiple widths), visually check layout/format/states, click through every interaction, and confirm all `/api/*` routes + SSE work.

Research note (per standing instruction): history UIs favour a chronological timeline pattern with a connector rail, full-text search, and explicit empty/partial/no-results states — all reflected here.

## Test plan
- [x] `npm run lint` — clean
- [x] `npx vitest run` — 222 tests pass (new `promptHistory` cases)
- [x] `npm run build` — succeeds (`/api/prompts` route present)
- [x] `npm run test:e2e` — 2 pass, widget `<section>` count bumped 15 → 16

https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk)_