### PR TITLE
Add streak &amp; productivity widget

### DIFF
--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -43,8 +43,8 @@ test("dashboard renders all four widgets and connects", async ({ page }) => {
 
   await expect(page.getByRole("heading", { name: "Claude Mission Control" })).toBeVisible();
 
-  // Sixteen widget panels (+ prompt-history).
-  await expect(page.locator("section")).toHaveCount(16);
+  // Seventeen widget panels (+ streak).
+  await expect(page.locator("section")).toHaveCount(17);
   // Two titles are identical in both locales — safe to assert regardless of language.
   await expect(page.getByText("Sessions", { exact: true })).toBeVisible();
   await expect(page.getByText("Live Stream", { exact: true })).toBeVisible();

--- a/src/app/api/streak/route.ts
+++ b/src/app/api/streak/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from "next/server";
+import { db } from "@/lib/db";
+import { recentActivity } from "@/lib/activity";
+import { dailySessions, hourHistogram, peakHour, streakStats } from "@/lib/streak";
+import { log } from "@/lib/log";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+// Productivity rollup: day-streak, sessions-per-day trend and peak-hours histogram.
+export async function GET(req: Request) {
+  const url = new URL(req.url);
+  const days = Math.min(Math.max(Math.trunc(Number(url.searchParams.get("days")) || 30), 7), 365);
+  try {
+    const series = dailySessions(db, days);
+    const hours = hourHistogram(recentActivity(db, 10000));
+    return NextResponse.json({
+      streak: streakStats(series),
+      days: series,
+      hours,
+      peakHour: peakHour(hours),
+    });
+  } catch (err) {
+    log.error("/api/streak failed", err);
+    return NextResponse.json({
+      streak: { current: 0, longest: 0, activeDays: 0, totalSessions: 0 },
+      days: [],
+      hours: new Array(24).fill(0),
+      peakHour: -1,
+    });
+  }
+}

--- a/src/lib/demo.ts
+++ b/src/lib/demo.ts
@@ -7,6 +7,7 @@ import { latencyStats } from "./latency";
 import { buildSankey, type SankeyTriple } from "./sankey";
 import type { ProjectUsage } from "./projects";
 import type { PromptHistoryItem } from "./prompts";
+import { streakStats, peakHour, type DayCount } from "./streak";
 import type { EventRow, SessionRow, StreamMessage } from "./types";
 
 export const DEMO =
@@ -538,6 +539,27 @@ export function demoPrompts() {
   return { prompts: items.slice(0, 100) };
 }
 
+export function demoStreak() {
+  const today = new Date();
+  const days: DayCount[] = [];
+  for (let i = 29; i >= 0; i--) {
+    const date = new Date(today.getTime() - i * 86_400_000);
+    const key = date.toISOString().slice(0, 10);
+    const weekday = date.getDay();
+    const weekendDip = weekday === 0 || weekday === 6 ? 0.3 : 1;
+    // Keep the last few days active so the demo always shows a live streak.
+    const base = i <= 4 ? 2 : Math.round((1 + Math.random() * 4) * weekendDip);
+    days.push({ date: key, count: Math.max(0, base) });
+  }
+  const hours = new Array<number>(24).fill(0);
+  for (let h = 0; h < 24; h++) {
+    const work = h >= 9 && h <= 18 ? 1 : 0.15;
+    const peak = h === 11 || h === 15 ? 1.6 : 1;
+    hours[h] = Math.round(20 * work * peak + Math.random() * 6);
+  }
+  return { streak: streakStats(days), days, hours, peakHour: peakHour(hours) };
+}
+
 export function demoSubscribe(fn: (m: StreamMessage) => void) {
   listeners.add(fn);
   return () => listeners.delete(fn);
@@ -566,6 +588,7 @@ export function installDemoBackend() {
     if (path.endsWith("/api/usage/projects")) return json(demoProjects());
     if (path.endsWith("/api/usage")) return json(demoUsage());
     if (path.endsWith("/api/prompts")) return json(demoPrompts());
+    if (path.endsWith("/api/streak")) return json(demoStreak());
     if (path.endsWith("/api/budget")) return json(demoBudget());
     if (path.endsWith("/api/stats")) return json(demoStats());
     if (path.endsWith("/api/activity")) return json(demoActivity());

--- a/src/lib/i18n.tsx
+++ b/src/lib/i18n.tsx
@@ -152,6 +152,16 @@ const DE: Record<string, string> = {
   "prompts.empty": "Noch keine Prompts.",
   "prompts.tokens": "Tokens",
 
+  "streak.title": "Streak & Produktivität",
+  "streak.info": "Tages-Streak aktiver Tage, Stoßzeiten und der Sessions-pro-Tag-Trend.",
+  "streak.empty": "Noch keine Aktivität.",
+  "streak.current": "Aktuell",
+  "streak.longest": "Längste",
+  "streak.activeDays": "Aktive Tage",
+  "streak.peak": "Stoßzeit",
+  "streak.perDay": "Sessions pro Tag (30 T.)",
+  "streak.peakHours": "Stoßzeiten (Stunde)",
+
   "search.label": "Sessions und Events durchsuchen",
   "search.placeholder": "Suchen…",
   "search.clear": "Suche löschen",
@@ -365,6 +375,16 @@ const EN: Record<string, string> = {
   "prompts.info": "Chronological, searchable list of your prompts (secrets are stripped before storage).",
   "prompts.empty": "No prompts yet.",
   "prompts.tokens": "tokens",
+
+  "streak.title": "Streak & productivity",
+  "streak.info": "Day-streak of active days, peak hours and the sessions-per-day trend.",
+  "streak.empty": "No activity yet.",
+  "streak.current": "Current",
+  "streak.longest": "Longest",
+  "streak.activeDays": "Active days",
+  "streak.peak": "Peak hour",
+  "streak.perDay": "Sessions per day (30d)",
+  "streak.peakHours": "Peak hours (hour)",
 
   "search.label": "Search sessions and events",
   "search.placeholder": "Search…",

--- a/src/lib/streak.test.ts
+++ b/src/lib/streak.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { hourHistogram, peakHour, streakStats, type DayCount } from "@/lib/streak";
+import type { ActivityBucket } from "@/lib/activity";
+
+const day = (date: string, count: number): DayCount => ({ date, count });
+
+describe("streakStats", () => {
+  it("counts the current streak back from today", () => {
+    const days = [day("2026-05-19", 1), day("2026-05-20", 0), day("2026-05-21", 2), day("2026-05-22", 1), day("2026-05-23", 3)];
+    const s = streakStats(days);
+    expect(s.current).toBe(3); // 21,22,23
+    expect(s.longest).toBe(3);
+    expect(s.activeDays).toBe(4);
+    expect(s.totalSessions).toBe(7);
+  });
+
+  it("reports a current streak of 0 when today is inactive", () => {
+    const days = [day("2026-05-21", 5), day("2026-05-22", 2), day("2026-05-23", 0)];
+    const s = streakStats(days);
+    expect(s.current).toBe(0);
+    expect(s.longest).toBe(2);
+  });
+
+  it("handles an all-zero series", () => {
+    expect(streakStats([day("2026-05-22", 0), day("2026-05-23", 0)])).toEqual({
+      current: 0,
+      longest: 0,
+      activeDays: 0,
+      totalSessions: 0,
+    });
+  });
+});
+
+describe("hourHistogram + peakHour", () => {
+  const b = (bucket: string, count: number): ActivityBucket => ({ bucket, event_type: "x", count });
+
+  it("buckets counts into 24 local hours and finds the peak", () => {
+    // 2026-05-23 09:00 UTC — fold uses local hours; assert via the produced index.
+    const hours = hourHistogram([b("2026-05-23 09", 3), b("2026-05-23 09", 2), b("2026-05-22 14", 1)]);
+    expect(hours).toHaveLength(24);
+    expect(hours.reduce((a, c) => a + c, 0)).toBe(6);
+    const peak = peakHour(hours);
+    expect(hours[peak]).toBe(5); // the doubled 09:00-UTC slot dominates
+  });
+
+  it("returns -1 for the peak when there is no activity", () => {
+    expect(peakHour(new Array(24).fill(0))).toBe(-1);
+  });
+});

--- a/src/lib/streak.ts
+++ b/src/lib/streak.ts
@@ -1,0 +1,86 @@
+import type Database from "better-sqlite3";
+import type { ActivityBucket } from "./activity";
+
+// Productivity rollups: a day-streak of activity, the sessions-per-day trend, and
+// a peak-hours histogram. Powers the streak / productivity widget.
+
+export interface DayCount {
+  date: string; // YYYY-MM-DD (UTC)
+  count: number;
+}
+
+export interface StreakStats {
+  current: number; // consecutive active days ending today
+  longest: number; // longest active run in the window
+  activeDays: number; // days with at least one session
+  totalSessions: number;
+}
+
+// Sessions started per day over the last `days` days (oldest first, gaps filled).
+export function dailySessions(db: Database.Database, days: number, now: Date = new Date()): DayCount[] {
+  const startKey = new Date(now.getTime() - (days - 1) * 86_400_000).toISOString().slice(0, 10);
+  const rows = db
+    .prepare(
+      `SELECT substr(first_seen, 1, 10) AS date, COUNT(*) AS count
+       FROM sessions
+       WHERE first_seen >= ?
+       GROUP BY date`,
+    )
+    .all(`${startKey} 00:00:00`) as DayCount[];
+  const map = new Map(rows.map((r) => [r.date, r.count]));
+  const out: DayCount[] = [];
+  for (let i = days - 1; i >= 0; i--) {
+    const key = new Date(now.getTime() - i * 86_400_000).toISOString().slice(0, 10);
+    out.push({ date: key, count: map.get(key) ?? 0 });
+  }
+  return out;
+}
+
+// Streak metrics from a gap-filled, oldest→newest day series. The current streak
+// counts back from the last day (today): if today is inactive it is 0.
+export function streakStats(days: DayCount[]): StreakStats {
+  let longest = 0;
+  let run = 0;
+  let activeDays = 0;
+  let totalSessions = 0;
+  for (const d of days) {
+    totalSessions += d.count;
+    if (d.count > 0) {
+      run += 1;
+      activeDays += 1;
+      if (run > longest) longest = run;
+    } else {
+      run = 0;
+    }
+  }
+  let current = 0;
+  for (let i = days.length - 1; i >= 0; i--) {
+    if (days[i].count > 0) current += 1;
+    else break;
+  }
+  return { current, longest, activeDays, totalSessions };
+}
+
+// Fold UTC hour-buckets into a 24-slot LOCAL-time histogram of event counts.
+export function hourHistogram(buckets: ActivityBucket[]): number[] {
+  const hours = new Array<number>(24).fill(0);
+  for (const b of buckets) {
+    const d = new Date(`${b.bucket.replace(" ", "T")}:00:00Z`);
+    if (Number.isNaN(d.getTime())) continue;
+    hours[d.getHours()] += b.count;
+  }
+  return hours;
+}
+
+// Index (0..23) of the busiest hour, or -1 when there is no activity.
+export function peakHour(hours: number[]): number {
+  let idx = -1;
+  let max = 0;
+  hours.forEach((c, i) => {
+    if (c > max) {
+      max = c;
+      idx = i;
+    }
+  });
+  return idx;
+}

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -16,6 +16,7 @@ import { SankeyFlow } from "./sankey-flow/widget";
 import { ProjectLeaderboard } from "./project-leaderboard/widget";
 import { LiveNow } from "./live-now/widget";
 import { PromptHistory } from "./prompt-history/widget";
+import { Streak } from "./streak/widget";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // PLUGIN REGISTRY
@@ -156,5 +157,12 @@ export const widgets: Widget[] = [
     span: "lg:col-span-3",
     height: "h-[360px] min-[2560px]:h-[480px] min-[3840px]:h-[660px]",
     component: PromptHistory,
+  },
+  {
+    id: "streak",
+    title: "Streak & Produktivität",
+    span: "lg:col-span-3",
+    height: "h-[360px] min-[2560px]:h-[480px] min-[3840px]:h-[660px]",
+    component: Streak,
   },
 ];

--- a/src/plugins/streak/widget.tsx
+++ b/src/plugins/streak/widget.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Flame } from "lucide-react";
+import { Panel } from "@/components/panel";
+import { WidgetState } from "@/components/widget-state";
+import { useLive } from "@/components/live-provider";
+import { useT } from "@/lib/i18n";
+import type { DayCount, StreakStats } from "@/lib/streak";
+
+interface StreakData {
+  streak: StreakStats;
+  days: DayCount[];
+  hours: number[];
+  peakHour: number;
+}
+
+export function Streak() {
+  const { tick } = useLive();
+  const { t } = useT();
+  const [data, setData] = useState<StreakData | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = () =>
+      fetch("/api/streak?days=30")
+        .then((r) => r.json())
+        .then((d: StreakData) => {
+          if (!cancelled) setData(d);
+        })
+        .catch(() => {});
+    load();
+    const poll = setInterval(load, 15_000);
+    return () => {
+      cancelled = true;
+      clearInterval(poll);
+    };
+  }, [tick]);
+
+  const empty = data && data.streak.totalSessions === 0;
+
+  return (
+    <Panel title={t("streak.title")} icon={<Flame className="h-4 w-4 text-accent" />} info={t("streak.info")}>
+      {!data ? (
+        <WidgetState icon={Flame} title={t("common.loading")} loading />
+      ) : empty ? (
+        <WidgetState icon={Flame} title={t("streak.empty")} />
+      ) : (
+        <div className="flex h-full flex-col gap-3 p-4">
+          <div className="grid grid-cols-4 gap-2 text-center">
+            <Stat value={`🔥 ${data.streak.current}`} label={t("streak.current")} accent />
+            <Stat value={String(data.streak.longest)} label={t("streak.longest")} />
+            <Stat value={String(data.streak.activeDays)} label={t("streak.activeDays")} />
+            <Stat value={data.peakHour >= 0 ? `${String(data.peakHour).padStart(2, "0")}:00` : "—"} label={t("streak.peak")} />
+          </div>
+
+          <Bars
+            label={t("streak.perDay")}
+            values={data.days.map((d) => d.count)}
+            labels={data.days.map((d) => d.date)}
+            highlightLast
+          />
+
+          <Bars
+            label={t("streak.peakHours")}
+            values={data.hours}
+            labels={data.hours.map((_, h) => `${String(h).padStart(2, "0")}:00`)}
+            highlight={data.peakHour}
+          />
+        </div>
+      )}
+    </Panel>
+  );
+}
+
+function Stat({ value, label, accent = false }: { value: string; label: string; accent?: boolean }) {
+  return (
+    <div className="rounded-lg bg-white/[0.03] px-2 py-1.5">
+      <p className={`truncate font-mono text-sm tabular-nums ${accent ? "text-accent" : "text-foreground"}`}>
+        {value}
+      </p>
+      <p className="truncate text-[10px] uppercase tracking-wide text-muted">{label}</p>
+    </div>
+  );
+}
+
+function Bars({
+  label,
+  values,
+  labels,
+  highlight = -1,
+  highlightLast = false,
+}: {
+  label: string;
+  values: number[];
+  labels: string[];
+  highlight?: number;
+  highlightLast?: boolean;
+}) {
+  const max = values.reduce((m, v) => Math.max(m, v), 0) || 1;
+  return (
+    <div className="min-w-0">
+      <p className="mb-1 text-[11px] font-medium uppercase tracking-wide text-muted">{label}</p>
+      <div className="flex h-12 items-end gap-px">
+        {values.map((v, i) => {
+          const hot = i === highlight || (highlightLast && i === values.length - 1);
+          return (
+            <div
+              key={i}
+              title={`${labels[i]}: ${v}`}
+              className={`flex-1 rounded-t-sm transition-[height] ${hot ? "bg-accent" : "bg-accent/30"}`}
+              style={{ height: `${Math.max(v > 0 ? 8 : 2, (v / max) * 100)}%` }}
+            />
+          );
+        })}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- New **Streak & Produktivität / Streak & productivity** widget (Run 50): a day-streak of active days (current + longest), the count of active days, the busiest hour, a 30-day sessions-per-day trend, and a 24-hour peak-hours histogram — all rendered as lightweight CSS bars (no extra deps).
- Adds `/api/streak`, a `streak` lib with pure helpers (`streakStats`, `dailySessions`, `hourHistogram`, `peakHour`) plus unit tests, a `demoStreak()` demo source, and de/en i18n.

Research note (per standing instruction): streak/productivity UIs favour a prominent streak counter, clean stat tiles, and compact trend/peak visualisations — reflected in the flame counter, stat grid and dual bar charts.

## Test plan
- [x] `npm run lint` — clean
- [x] `npx vitest run` — 227 tests pass (new streak/histogram cases)
- [x] `npm run build` — succeeds (`/api/streak` route present)
- [x] `npm run test:e2e` — 2 pass, widget `<section>` count bumped 16 → 17

https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk)_