### PR TITLE
Add subagent tree widget

### DIFF
--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -43,8 +43,8 @@ test("dashboard renders all four widgets and connects", async ({ page }) => {
 
   await expect(page.getByRole("heading", { name: "Claude Mission Control" })).toBeVisible();
 
-  // Seventeen widget panels (+ streak).
-  await expect(page.locator("section")).toHaveCount(17);
+  // Eighteen widget panels (+ subagent-tree).
+  await expect(page.locator("section")).toHaveCount(18);
   // Two titles are identical in both locales — safe to assert regardless of language.
   await expect(page.getByText("Sessions", { exact: true })).toBeVisible();
   await expect(page.getByText("Live Stream", { exact: true })).toBeVisible();

--- a/src/app/api/subagents/route.ts
+++ b/src/app/api/subagents/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from "next/server";
+import { db } from "@/lib/db";
+import { subagentTree } from "@/lib/subagents";
+import { log } from "@/lib/log";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+// Session → subagent tree, grouped from the Task links captured at ingest.
+export async function GET(req: Request) {
+  const url = new URL(req.url);
+  const limit = Math.min(Math.max(Math.trunc(Number(url.searchParams.get("limit")) || 200), 1), 1000);
+  try {
+    return NextResponse.json({ groups: subagentTree(db, limit) });
+  } catch (err) {
+    log.error("/api/subagents failed", err);
+    return NextResponse.json({ groups: [] });
+  }
+}

--- a/src/lib/demo.ts
+++ b/src/lib/demo.ts
@@ -8,6 +8,7 @@ import { buildSankey, type SankeyTriple } from "./sankey";
 import type { ProjectUsage } from "./projects";
 import type { PromptHistoryItem } from "./prompts";
 import { streakStats, peakHour, type DayCount } from "./streak";
+import type { SubagentGroup } from "./subagents";
 import type { EventRow, SessionRow, StreamMessage } from "./types";
 
 export const DEMO =
@@ -560,6 +561,45 @@ export function demoStreak() {
   return { streak: streakStats(days), days, hours, peakHour: peakHour(hours) };
 }
 
+export function demoSubagents() {
+  const groups: SubagentGroup[] = [];
+  let id = 1;
+  for (const s of sessions) {
+    const tasks = s.tools.filter((tc) => tc.tool === "Task");
+    if (tasks.length === 0) continue;
+    groups.push({
+      session_id: s.id,
+      project: s.project,
+      title: s.title,
+      count: tasks.length,
+      last_at: s.last_seen,
+      tasks: tasks.map((tk) => ({
+        id: id++,
+        label: tk.full,
+        child_session_id: null,
+        tool_call_id: null,
+        created_at: s.last_seen,
+      })),
+    });
+  }
+  // Guarantee the demo shows the widget even if no Task calls fired yet.
+  if (groups.length === 0 && sessions.length > 0) {
+    const s = sessions[sessions.length - 1];
+    groups.push({
+      session_id: s.id,
+      project: s.project,
+      title: s.title,
+      count: 2,
+      last_at: s.last_seen,
+      tasks: [
+        { id: id++, label: "Explore: locate the ingest pipeline", child_session_id: null, tool_call_id: null, created_at: s.last_seen },
+        { id: id++, label: "Plan: design the retention sweep", child_session_id: null, tool_call_id: null, created_at: s.last_seen },
+      ],
+    });
+  }
+  return { groups: groups.reverse() };
+}
+
 export function demoSubscribe(fn: (m: StreamMessage) => void) {
   listeners.add(fn);
   return () => listeners.delete(fn);
@@ -589,6 +629,7 @@ export function installDemoBackend() {
     if (path.endsWith("/api/usage")) return json(demoUsage());
     if (path.endsWith("/api/prompts")) return json(demoPrompts());
     if (path.endsWith("/api/streak")) return json(demoStreak());
+    if (path.endsWith("/api/subagents")) return json(demoSubagents());
     if (path.endsWith("/api/budget")) return json(demoBudget());
     if (path.endsWith("/api/stats")) return json(demoStats());
     if (path.endsWith("/api/activity")) return json(demoActivity());

--- a/src/lib/i18n.tsx
+++ b/src/lib/i18n.tsx
@@ -162,6 +162,12 @@ const DE: Record<string, string> = {
   "streak.perDay": "Sessions pro Tag (30 T.)",
   "streak.peakHours": "Stoßzeiten (Stunde)",
 
+  "subagents.title": "Subagent-Baum",
+  "subagents.info": "Welche Sessions Subagenten per Task gestartet haben – aufklappen zeigt die einzelnen Subagenten.",
+  "subagents.empty": "Noch keine Subagenten.",
+  "subagents.emptyHint": "Sobald Claude einen Task-Subagenten startet, erscheint er hier.",
+  "subagents.unnamed": "Unbenannter Subagent",
+
   "search.label": "Sessions und Events durchsuchen",
   "search.placeholder": "Suchen…",
   "search.clear": "Suche löschen",
@@ -385,6 +391,12 @@ const EN: Record<string, string> = {
   "streak.peak": "Peak hour",
   "streak.perDay": "Sessions per day (30d)",
   "streak.peakHours": "Peak hours (hour)",
+
+  "subagents.title": "Subagent tree",
+  "subagents.info": "Which sessions spawned subagents via Task — expand to see the individual subagents.",
+  "subagents.empty": "No subagents yet.",
+  "subagents.emptyHint": "As soon as Claude launches a Task subagent, it shows up here.",
+  "subagents.unnamed": "Unnamed subagent",
 
   "search.label": "Search sessions and events",
   "search.placeholder": "Search…",

--- a/src/lib/subagents.test.ts
+++ b/src/lib/subagents.test.ts
@@ -1,0 +1,52 @@
+import Database from "better-sqlite3";
+import { afterEach, describe, expect, it } from "vitest";
+import { migrate } from "@/lib/migrations";
+import { subagentTree } from "@/lib/subagents";
+
+let open: Database.Database | null = null;
+afterEach(() => {
+  open?.close();
+  open = null;
+});
+
+function seed(): Database.Database {
+  const db = (open = new Database(":memory:"));
+  migrate(db);
+  db.prepare(`INSERT INTO sessions (id, project_name, title) VALUES (?, ?, ?)`).run("p1", "alpha", "Build feature");
+  db.prepare(`INSERT INTO sessions (id, project_name, title) VALUES (?, ?, ?)`).run("p2", null, null);
+  const ins = db.prepare(
+    `INSERT INTO session_links (parent_session_id, child_session_id, tool_call_id, kind, label)
+     VALUES (?, ?, ?, ?, ?)`,
+  );
+  ins.run("p1", null, 10, "subagent", "Explore: find auth code");
+  ins.run("p1", null, 11, "subagent", "Plan: design API");
+  ins.run("p2", null, 12, "subagent", "general-purpose");
+  ins.run("p1", null, 13, "other", "not a subagent"); // filtered out
+  return db;
+}
+
+describe("subagentTree", () => {
+  it("groups subagent links by spawning session", () => {
+    const groups = subagentTree(seed());
+    const p1 = groups.find((g) => g.session_id === "p1")!;
+    expect(p1.count).toBe(2);
+    expect(p1.project).toBe("alpha");
+    expect(p1.title).toBe("Build feature");
+    expect(p1.tasks.map((t) => t.label)).toContain("Plan: design API");
+  });
+
+  it("only includes subagent-kind links and labels unknown projects", () => {
+    const groups = subagentTree(seed());
+    const p2 = groups.find((g) => g.session_id === "p2")!;
+    expect(p2.project).toBe("(unknown)");
+    expect(p2.count).toBe(1);
+    // The 'other'-kind link on p1 must not be counted.
+    expect(groups.find((g) => g.session_id === "p1")!.count).toBe(2);
+  });
+
+  it("returns an empty array when there are no links", () => {
+    const db = (open = new Database(":memory:"));
+    migrate(db);
+    expect(subagentTree(db)).toEqual([]);
+  });
+});

--- a/src/lib/subagents.ts
+++ b/src/lib/subagents.ts
@@ -1,0 +1,73 @@
+import type Database from "better-sqlite3";
+
+// Subagent tree: every `Task` tool call records a parent→subagent link at ingest
+// (session_links, kind='subagent'). We group those links by the spawning session
+// to render a Session → subagents tree. Powers the subagent-tree widget.
+
+export interface SubagentTask {
+  id: number;
+  label: string | null;
+  child_session_id: string | null;
+  tool_call_id: number | null;
+  created_at: string;
+}
+
+export interface SubagentGroup {
+  session_id: string;
+  project: string;
+  title: string | null;
+  count: number;
+  last_at: string;
+  tasks: SubagentTask[];
+}
+
+interface LinkRow extends SubagentTask {
+  parent_session_id: string;
+  project: string;
+  title: string | null;
+}
+
+export function subagentTree(db: Database.Database, limit = 200): SubagentGroup[] {
+  const rows = db
+    .prepare(
+      `SELECT sl.id,
+              sl.parent_session_id,
+              sl.child_session_id,
+              sl.tool_call_id,
+              sl.label,
+              sl.created_at,
+              COALESCE(NULLIF(s.project_name, ''), '(unknown)') AS project,
+              s.title
+       FROM session_links sl
+       LEFT JOIN sessions s ON s.id = sl.parent_session_id
+       WHERE sl.kind = 'subagent'
+       ORDER BY sl.id DESC
+       LIMIT ?`,
+    )
+    .all(limit) as LinkRow[];
+
+  const groups = new Map<string, SubagentGroup>();
+  for (const r of rows) {
+    let g = groups.get(r.parent_session_id);
+    if (!g) {
+      g = {
+        session_id: r.parent_session_id,
+        project: r.project,
+        title: r.title,
+        count: 0,
+        last_at: r.created_at,
+        tasks: [],
+      };
+      groups.set(r.parent_session_id, g);
+    }
+    g.tasks.push({
+      id: r.id,
+      label: r.label,
+      child_session_id: r.child_session_id,
+      tool_call_id: r.tool_call_id,
+      created_at: r.created_at,
+    });
+    g.count += 1;
+  }
+  return [...groups.values()];
+}

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -17,6 +17,7 @@ import { ProjectLeaderboard } from "./project-leaderboard/widget";
 import { LiveNow } from "./live-now/widget";
 import { PromptHistory } from "./prompt-history/widget";
 import { Streak } from "./streak/widget";
+import { SubagentTree } from "./subagent-tree/widget";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // PLUGIN REGISTRY
@@ -164,5 +165,12 @@ export const widgets: Widget[] = [
     span: "lg:col-span-3",
     height: "h-[360px] min-[2560px]:h-[480px] min-[3840px]:h-[660px]",
     component: Streak,
+  },
+  {
+    id: "subagent-tree",
+    title: "Subagent-Baum",
+    span: "lg:col-span-3",
+    height: "h-[360px] min-[2560px]:h-[480px] min-[3840px]:h-[660px]",
+    component: SubagentTree,
   },
 ];

--- a/src/plugins/subagent-tree/widget.tsx
+++ b/src/plugins/subagent-tree/widget.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Bot, ChevronDown, ChevronRight, GitBranch, Layers } from "lucide-react";
+import { Panel } from "@/components/panel";
+import { WidgetState } from "@/components/widget-state";
+import { useLive } from "@/components/live-provider";
+import { useSearch, matchesQuery } from "@/components/search";
+import { useT } from "@/lib/i18n";
+import { relativeTime } from "@/lib/format";
+import type { SubagentGroup } from "@/lib/subagents";
+
+export function SubagentTree() {
+  const { tick } = useLive();
+  const { query } = useSearch();
+  const { t, lang } = useT();
+  const [groups, setGroups] = useState<SubagentGroup[] | null>(null);
+  const [collapsed, setCollapsed] = useState<Set<string>>(new Set());
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = () =>
+      fetch("/api/subagents?limit=200")
+        .then((r) => r.json())
+        .then((d: { groups: SubagentGroup[] }) => {
+          if (!cancelled) setGroups(d.groups);
+        })
+        .catch(() => {});
+    load();
+    const poll = setInterval(load, 15_000);
+    return () => {
+      cancelled = true;
+      clearInterval(poll);
+    };
+  }, [tick]);
+
+  const toggle = (id: string) =>
+    setCollapsed((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+
+  const filtered = (groups ?? []).filter((g) =>
+    matchesQuery(query, g.title, g.project, ...g.tasks.map((tk) => tk.label)),
+  );
+
+  return (
+    <Panel title={t("subagents.title")} icon={<GitBranch className="h-4 w-4 text-accent" />} info={t("subagents.info")}>
+      {!groups ? (
+        <WidgetState icon={GitBranch} title={t("common.loading")} loading />
+      ) : groups.length === 0 ? (
+        <WidgetState icon={GitBranch} title={t("subagents.empty")} description={t("subagents.emptyHint")} />
+      ) : filtered.length === 0 ? (
+        <WidgetState icon={GitBranch} title={t("common.noResults")} />
+      ) : (
+        <ul className="py-1">
+          {filtered.map((g) => {
+            const open = !collapsed.has(g.session_id);
+            return (
+              <li key={g.session_id} className="mc-stream-in">
+                <button
+                  onClick={() => toggle(g.session_id)}
+                  aria-expanded={open}
+                  className="flex w-full items-center gap-2 px-3 py-2 text-left transition-colors hover:bg-white/[0.03]"
+                >
+                  {open ? (
+                    <ChevronDown className="h-3.5 w-3.5 shrink-0 text-muted" />
+                  ) : (
+                    <ChevronRight className="h-3.5 w-3.5 shrink-0 text-muted" />
+                  )}
+                  <Layers className="h-4 w-4 shrink-0 text-sky-400" />
+                  <span className="min-w-0 flex-1 truncate text-sm text-foreground" title={g.title ?? g.session_id}>
+                    {g.title ?? g.session_id.slice(0, 8)}
+                  </span>
+                  <span className="shrink-0 rounded-full bg-accent/15 px-1.5 py-0.5 text-[10px] font-medium tabular-nums text-accent">
+                    {g.count}
+                  </span>
+                  <span className="hidden shrink-0 truncate font-mono text-[11px] text-muted sm:inline" title={g.project}>
+                    {g.project}
+                  </span>
+                </button>
+                {open && (
+                  <ul className="ml-[19px] border-l border-panel-border/70">
+                    {g.tasks.map((tk) => (
+                      <li key={tk.id} className="flex items-center gap-2 py-1 pl-4 pr-3 text-sm">
+                        <Bot className="h-3.5 w-3.5 shrink-0 text-violet-400" />
+                        <span className="min-w-0 flex-1 truncate text-foreground" title={tk.label ?? undefined}>
+                          {tk.label ?? t("subagents.unnamed")}
+                        </span>
+                        <span className="shrink-0 whitespace-nowrap text-[11px] text-muted">
+                          {relativeTime(tk.created_at, lang)}
+                        </span>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </Panel>
+  );
+}


### PR DESCRIPTION
## Summary
- New **Subagent-Baum / Subagent tree** widget (Run 51): an expandable Session → subagents tree. Each spawning session is a collapsible parent (chevron, count badge, project); expanding reveals the individual `Task` subagents with their labels and timestamps. Integrates with the dashboard-wide search filter.
- This is the first consumer of the `session_links` table (populated since Run 21 but previously unread).
- Adds `/api/subagents`, a `subagentTree` lib (+ unit tests), a `demoSubagents()` source (with a fallback group so the demo always renders), and de/en i18n.

Research note (per standing instruction): tree views use right/down chevrons for collapse/expand, per-level indentation with aligned leading visuals, and icon+text nodes for contrast — all applied here.

## Test plan
- [x] `npm run lint` — clean
- [x] `npx vitest run` — 230 tests pass (new `subagentTree` cases)
- [x] `npm run build` — succeeds (`/api/subagents` route present)
- [x] `npm run test:e2e` — 2 pass, widget `<section>` count bumped 17 → 18

https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk)_