### PR TITLE
Add MCP server widget; restructure roadmap visual-audit phase

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -280,7 +280,7 @@ README/Docs sind nachgezogen.
 95. **API-Doku (OpenAPI).** Alle Lesepfade + den einzigen Schreibpfad
     dokumentieren. *Ergebnis:* offener, integrierbarer Daten-Hub.
 
-## Phase I — Politur, Performance, Release (Runs 96–100)
+## Phase I — Politur & Performance (Runs 96–99)
 
 96. **Barrierefreiheit-Audit.** Voller a11y-Pass (ARIA, Fokus, Kontrast,
     Tastatur) + automatische axe-Checks in CI.
@@ -290,27 +290,60 @@ README/Docs sind nachgezogen.
     Tour) in App + Electron-Tray.
 99. **Doku-Refresh.** README/Architektur/Plugin-Docs auf den neuen Stand;
     Screenshots/GIFs neu; `src/lib/demo.ts` zeigt die neuen Widgets.
-100. ⚙️ **v1.0-Release.** Signierte Installer + Auto-Update, Version-Bump,
-     Changelog, Release-Workflow finalisieren, Pages-Demo mit allen Widgets.
+
+## Phase Z — Visuelle & funktionale Gesamtabnahme (Runs 100–119, **VOR dem Release**)
+
+Erst wenn **jeder** dieser 20 Checks grün ist, wird v1.0 freigegeben. Jeder Run
+nimmt Playwright-Screenshots (De **und** En, Light/Dark, Breiten: Desktop,
+2560px, 3840px, Mobil) auf, prüft das Thema **einzeln** und klickt **jede**
+Interaktion einmal an (jeder Button, jede sortierbare Spalte, jeder Balken,
+jede Zelle, jeder Tooltip). Bilder werden als CI-Artefakte gesammelt; jede
+Abweichung wird als Folge-Fix notiert. Konsole muss frei von Fehlern/Hydration
+sein.
+
+100. 📐 **Layout & Raster.** Abstände, Gutter, Padding, Ausrichtung, gleiche
+     Panel-Höhen, kein Überlauf — über alle Breakpoints.
+101. 🎨 **Farbsystem & Kontrast.** Palette, Akzent-/Statusfarben,
+     Farbenblind-Palette, Dark/Light-Kontrast (WCAG AA) je Widget.
+102. 🔤 **Typografie & Lesbarkeit.** Schriftgrößen, Zeilenhöhe, Truncation/
+     Ellipsis, `tabular-nums`, Mono-Felder, lange Texte/Übersetzungen.
+103. 📊 **KPI-Bar & Übersicht.** Werte, Count-up-Animation, Sparkline,
+     Lade-/Leer-/Fehlerzustände.
+104. 🗂️ **Kanban (Sessions).** Spalten, Karten, Status-Punkte, Filter, Klick
+     auf jede Karte + Drilldown.
+105. 📡 **Live-Stream & Jetzt-live.** SSE-Verbindung, Einlauf-Animation,
+     Pulse/Ping, tickender Timer.
+106. 💸 **Token-/Kosten-Chart.** Achsen, Tooltips, Hover, Legende, Umschalter
+     (Tokens/Kosten, USD/EUR).
+107. 🕸️ **Tool-Graph (3D).** Laden, Drehen/Zoom, Knoten-Klick, Labels,
+     Performance.
+108. ⛽ **Budget-Gauge.** Schwellen-Farben, Anzeige, Überschreitung, Animation.
+109. 🔥 **Heatmap (Aktivität).** Punchcard-Zellen, Farbstufen, p95-Clamp,
+     Tooltip jeder Zelle.
+110. 🛠️ **Top-Tools & Tool-Frequenz.** Balken, Sortierung, Hover — jeden Balken
+     einzeln prüfen.
+111. 🧩 **Datei-Hotspots (Treemap).** Kacheln, Farben, Tooltip, Klick.
+112. ⏱️ **Session-Timeline.** Spuren, Zeitfenster, Zoom/Scroll.
+113. 📈 **Latenz.** Histogramm-Buckets, p50/p95/p99, jeder Balken, Tooltip.
+114. ❗ **Fehlerrate & Fehler-Panel.** Serie, Top-Fehler-Tools, Fehlerliste,
+     Klick.
+115. 🍩 **Modelle-Donut.** Segmente, Legende, Center-Total, Hover jedes Segment.
+116. 🌊 **Sankey-Fluss.** Knoten/Links, Hover, Other-Bucket, Label-Lesbarkeit.
+117. 🏆 **Projekt-Leaderboard.** Sortierbare Spalten (jede Spalte klicken),
+     Medaillen, Hover-Zeilen.
+118. 🔢 **Streak/Produktivität & Subagent-Baum.** Streak-Kacheln, jeder Balken,
+     Auf-/Zuklappen jedes Knotens.
+119. 🔌 **MCP-Server + globale Interaktionen.** MCP-Zeilen/Balken; Sprach- &
+     Theme-Umschalter, Suche filtert alle Widgets, Layout-Reset/Drag, Info-
+     Hints überall; alle `/api/*`-Routen antworten; Demo-Modus zeigt alle
+     Widgets. Abschluss-Sammlung aller Screenshots.
+
+## Phase Ω — Release (Run 120)
+
+120. ⚙️ **v1.0-Release** (erst nach grüner Phase Z). Signierte Installer +
+     Auto-Update, Version-Bump, Changelog, Release-Workflow finalisieren,
+     Pages-Demo mit allen Widgets.
      *Ergebnis:* das beste Claude-Code-Observability-Tool — ausgeliefert.
-
-## Phase Z — Abschluss-Check: visuelle & funktionale Gesamtabnahme (nach allen Widgets)
-
-101. 📸 **Voller Widget-Audit per Playwright.** Wenn alle Widgets stehen: das
-     Dashboard end-to-end durchklicken und visuell abnehmen. Konkret:
-     - Mit Playwright **Screenshots von jedem einzelnen Widget** (`section`)
-       sowie ein Full-Page-Bild in De **und** En, Light/Dark, und auf mehreren
-       Breiten (Desktop, 2560px, 3840px, Mobil) aufnehmen.
-     - **Jedes** Widget visuell prüfen: Layout/Format, kein Überlauf, keine
-       abgeschnittenen Texte, Lade-/Leer-/Fehlerzustände, Animationen.
-     - **Alles anklicken**: sortierbare Spalten, Filter, Drilldowns, Tabs,
-       Tooltips/Info-Hints, Sprach- und Theme-Umschalter, Layout-Reset — jede
-       Interaktion einmal auslösen und auf Konsolen-/Hydrations-Fehler achten.
-     - Funktion bestätigen: SSE verbindet, Live-Daten fließen, Suche filtert,
-       jede `/api/*`-Route antwortet, Demo-Modus zeigt alle Widgets.
-     - Bilder als Artefakte sammeln (CI-Upload), Abweichungen als Folge-Fixes
-       notieren. Abnahme erst grün, wenn jedes Widget geprüft, bebildert und
-       fehlerfrei ist.
 
 ---
 
@@ -326,8 +359,11 @@ README/Docs sind nachgezogen.
 | F | 73–80 | Plugin-Plattform | aus „Registry" wird echtes Ökosystem |
 | G | 81–88 | Alerting | proaktiv, read-only-sicher |
 | H | 89–95 | Integrationen | OTLP/Prometheus/Git — offener Hub |
-| I | 96–100 | Politur & Release | a11y, Performance, v1.0 |
+| I | 96–99 | Politur & Performance | a11y, Performance, Onboarding, Docs |
+| Z | 100–119 | Visuelle & funktionale Gesamtabnahme | 20 Einzel-Checks **vor** Release |
+| Ω | 120 | Release | v1.0 erst nach grüner Phase Z |
 
-**Leitstern:** Nach 100 Runs ist Claude Mission Control das vollständigste,
-am besten gehärtete, lokal-first Observability-Tool für Claude Code — ohne die
-goldene Regel je gebrochen zu haben.
+**Leitstern:** Nach 120 Runs — inklusive einer 20-teiligen visuellen &
+funktionalen Gesamtabnahme **vor** dem Release — ist Claude Mission Control das
+vollständigste, am besten gehärtete, lokal-first Observability-Tool für Claude
+Code — ohne die goldene Regel je gebrochen zu haben.

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -43,8 +43,8 @@ test("dashboard renders all four widgets and connects", async ({ page }) => {
 
   await expect(page.getByRole("heading", { name: "Claude Mission Control" })).toBeVisible();
 
-  // Eighteen widget panels (+ subagent-tree).
-  await expect(page.locator("section")).toHaveCount(18);
+  // Nineteen widget panels (+ mcp-servers).
+  await expect(page.locator("section")).toHaveCount(19);
   // Two titles are identical in both locales — safe to assert regardless of language.
   await expect(page.getByText("Sessions", { exact: true })).toBeVisible();
   await expect(page.getByText("Live Stream", { exact: true })).toBeVisible();

--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from "next/server";
+import { db } from "@/lib/db";
+import { mcpServerUsage } from "@/lib/mcp-servers";
+import { log } from "@/lib/log";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+// Activity per MCP server (call volume, error rate, latency), busiest first.
+export async function GET(req: Request) {
+  const url = new URL(req.url);
+  const limit = Math.min(Math.max(Math.trunc(Number(url.searchParams.get("limit")) || 50), 1), 200);
+  try {
+    return NextResponse.json({ servers: mcpServerUsage(db, limit) });
+  } catch (err) {
+    log.error("/api/mcp failed", err);
+    return NextResponse.json({ servers: [] });
+  }
+}

--- a/src/lib/demo.ts
+++ b/src/lib/demo.ts
@@ -7,6 +7,7 @@ import { latencyStats } from "./latency";
 import { buildSankey, type SankeyTriple } from "./sankey";
 import type { ProjectUsage } from "./projects";
 import type { PromptHistoryItem } from "./prompts";
+import type { McpServerUsage } from "./mcp-servers";
 import { streakStats, peakHour, type DayCount } from "./streak";
 import type { SubagentGroup } from "./subagents";
 import type { EventRow, SessionRow, StreamMessage } from "./types";
@@ -600,6 +601,22 @@ export function demoSubagents() {
   return { groups: groups.reverse() };
 }
 
+export function demoMcp() {
+  const base = [
+    { server: "github", calls: 124, errorRate: 0.04, tools: 9, avgMs: 380 },
+    { server: "notion", calls: 67, errorRate: 0, tools: 5, avgMs: 210 },
+    { server: "supabase", calls: 41, errorRate: 0.12, tools: 7, avgMs: 540 },
+    { server: "playwright", calls: 23, errorRate: 0, tools: 4, avgMs: 95 },
+  ];
+  const now = dbNow();
+  const servers: McpServerUsage[] = base.map((b) => ({
+    ...b,
+    failures: Math.round(b.calls * b.errorRate),
+    last_at: now,
+  }));
+  return { servers };
+}
+
 export function demoSubscribe(fn: (m: StreamMessage) => void) {
   listeners.add(fn);
   return () => listeners.delete(fn);
@@ -630,6 +647,7 @@ export function installDemoBackend() {
     if (path.endsWith("/api/prompts")) return json(demoPrompts());
     if (path.endsWith("/api/streak")) return json(demoStreak());
     if (path.endsWith("/api/subagents")) return json(demoSubagents());
+    if (path.endsWith("/api/mcp")) return json(demoMcp());
     if (path.endsWith("/api/budget")) return json(demoBudget());
     if (path.endsWith("/api/stats")) return json(demoStats());
     if (path.endsWith("/api/activity")) return json(demoActivity());

--- a/src/lib/i18n.tsx
+++ b/src/lib/i18n.tsx
@@ -168,6 +168,13 @@ const DE: Record<string, string> = {
   "subagents.emptyHint": "Sobald Claude einen Task-Subagenten startet, erscheint er hier.",
   "subagents.unnamed": "Unbenannter Subagent",
 
+  "mcp.title": "MCP-Server",
+  "mcp.info": "Aktivität je MCP-Server: Aufrufe, Fehlerrate und mittlere Latenz.",
+  "mcp.empty": "Noch keine MCP-Aufrufe.",
+  "mcp.emptyHint": "Sobald ein MCP-Tool (mcp__…) läuft, erscheint sein Server hier.",
+  "mcp.errors": "Fehler",
+  "mcp.tools": "Tools",
+
   "search.label": "Sessions und Events durchsuchen",
   "search.placeholder": "Suchen…",
   "search.clear": "Suche löschen",
@@ -397,6 +404,13 @@ const EN: Record<string, string> = {
   "subagents.empty": "No subagents yet.",
   "subagents.emptyHint": "As soon as Claude launches a Task subagent, it shows up here.",
   "subagents.unnamed": "Unnamed subagent",
+
+  "mcp.title": "MCP servers",
+  "mcp.info": "Activity per MCP server: calls, error rate and average latency.",
+  "mcp.empty": "No MCP calls yet.",
+  "mcp.emptyHint": "As soon as an MCP tool (mcp__…) runs, its server appears here.",
+  "mcp.errors": "errors",
+  "mcp.tools": "tools",
 
   "search.label": "Search sessions and events",
   "search.placeholder": "Search…",

--- a/src/lib/mcp-servers.test.ts
+++ b/src/lib/mcp-servers.test.ts
@@ -1,0 +1,52 @@
+import Database from "better-sqlite3";
+import { afterEach, describe, expect, it } from "vitest";
+import { migrate } from "@/lib/migrations";
+import { mcpServerUsage } from "@/lib/mcp-servers";
+
+let open: Database.Database | null = null;
+afterEach(() => {
+  open?.close();
+  open = null;
+});
+
+function seed(): Database.Database {
+  const db = (open = new Database(":memory:"));
+  migrate(db);
+  const ins = db.prepare(
+    `INSERT INTO tool_calls (session_id, tool_name, duration_ms, success, source, mcp_server)
+     VALUES (?, ?, ?, ?, ?, ?)`,
+  );
+  // github: 3 calls, 1 failure, 2 distinct tools
+  ins.run("s1", "create_pr", 100, 1, "mcp", "github");
+  ins.run("s1", "create_pr", 300, 0, "mcp", "github");
+  ins.run("s1", "list_issues", 200, 1, "mcp", "github");
+  // notion: 1 call, no failures
+  ins.run("s1", "search", 50, 1, "mcp", "notion");
+  // builtin calls must be ignored
+  ins.run("s1", "Read", 10, 1, "builtin", null);
+  return db;
+}
+
+describe("mcpServerUsage", () => {
+  it("aggregates per server, busiest first, ignoring builtin calls", () => {
+    const rows = mcpServerUsage(seed());
+    expect(rows.map((r) => r.server)).toEqual(["github", "notion"]);
+    const gh = rows.find((r) => r.server === "github")!;
+    expect(gh.calls).toBe(3);
+    expect(gh.failures).toBe(1);
+    expect(gh.errorRate).toBeCloseTo(1 / 3);
+    expect(gh.tools).toBe(2);
+    expect(gh.avgMs).toBe(200); // (100+300+200)/3
+  });
+
+  it("reports a zero error rate for a clean server", () => {
+    const rows = mcpServerUsage(seed());
+    expect(rows.find((r) => r.server === "notion")!.errorRate).toBe(0);
+  });
+
+  it("returns an empty array when there are no MCP calls", () => {
+    const db = (open = new Database(":memory:"));
+    migrate(db);
+    expect(mcpServerUsage(db)).toEqual([]);
+  });
+});

--- a/src/lib/mcp-servers.ts
+++ b/src/lib/mcp-servers.ts
@@ -1,0 +1,48 @@
+import type Database from "better-sqlite3";
+
+// Per-MCP-server rollup over tool_calls (source='mcp'): call volume, error rate,
+// average latency, distinct tools and last use. Powers the MCP-server widget.
+export interface McpServerUsage {
+  server: string;
+  calls: number;
+  failures: number;
+  errorRate: number; // 0..1
+  tools: number;
+  avgMs: number;
+  last_at: string;
+}
+
+export function mcpServerUsage(db: Database.Database, limit = 50): McpServerUsage[] {
+  const rows = db
+    .prepare(
+      `SELECT mcp_server AS server,
+              COUNT(*) AS calls,
+              SUM(CASE WHEN success = 0 THEN 1 ELSE 0 END) AS failures,
+              COUNT(DISTINCT tool_name) AS tools,
+              AVG(duration_ms) AS avgMs,
+              MAX(created_at) AS last_at
+       FROM tool_calls
+       WHERE source = 'mcp' AND mcp_server IS NOT NULL AND mcp_server <> ''
+       GROUP BY server
+       ORDER BY calls DESC, server ASC
+       LIMIT ?`,
+    )
+    .all(limit) as {
+    server: string;
+    calls: number;
+    failures: number;
+    tools: number;
+    avgMs: number | null;
+    last_at: string;
+  }[];
+
+  return rows.map((r) => ({
+    server: r.server,
+    calls: r.calls,
+    failures: r.failures,
+    errorRate: r.calls ? r.failures / r.calls : 0,
+    tools: r.tools,
+    avgMs: Math.round(r.avgMs ?? 0),
+    last_at: r.last_at,
+  }));
+}

--- a/src/plugins/mcp-servers/widget.tsx
+++ b/src/plugins/mcp-servers/widget.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Plug } from "lucide-react";
+import { Panel } from "@/components/panel";
+import { WidgetState } from "@/components/widget-state";
+import { useLive } from "@/components/live-provider";
+import { useSearch, matchesQuery } from "@/components/search";
+import { useT } from "@/lib/i18n";
+import { formatCompact, relativeTime } from "@/lib/format";
+import { formatMs } from "@/lib/latency";
+import type { McpServerUsage } from "@/lib/mcp-servers";
+
+function errorColor(rate: number): string {
+  if (rate <= 0) return "text-emerald-400";
+  if (rate < 0.1) return "text-amber-400";
+  return "text-red-400";
+}
+
+export function McpServers() {
+  const { tick } = useLive();
+  const { query } = useSearch();
+  const { t, lang } = useT();
+  const [servers, setServers] = useState<McpServerUsage[] | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = () =>
+      fetch("/api/mcp?limit=50")
+        .then((r) => r.json())
+        .then((d: { servers: McpServerUsage[] }) => {
+          if (!cancelled) setServers(d.servers);
+        })
+        .catch(() => {});
+    load();
+    const poll = setInterval(load, 15_000);
+    return () => {
+      cancelled = true;
+      clearInterval(poll);
+    };
+  }, [tick]);
+
+  const filtered = (servers ?? []).filter((s) => matchesQuery(query, s.server));
+  const max = filtered.reduce((m, s) => Math.max(m, s.calls), 0) || 1;
+
+  return (
+    <Panel title={t("mcp.title")} icon={<Plug className="h-4 w-4 text-accent" />} info={t("mcp.info")}>
+      {!servers ? (
+        <WidgetState icon={Plug} title={t("common.loading")} loading />
+      ) : servers.length === 0 ? (
+        <WidgetState icon={Plug} title={t("mcp.empty")} description={t("mcp.emptyHint")} />
+      ) : filtered.length === 0 ? (
+        <WidgetState icon={Plug} title={t("common.noResults")} />
+      ) : (
+        <ul className="divide-y divide-panel-border/60">
+          {filtered.map((s) => (
+            <li key={s.server} className="mc-stream-in px-4 py-2.5">
+              <div className="flex items-center gap-2">
+                <Plug className="h-3.5 w-3.5 shrink-0 text-sky-400" />
+                <span className="min-w-0 flex-1 truncate font-mono text-sm text-foreground" title={s.server}>
+                  {s.server}
+                </span>
+                <span className="shrink-0 rounded-full bg-accent/15 px-1.5 py-0.5 text-[10px] font-medium tabular-nums text-accent">
+                  {formatCompact(s.calls)}
+                </span>
+              </div>
+              <div className="mt-1.5 h-1.5 w-full overflow-hidden rounded-full bg-white/[0.05]">
+                <div className="h-full rounded-full bg-accent/70" style={{ width: `${(s.calls / max) * 100}%` }} />
+              </div>
+              <div className="mt-1.5 flex items-center gap-2 text-[11px] text-muted">
+                <span className={`tabular-nums ${errorColor(s.errorRate)}`}>
+                  {(s.errorRate * 100).toFixed(s.errorRate > 0 && s.errorRate < 0.1 ? 1 : 0)}% {t("mcp.errors")}
+                </span>
+                <span aria-hidden>·</span>
+                <span className="tabular-nums">{formatMs(s.avgMs)}</span>
+                <span aria-hidden>·</span>
+                <span className="tabular-nums">
+                  {s.tools} {t("mcp.tools")}
+                </span>
+                <span className="ml-auto shrink-0 whitespace-nowrap">{relativeTime(s.last_at, lang)}</span>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </Panel>
+  );
+}

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -18,6 +18,7 @@ import { LiveNow } from "./live-now/widget";
 import { PromptHistory } from "./prompt-history/widget";
 import { Streak } from "./streak/widget";
 import { SubagentTree } from "./subagent-tree/widget";
+import { McpServers } from "./mcp-servers/widget";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // PLUGIN REGISTRY
@@ -172,5 +173,12 @@ export const widgets: Widget[] = [
     span: "lg:col-span-3",
     height: "h-[360px] min-[2560px]:h-[480px] min-[3840px]:h-[660px]",
     component: SubagentTree,
+  },
+  {
+    id: "mcp-servers",
+    title: "MCP-Server",
+    span: "lg:col-span-3",
+    height: "h-[360px] min-[2560px]:h-[480px] min-[3840px]:h-[660px]",
+    component: McpServers,
   },
 ];


### PR DESCRIPTION
## Summary
- New **MCP-Server / MCP servers** widget (Run 52): activity per MCP server using the RED method — call volume (with a relative bar), error rate (threshold-coloured: green/amber/red), average latency, distinct tool count and last use, busiest first. Reads `tool_calls` where `source='mcp'`. Integrates with the dashboard-wide search filter.
- Adds `/api/mcp`, an `mcpServerUsage` lib (+ unit tests), a `demoMcp()` source, and de/en i18n.
- **Roadmap restructure** (per your correction): the visual & functional audit now runs **before** the release as **20 dedicated single-topic check runs** (Phase Z, runs 100–119) — spacing, colour/contrast, readability, and each visualization individually, with every button/sortable column/bar/cell/tooltip clicked, screenshots in de/en × light/dark × multiple widths. The v1.0 release moves to run 120 and is gated on Phase Z passing. Overview table + Leitstern updated.

Research note (per standing instruction): per-service monitoring panels favour the RED method (rate/errors/duration), one row per service, and green-good/red-bad threshold colours — all applied here.

## Test plan
- [x] `npm run lint` — clean
- [x] `npx vitest run` — 233 tests pass (new `mcpServerUsage` cases)
- [x] `npm run build` — succeeds (`/api/mcp` route present)
- [x] `npm run test:e2e` — 2 pass, widget `<section>` count bumped 18 → 19

https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk)_