### PR TITLE
Add topic/tag cloud and token-burn-per-tool widgets

### DIFF
--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -43,8 +43,8 @@ test("dashboard renders all four widgets and connects", async ({ page }) => {
 
   await expect(page.getByRole("heading", { name: "Claude Mission Control" })).toBeVisible();
 
-  // Twenty-one widget panels (+ tag-cloud).
-  await expect(page.locator("section")).toHaveCount(21);
+  // Twenty-two widget panels (+ token-burn).
+  await expect(page.locator("section")).toHaveCount(22);
   // Two titles are identical in both locales — safe to assert regardless of language.
   await expect(page.getByText("Sessions", { exact: true })).toBeVisible();
   await expect(page.getByText("Live Stream", { exact: true })).toBeVisible();

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -43,8 +43,8 @@ test("dashboard renders all four widgets and connects", async ({ page }) => {
 
   await expect(page.getByRole("heading", { name: "Claude Mission Control" })).toBeVisible();
 
-  // Twenty widget panels (+ compaction-timeline).
-  await expect(page.locator("section")).toHaveCount(20);
+  // Twenty-one widget panels (+ tag-cloud).
+  await expect(page.locator("section")).toHaveCount(21);
   // Two titles are identical in both locales — safe to assert regardless of language.
   await expect(page.getByText("Sessions", { exact: true })).toBeVisible();
   await expect(page.getByText("Live Stream", { exact: true })).toBeVisible();

--- a/src/app/api/tags/route.ts
+++ b/src/app/api/tags/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from "next/server";
+import { db } from "@/lib/db";
+import { promptHistory } from "@/lib/prompts";
+import { topTerms } from "@/lib/tags";
+import { log } from "@/lib/log";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+// Topic/tag cloud: frequent terms extracted locally from prompt text (no LLM).
+export async function GET(req: Request) {
+  const url = new URL(req.url);
+  const limit = Math.min(Math.max(Math.trunc(Number(url.searchParams.get("limit")) || 40), 1), 200);
+  try {
+    const prompts = promptHistory(db, 500);
+    return NextResponse.json({ terms: topTerms(prompts.map((p) => p.text ?? ""), limit) });
+  } catch (err) {
+    log.error("/api/tags failed", err);
+    return NextResponse.json({ terms: [] });
+  }
+}

--- a/src/app/api/token-burn/route.ts
+++ b/src/app/api/token-burn/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from "next/server";
+import { db } from "@/lib/db";
+import { toolTokenBurn } from "@/lib/token-burn";
+import { log } from "@/lib/log";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+// Estimated token burn per tool (from tool I/O size), biggest first.
+export async function GET(req: Request) {
+  const url = new URL(req.url);
+  const limit = Math.min(Math.max(Math.trunc(Number(url.searchParams.get("limit")) || 8), 1), 50);
+  try {
+    return NextResponse.json({ tools: toolTokenBurn(db, limit) });
+  } catch (err) {
+    log.error("/api/token-burn failed", err);
+    return NextResponse.json({ tools: [] });
+  }
+}

--- a/src/lib/demo.ts
+++ b/src/lib/demo.ts
@@ -11,6 +11,7 @@ import type { Compaction } from "./compaction";
 import type { McpServerUsage } from "./mcp-servers";
 import { streakStats, peakHour, type DayCount } from "./streak";
 import { topTerms } from "./tags";
+import type { ToolTokenBurn } from "./token-burn";
 import type { SubagentGroup } from "./subagents";
 import type { EventRow, SessionRow, StreamMessage } from "./types";
 
@@ -664,6 +665,20 @@ export function demoTags() {
   return { terms };
 }
 
+export function demoTokenBurn() {
+  const base = [
+    { tool: "Read", tokens: 184_000, calls: 142 },
+    { tool: "Edit", tokens: 96_000, calls: 88 },
+    { tool: "Bash", tokens: 71_000, calls: 130 },
+    { tool: "Grep", tokens: 38_000, calls: 64 },
+    { tool: "Write", tokens: 22_000, calls: 31 },
+    { tool: "WebFetch", tokens: 14_000, calls: 12 },
+  ];
+  const total = base.reduce((a, t) => a + t.tokens, 0) || 1;
+  const tools: ToolTokenBurn[] = base.map((t) => ({ ...t, share: t.tokens / total }));
+  return { tools };
+}
+
 export function demoSubscribe(fn: (m: StreamMessage) => void) {
   listeners.add(fn);
   return () => listeners.delete(fn);
@@ -697,6 +712,7 @@ export function installDemoBackend() {
     if (path.endsWith("/api/mcp")) return json(demoMcp());
     if (path.endsWith("/api/compactions")) return json(demoCompactions());
     if (path.endsWith("/api/tags")) return json(demoTags());
+    if (path.endsWith("/api/token-burn")) return json(demoTokenBurn());
     if (path.endsWith("/api/budget")) return json(demoBudget());
     if (path.endsWith("/api/stats")) return json(demoStats());
     if (path.endsWith("/api/activity")) return json(demoActivity());

--- a/src/lib/demo.ts
+++ b/src/lib/demo.ts
@@ -10,6 +10,7 @@ import type { PromptHistoryItem } from "./prompts";
 import type { Compaction } from "./compaction";
 import type { McpServerUsage } from "./mcp-servers";
 import { streakStats, peakHour, type DayCount } from "./streak";
+import { topTerms } from "./tags";
 import type { SubagentGroup } from "./subagents";
 import type { EventRow, SessionRow, StreamMessage } from "./types";
 
@@ -638,6 +639,31 @@ export function demoCompactions() {
   return { compactions: out };
 }
 
+export function demoTags() {
+  const texts: string[] = [];
+  for (const s of sessions) for (const p of s.prompts) texts.push(p.text);
+  const terms = topTerms(texts, 40);
+  // Seed a richer cloud if the demo hasn't accumulated enough prompts yet.
+  if (terms.length < 8) {
+    return {
+      terms: topTerms(
+        [
+          "refactor the ingest pipeline and add retention tests",
+          "build the dashboard widget registry and plugins",
+          "improve token cost tracking and budget gauge",
+          "fix the sankey flow chart colors and tooltips",
+          "add subagent tree and mcp server panel",
+          "compaction timeline and prompt history widgets",
+          "session timeline latency heatmap error rate",
+          "playwright screenshots visual audit readability",
+        ],
+        40,
+      ),
+    };
+  }
+  return { terms };
+}
+
 export function demoSubscribe(fn: (m: StreamMessage) => void) {
   listeners.add(fn);
   return () => listeners.delete(fn);
@@ -670,6 +696,7 @@ export function installDemoBackend() {
     if (path.endsWith("/api/subagents")) return json(demoSubagents());
     if (path.endsWith("/api/mcp")) return json(demoMcp());
     if (path.endsWith("/api/compactions")) return json(demoCompactions());
+    if (path.endsWith("/api/tags")) return json(demoTags());
     if (path.endsWith("/api/budget")) return json(demoBudget());
     if (path.endsWith("/api/stats")) return json(demoStats());
     if (path.endsWith("/api/activity")) return json(demoActivity());

--- a/src/lib/i18n.tsx
+++ b/src/lib/i18n.tsx
@@ -187,6 +187,11 @@ const DE: Record<string, string> = {
   "compaction.trigger.auto": "auto",
   "compaction.trigger.manual": "manuell",
 
+  "tags.title": "Themen-Cloud",
+  "tags.info": "Häufige Begriffe aus deinen Prompts – lokal berechnet, ohne LLM. Größe = Häufigkeit.",
+  "tags.empty": "Noch keine Begriffe.",
+  "tags.emptyHint": "Sobald du Prompts schreibst, erscheinen die häufigsten Begriffe hier.",
+
   "search.label": "Sessions und Events durchsuchen",
   "search.placeholder": "Suchen…",
   "search.clear": "Suche löschen",
@@ -435,6 +440,11 @@ const EN: Record<string, string> = {
   "compaction.perDay": "Per day (14d)",
   "compaction.trigger.auto": "auto",
   "compaction.trigger.manual": "manual",
+
+  "tags.title": "Topic cloud",
+  "tags.info": "Frequent terms from your prompts — computed locally, no LLM. Size = frequency.",
+  "tags.empty": "No terms yet.",
+  "tags.emptyHint": "As soon as you write prompts, the most frequent terms appear here.",
 
   "search.label": "Search sessions and events",
   "search.placeholder": "Search…",

--- a/src/lib/i18n.tsx
+++ b/src/lib/i18n.tsx
@@ -192,6 +192,10 @@ const DE: Record<string, string> = {
   "tags.empty": "Noch keine Begriffe.",
   "tags.emptyHint": "Sobald du Prompts schreibst, erscheinen die häufigsten Begriffe hier.",
 
+  "burn.title": "Token-Verbrauch je Tool",
+  "burn.info": "Wo die meisten Tokens verbrennen – geschätzt aus der Tool-I/O-Größe (Zeichen ÷ 4).",
+  "burn.empty": "Noch keine Tool-Daten.",
+
   "search.label": "Sessions und Events durchsuchen",
   "search.placeholder": "Suchen…",
   "search.clear": "Suche löschen",
@@ -445,6 +449,10 @@ const EN: Record<string, string> = {
   "tags.info": "Frequent terms from your prompts — computed locally, no LLM. Size = frequency.",
   "tags.empty": "No terms yet.",
   "tags.emptyHint": "As soon as you write prompts, the most frequent terms appear here.",
+
+  "burn.title": "Token burn per tool",
+  "burn.info": "Where most tokens burn — estimated from tool I/O size (chars ÷ 4).",
+  "burn.empty": "No tool data yet.",
 
   "search.label": "Search sessions and events",
   "search.placeholder": "Search…",

--- a/src/lib/tags.test.ts
+++ b/src/lib/tags.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { topTerms } from "@/lib/tags";
+
+describe("topTerms", () => {
+  it("counts terms, sorted by frequency then name", () => {
+    const terms = topTerms([
+      "Refactor the ingest pipeline",
+      "ingest pipeline cleanup",
+      "ingest tests",
+    ]);
+    expect(terms[0]).toEqual({ term: "ingest", count: 3 });
+    expect(terms.find((t) => t.term === "pipeline")?.count).toBe(2);
+  });
+
+  it("drops stop words, short tokens and pure numbers", () => {
+    const terms = topTerms(["the widget is 42 ok"]);
+    const words = terms.map((t) => t.term);
+    expect(words).toContain("widget");
+    expect(words).not.toContain("the"); // stop word
+    expect(words).not.toContain("is"); // stop word + short
+    expect(words).not.toContain("ok"); // too short (< 3)
+    expect(words).not.toContain("42"); // pure number
+  });
+
+  it("handles German stop words and umlauts", () => {
+    const terms = topTerms(["Bitte die Übersicht für das Widget verbessern"]);
+    const words = terms.map((t) => t.term);
+    expect(words).toContain("übersicht");
+    expect(words).toContain("widget");
+    expect(words).toContain("verbessern");
+    expect(words).not.toContain("bitte");
+    expect(words).not.toContain("die");
+  });
+
+  it("respects the limit and tolerates empty input", () => {
+    expect(topTerms([])).toEqual([]);
+    expect(topTerms(["alpha beta gamma delta"], 2)).toHaveLength(2);
+  });
+});

--- a/src/lib/tags.ts
+++ b/src/lib/tags.ts
@@ -1,0 +1,42 @@
+// Local, LLM-free keyword extraction from prompt text for the topic/tag cloud.
+// Lowercase, split on non-word chars, drop stop words / pure numbers / short
+// tokens, then count. German + English stop words since prompts are mixed.
+
+export interface TermCount {
+  term: string;
+  count: number;
+}
+
+const STOP = new Set<string>([
+  // German
+  "der", "die", "das", "und", "oder", "aber", "ist", "sind", "war", "wird", "werden", "wurde",
+  "ein", "eine", "einen", "einem", "einer", "eines", "den", "dem", "des", "auf", "für", "mit",
+  "von", "vom", "zum", "zur", "aus", "bei", "nach", "über", "unter", "auch", "noch", "schon",
+  "nur", "nicht", "kein", "keine", "man", "ich", "wir", "ihr", "sie", "mir", "mich", "dich",
+  "dir", "uns", "euch", "ihn", "ihm", "hier", "dort", "dann", "wenn", "weil", "dass", "als",
+  "wie", "was", "wer", "wo", "wann", "warum", "soll", "sollte", "kann", "könnte", "muss",
+  "mach", "mache", "machen", "bitte", "alle", "alles", "dem", "im", "am", "an", "zu", "so",
+  // English
+  "the", "and", "for", "are", "was", "were", "with", "from", "this", "that", "these", "those",
+  "you", "your", "our", "their", "its", "have", "has", "had", "will", "would", "could", "should",
+  "can", "may", "might", "must", "not", "but", "all", "any", "into", "out", "off", "over",
+  "then", "than", "when", "where", "what", "which", "who", "why", "how", "please", "make",
+  "use", "using", "add", "let", "get", "set", "run", "new", "via", "per", "also", "just",
+]);
+
+export function topTerms(texts: string[], limit = 40, minLen = 3): TermCount[] {
+  const counts = new Map<string, number>();
+  for (const text of texts) {
+    if (!text) continue;
+    for (const raw of text.toLowerCase().split(/[^a-z0-9äöüß]+/)) {
+      if (raw.length < minLen) continue;
+      if (STOP.has(raw)) continue;
+      if (/^\d+$/.test(raw)) continue;
+      counts.set(raw, (counts.get(raw) ?? 0) + 1);
+    }
+  }
+  return [...counts.entries()]
+    .map(([term, count]) => ({ term, count }))
+    .sort((a, b) => b.count - a.count || a.term.localeCompare(b.term))
+    .slice(0, limit);
+}

--- a/src/lib/token-burn.test.ts
+++ b/src/lib/token-burn.test.ts
@@ -1,0 +1,52 @@
+import Database from "better-sqlite3";
+import { afterEach, describe, expect, it } from "vitest";
+import { migrate } from "@/lib/migrations";
+import { toolTokenBurn } from "@/lib/token-burn";
+
+let open: Database.Database | null = null;
+afterEach(() => {
+  open?.close();
+  open = null;
+});
+
+function seed(): Database.Database {
+  const db = (open = new Database(":memory:"));
+  migrate(db);
+  const tc = db.prepare(`INSERT INTO tool_calls (session_id, tool_name) VALUES (?, ?)`);
+  const io = db.prepare(
+    `INSERT INTO tool_io (tool_call_id, input_json, output_json, is_error) VALUES (?, ?, ?, 0)`,
+  );
+  // Read: small input, large output (8 + 400 chars => 102 tokens)
+  const r1 = tc.run("s1", "Read");
+  io.run(Number(r1.lastInsertRowid), "x".repeat(8), "y".repeat(400));
+  // Bash: medium (40 + 40 => 20 tokens)
+  const r2 = tc.run("s1", "Bash");
+  io.run(Number(r2.lastInsertRowid), "z".repeat(40), "w".repeat(40));
+  // Grep: a call with no I/O row at all (0 tokens)
+  tc.run("s1", "Grep");
+  return db;
+}
+
+describe("toolTokenBurn", () => {
+  it("estimates tokens from I/O size, biggest first, with shares", () => {
+    const tools = toolTokenBurn(seed());
+    expect(tools[0].tool).toBe("Read");
+    expect(tools[0].tokens).toBe(102); // ceil(408/4)
+    const bash = tools.find((t) => t.tool === "Bash")!;
+    expect(bash.tokens).toBe(20); // ceil(80/4)
+    // Shares sum to ~1 across the returned (here all) tools.
+    const sum = tools.reduce((a, t) => a + t.share, 0);
+    expect(sum).toBeCloseTo(1);
+  });
+
+  it("counts calls and tolerates missing I/O", () => {
+    const tools = toolTokenBurn(seed());
+    const grep = tools.find((t) => t.tool === "Grep")!;
+    expect(grep.calls).toBe(1);
+    expect(grep.tokens).toBe(0);
+  });
+
+  it("respects the limit", () => {
+    expect(toolTokenBurn(seed(), 1)).toHaveLength(1);
+  });
+});

--- a/src/lib/token-burn.ts
+++ b/src/lib/token-burn.ts
@@ -1,0 +1,38 @@
+import type Database from "better-sqlite3";
+
+// "Where do tokens burn?" — we don't store per-tool token counts, but each tool
+// call's I/O is persisted (tool_io). The size of that I/O (chars / 4) is a solid
+// proxy for the context a tool pushes through the model. Aggregated per tool and
+// expressed as a share of the total. Estimate, clearly labelled as such in the UI.
+
+export interface ToolTokenBurn {
+  tool: string;
+  calls: number;
+  tokens: number; // estimated from I/O size
+  share: number; // 0..1 of total estimated tokens
+}
+
+export function toolTokenBurn(db: Database.Database, limit = 8): ToolTokenBurn[] {
+  const rows = db
+    .prepare(
+      `SELECT tc.tool_name AS tool,
+              COUNT(*) AS calls,
+              SUM(COALESCE(LENGTH(io.input_json), 0) + COALESCE(LENGTH(io.output_json), 0)) AS chars
+       FROM tool_calls tc
+       LEFT JOIN tool_io io ON io.tool_call_id = tc.id
+       GROUP BY tc.tool_name`,
+    )
+    .all() as { tool: string; calls: number; chars: number | null }[];
+
+  const withTokens = rows.map((r) => ({
+    tool: r.tool,
+    calls: r.calls,
+    tokens: Math.ceil((r.chars ?? 0) / 4),
+  }));
+  const total = withTokens.reduce((a, r) => a + r.tokens, 0) || 1;
+
+  return withTokens
+    .sort((a, b) => b.tokens - a.tokens || a.tool.localeCompare(b.tool))
+    .slice(0, limit)
+    .map((r) => ({ ...r, share: r.tokens / total }));
+}

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -21,6 +21,7 @@ import { SubagentTree } from "./subagent-tree/widget";
 import { McpServers } from "./mcp-servers/widget";
 import { CompactionTimeline } from "./compaction-timeline/widget";
 import { TagCloud } from "./tag-cloud/widget";
+import { TokenBurn } from "./token-burn/widget";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // PLUGIN REGISTRY
@@ -196,5 +197,12 @@ export const widgets: Widget[] = [
     span: "lg:col-span-3",
     height: "h-[360px] min-[2560px]:h-[480px] min-[3840px]:h-[660px]",
     component: TagCloud,
+  },
+  {
+    id: "token-burn",
+    title: "Token-Verbrauch je Tool",
+    span: "lg:col-span-3",
+    height: "h-[360px] min-[2560px]:h-[480px] min-[3840px]:h-[660px]",
+    component: TokenBurn,
   },
 ];

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -20,6 +20,7 @@ import { Streak } from "./streak/widget";
 import { SubagentTree } from "./subagent-tree/widget";
 import { McpServers } from "./mcp-servers/widget";
 import { CompactionTimeline } from "./compaction-timeline/widget";
+import { TagCloud } from "./tag-cloud/widget";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // PLUGIN REGISTRY
@@ -188,5 +189,12 @@ export const widgets: Widget[] = [
     span: "lg:col-span-3",
     height: "h-[360px] min-[2560px]:h-[480px] min-[3840px]:h-[660px]",
     component: CompactionTimeline,
+  },
+  {
+    id: "tag-cloud",
+    title: "Themen-Cloud",
+    span: "lg:col-span-3",
+    height: "h-[360px] min-[2560px]:h-[480px] min-[3840px]:h-[660px]",
+    component: TagCloud,
   },
 ];

--- a/src/plugins/tag-cloud/widget.tsx
+++ b/src/plugins/tag-cloud/widget.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Hash } from "lucide-react";
+import { Panel } from "@/components/panel";
+import { WidgetState } from "@/components/widget-state";
+import { useLive } from "@/components/live-provider";
+import { useSearch, matchesQuery } from "@/components/search";
+import { useT } from "@/lib/i18n";
+import type { TermCount } from "@/lib/tags";
+
+export function TagCloud() {
+  const { tick } = useLive();
+  const { query } = useSearch();
+  const { t } = useT();
+  const [terms, setTerms] = useState<TermCount[] | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = () =>
+      fetch("/api/tags?limit=40")
+        .then((r) => r.json())
+        .then((d: { terms: TermCount[] }) => {
+          if (!cancelled) setTerms(d.terms);
+        })
+        .catch(() => {});
+    load();
+    const poll = setInterval(load, 15_000);
+    return () => {
+      cancelled = true;
+      clearInterval(poll);
+    };
+  }, [tick]);
+
+  const filtered = (terms ?? []).filter((t) => matchesQuery(query, t.term));
+  const max = filtered.reduce((m, t) => Math.max(m, t.count), 0) || 1;
+  const min = filtered.reduce((m, t) => Math.min(m, t.count), max);
+
+  // 0..1 weight; size and font-weight both encode frequency (stronger than colour alone).
+  const scale = (c: number) => (max === min ? 0.5 : (c - min) / (max - min));
+
+  return (
+    <Panel title={t("tags.title")} icon={<Hash className="h-4 w-4 text-accent" />} info={t("tags.info")}>
+      {!terms ? (
+        <WidgetState icon={Hash} title={t("common.loading")} loading />
+      ) : terms.length === 0 ? (
+        <WidgetState icon={Hash} title={t("tags.empty")} description={t("tags.emptyHint")} />
+      ) : filtered.length === 0 ? (
+        <WidgetState icon={Hash} title={t("common.noResults")} />
+      ) : (
+        <div className="flex h-full flex-wrap content-start items-baseline gap-x-3 gap-y-1.5 overflow-auto p-4 leading-tight">
+          {filtered.map((tc) => {
+            const s = scale(tc.count);
+            return (
+              <span
+                key={tc.term}
+                title={`${tc.term}: ${tc.count}`}
+                className="cursor-default whitespace-nowrap transition-colors hover:text-accent"
+                style={{
+                  fontSize: `${0.72 + s * 1.0}rem`,
+                  fontWeight: 400 + Math.round(s * 3) * 100,
+                  color: `color-mix(in oklab, var(--color-accent) ${Math.round(40 + s * 60)}%, var(--color-muted))`,
+                }}
+              >
+                {tc.term}
+              </span>
+            );
+          })}
+        </div>
+      )}
+    </Panel>
+  );
+}

--- a/src/plugins/token-burn/widget.tsx
+++ b/src/plugins/token-burn/widget.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Flame } from "lucide-react";
+import { Panel } from "@/components/panel";
+import { WidgetState } from "@/components/widget-state";
+import { useLive } from "@/components/live-provider";
+import { useT } from "@/lib/i18n";
+import { formatCompact } from "@/lib/format";
+import type { ToolTokenBurn } from "@/lib/token-burn";
+
+export function TokenBurn() {
+  const { tick } = useLive();
+  const { t } = useT();
+  const [tools, setTools] = useState<ToolTokenBurn[] | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = () =>
+      fetch("/api/token-burn?limit=8")
+        .then((r) => r.json())
+        .then((d: { tools: ToolTokenBurn[] }) => {
+          if (!cancelled) setTools(d.tools);
+        })
+        .catch(() => {});
+    load();
+    const poll = setInterval(load, 15_000);
+    return () => {
+      cancelled = true;
+      clearInterval(poll);
+    };
+  }, [tick]);
+
+  const empty = tools && (tools.length === 0 || tools.every((t) => t.tokens === 0));
+  const max = (tools ?? []).reduce((m, t) => Math.max(m, t.tokens), 0) || 1;
+
+  return (
+    <Panel title={t("burn.title")} icon={<Flame className="h-4 w-4 text-accent" />} info={t("burn.info")}>
+      {!tools ? (
+        <WidgetState icon={Flame} title={t("common.loading")} loading />
+      ) : empty ? (
+        <WidgetState icon={Flame} title={t("burn.empty")} />
+      ) : (
+        <ul className="flex h-full flex-col justify-center gap-2.5 p-4">
+          {tools.map((tool) => (
+            <li key={tool.tool} className="mc-stream-in">
+              <div className="mb-0.5 flex items-baseline justify-between gap-2 text-xs">
+                <span className="truncate font-mono text-foreground" title={tool.tool}>
+                  {tool.tool}
+                </span>
+                <span className="shrink-0 tabular-nums text-muted">
+                  <span className="text-foreground">~{formatCompact(tool.tokens)}</span> ·{" "}
+                  {(tool.share * 100).toFixed(0)}% · {tool.calls}×
+                </span>
+              </div>
+              <div className="h-2 w-full overflow-hidden rounded-full bg-white/[0.05]">
+                <div
+                  className="h-full rounded-full bg-gradient-to-r from-accent/60 to-accent transition-[width]"
+                  style={{ width: `${(tool.tokens / max) * 100}%` }}
+                />
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </Panel>
+  );
+}


### PR DESCRIPTION
This branch bundles two roadmap runs (PR #75 wasn't merged before Run 55 started, so both commits stack on the shared branch).

## Run 54 — Themen-Cloud / Topic cloud
- Most frequent terms from your prompts, extracted **locally with no LLM** — lowercase tokenization, German + English stop-word filtering, dropping short tokens and pure numbers. Sized **and** weighted (and colour-graded) by frequency. Integrates with the dashboard-wide search filter.
- Adds `/api/tags`, a `topTerms` lib (+ unit tests), a `demoTags()` source, de/en i18n.

## Run 55 — Token-Verbrauch je Tool / Token burn per tool
- Where most tokens burn, estimated from each tool's stored I/O size (`tool_io` chars ÷ 4) as a share of the total, biggest first. Honestly labelled as an estimate.
- Adds `/api/token-burn`, a `toolTokenBurn` lib (+ unit tests), a `demoTokenBurn()` source, de/en i18n.

## Test plan
- [x] `npm run lint` — clean
- [x] `npx vitest run` — 243 tests pass (new `topTerms` + `toolTokenBurn` cases)
- [x] `npm run build` — succeeds (`/api/tags`, `/api/token-burn` routes present)
- [x] `npm run test:e2e` — 2 pass, widget `<section>` count now 22

https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk