### PR TITLE
Add year calendar heatmap widget

### DIFF
--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -43,8 +43,8 @@ test("dashboard renders all four widgets and connects", async ({ page }) => {
 
   await expect(page.getByRole("heading", { name: "Claude Mission Control" })).toBeVisible();
 
-  // Twenty-two widget panels (+ token-burn).
-  await expect(page.locator("section")).toHaveCount(22);
+  // Twenty-three widget panels (+ calendar-heatmap).
+  await expect(page.locator("section")).toHaveCount(23);
   // Two titles are identical in both locales — safe to assert regardless of language.
   await expect(page.getByText("Sessions", { exact: true })).toBeVisible();
   await expect(page.getByText("Live Stream", { exact: true })).toBeVisible();

--- a/src/app/api/calendar/route.ts
+++ b/src/app/api/calendar/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from "next/server";
+import { db } from "@/lib/db";
+import { dailyActivity } from "@/lib/calendar";
+import { log } from "@/lib/log";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+// Per-day activity for the year calendar heatmap (53 weeks ending today).
+export async function GET(req: Request) {
+  const url = new URL(req.url);
+  const days = Math.min(Math.max(Math.trunc(Number(url.searchParams.get("days")) || 371), 7), 731);
+  try {
+    return NextResponse.json({ days: dailyActivity(db, days) });
+  } catch (err) {
+    log.error("/api/calendar failed", err);
+    return NextResponse.json({ days: [] });
+  }
+}

--- a/src/lib/calendar.test.ts
+++ b/src/lib/calendar.test.ts
@@ -1,0 +1,65 @@
+import Database from "better-sqlite3";
+import { afterEach, describe, expect, it } from "vitest";
+import { buildCalendar, dailyActivity, type CalDayCount } from "@/lib/calendar";
+import { migrate } from "@/lib/migrations";
+
+describe("buildCalendar", () => {
+  it("pads the leading week to the first day's weekday (Mon-first)", () => {
+    // 2026-05-20 is a Wednesday → weekday index 2 (Mon=0).
+    const series: CalDayCount[] = [
+      { date: "2026-05-20", count: 0 },
+      { date: "2026-05-21", count: 2 },
+      { date: "2026-05-22", count: 5 },
+    ];
+    const cal = buildCalendar(series);
+    expect(cal.weeks).toHaveLength(1);
+    expect(cal.weeks[0][0]).toBeNull();
+    expect(cal.weeks[0][1]).toBeNull();
+    expect(cal.weeks[0][2]?.date).toBe("2026-05-20");
+    expect(cal.weeks[0][4]?.date).toBe("2026-05-22");
+    expect(cal.weeks[0][5]).toBeNull();
+    expect(cal.total).toBe(7);
+    expect(cal.max).toBe(5);
+    expect(cal.months[0].month).toBe(4); // May (0-indexed)
+  });
+
+  it("starts a fresh column every 7 days with no padding on a Monday start", () => {
+    // 2026-05-18 is a Monday.
+    const series: CalDayCount[] = Array.from({ length: 14 }, (_, i) => ({
+      date: new Date(Date.UTC(2026, 4, 18 + i)).toISOString().slice(0, 10),
+      count: i,
+    }));
+    const cal = buildCalendar(series);
+    expect(cal.weeks).toHaveLength(2);
+    expect(cal.weeks[0][0]?.date).toBe("2026-05-18");
+    expect(cal.weeks[1][0]?.date).toBe("2026-05-25");
+  });
+
+  it("returns an empty calendar for no data", () => {
+    expect(buildCalendar([])).toEqual({ weeks: [], months: [], total: 0, max: 0 });
+  });
+});
+
+describe("dailyActivity", () => {
+  let open: Database.Database | null = null;
+  afterEach(() => {
+    open?.close();
+    open = null;
+  });
+
+  it("folds hour buckets into per-day counts, gap-filled", () => {
+    const db = (open = new Database(":memory:"));
+    migrate(db);
+    const now = new Date("2026-05-23T12:00:00Z");
+    const ins = db.prepare(
+      `INSERT INTO activity_buckets (bucket, event_type, count) VALUES (?, ?, ?)`,
+    );
+    ins.run("2026-05-23 09", "PreToolUse", 3);
+    ins.run("2026-05-23 10", "PostToolUse", 2);
+    ins.run("2026-05-21 08", "SessionStart", 1);
+
+    const days = dailyActivity(db, 3, now);
+    expect(days.map((d) => d.date)).toEqual(["2026-05-21", "2026-05-22", "2026-05-23"]);
+    expect(days.map((d) => d.count)).toEqual([1, 0, 5]);
+  });
+});

--- a/src/lib/calendar.ts
+++ b/src/lib/calendar.ts
@@ -1,0 +1,94 @@
+import type Database from "better-sqlite3";
+import { level } from "./heatmap";
+
+// Year calendar (GitHub-style): per-day activity folded into week-columns. Days
+// come from the hour activity_buckets, which survive event pruning, so the year
+// view stays intact. Pure layout in buildCalendar so it's unit-testable.
+
+export interface CalDayCount {
+  date: string; // YYYY-MM-DD (UTC)
+  count: number;
+}
+
+// Per-day event counts over the last `days` days (oldest first, gaps filled).
+export function dailyActivity(db: Database.Database, days: number, now: Date = new Date()): CalDayCount[] {
+  const startKey = new Date(now.getTime() - (days - 1) * 86_400_000).toISOString().slice(0, 10);
+  const rows = db
+    .prepare(
+      `SELECT substr(bucket, 1, 10) AS date, SUM(count) AS count
+       FROM activity_buckets
+       WHERE bucket >= ?
+       GROUP BY date`,
+    )
+    .all(`${startKey} 00`) as CalDayCount[];
+  const map = new Map(rows.map((r) => [r.date, r.count]));
+  const out: CalDayCount[] = [];
+  for (let i = days - 1; i >= 0; i--) {
+    const key = new Date(now.getTime() - i * 86_400_000).toISOString().slice(0, 10);
+    out.push({ date: key, count: map.get(key) ?? 0 });
+  }
+  return out;
+}
+
+export interface CalDay {
+  date: string;
+  count: number;
+  level: number; // 0..4
+}
+
+export interface CalendarYear {
+  weeks: (CalDay | null)[][]; // each inner array has 7 cells (Mon..Sun)
+  months: { month: number; week: number }[]; // month label anchored to a week column
+  total: number;
+  max: number;
+}
+
+// UTC weekday, Monday-first (Mon=0 … Sun=6).
+function weekdayMon(date: string): number {
+  return (new Date(`${date}T00:00:00Z`).getUTCDay() + 6) % 7;
+}
+
+export function buildCalendar(series: CalDayCount[]): CalendarYear {
+  const nonzero = series
+    .map((s) => s.count)
+    .filter((c) => c > 0)
+    .sort((a, b) => a - b);
+  const clamp = nonzero.length ? nonzero[Math.floor((nonzero.length - 1) * 0.95)] : 0;
+
+  const weeks: (CalDay | null)[][] = [];
+  let current: (CalDay | null)[] = [];
+  let total = 0;
+  let max = 0;
+
+  series.forEach((s, i) => {
+    if (i === 0) {
+      const pad = weekdayMon(s.date);
+      for (let p = 0; p < pad; p++) current.push(null);
+    }
+    current.push({ date: s.date, count: s.count, level: level(s.count, clamp) });
+    total += s.count;
+    if (s.count > max) max = s.count;
+    if (current.length === 7) {
+      weeks.push(current);
+      current = [];
+    }
+  });
+  if (current.length > 0) {
+    while (current.length < 7) current.push(null);
+    weeks.push(current);
+  }
+
+  const months: { month: number; week: number }[] = [];
+  let lastMonth = -1;
+  weeks.forEach((wk, wi) => {
+    const first = wk.find((c): c is CalDay => c !== null);
+    if (!first) return;
+    const m = new Date(`${first.date}T00:00:00Z`).getUTCMonth();
+    if (m !== lastMonth) {
+      months.push({ month: m, week: wi });
+      lastMonth = m;
+    }
+  });
+
+  return { weeks, months, total, max };
+}

--- a/src/lib/demo.ts
+++ b/src/lib/demo.ts
@@ -679,6 +679,21 @@ export function demoTokenBurn() {
   return { tools };
 }
 
+export function demoCalendar() {
+  const today = new Date();
+  const days: { date: string; count: number }[] = [];
+  for (let i = 370; i >= 0; i--) {
+    const date = new Date(today.getTime() - i * 86_400_000);
+    const key = date.toISOString().slice(0, 10);
+    const weekday = date.getUTCDay();
+    const weekend = weekday === 0 || weekday === 6 ? 0.25 : 1;
+    const burst = Math.random() < 0.12 ? 3 : 1; // occasional heavy days
+    const count = Math.max(0, Math.round((Math.random() * 40 - 6) * weekend * burst));
+    days.push({ date: key, count });
+  }
+  return { days };
+}
+
 export function demoSubscribe(fn: (m: StreamMessage) => void) {
   listeners.add(fn);
   return () => listeners.delete(fn);
@@ -713,6 +728,7 @@ export function installDemoBackend() {
     if (path.endsWith("/api/compactions")) return json(demoCompactions());
     if (path.endsWith("/api/tags")) return json(demoTags());
     if (path.endsWith("/api/token-burn")) return json(demoTokenBurn());
+    if (path.endsWith("/api/calendar")) return json(demoCalendar());
     if (path.endsWith("/api/budget")) return json(demoBudget());
     if (path.endsWith("/api/stats")) return json(demoStats());
     if (path.endsWith("/api/activity")) return json(demoActivity());

--- a/src/lib/i18n.tsx
+++ b/src/lib/i18n.tsx
@@ -196,6 +196,13 @@ const DE: Record<string, string> = {
   "burn.info": "Wo die meisten Tokens verbrennen – geschätzt aus der Tool-I/O-Größe (Zeichen ÷ 4).",
   "burn.empty": "Noch keine Tool-Daten.",
 
+  "calendar.title": "Jahres-Kalender",
+  "calendar.info": "Aktivität pro Tag über das letzte Jahr – je dunkler, desto mehr Events.",
+  "calendar.empty": "Noch keine Aktivität.",
+  "calendar.events": "Events",
+  "calendar.less": "weniger",
+  "calendar.more": "mehr",
+
   "search.label": "Sessions und Events durchsuchen",
   "search.placeholder": "Suchen…",
   "search.clear": "Suche löschen",
@@ -453,6 +460,13 @@ const EN: Record<string, string> = {
   "burn.title": "Token burn per tool",
   "burn.info": "Where most tokens burn — estimated from tool I/O size (chars ÷ 4).",
   "burn.empty": "No tool data yet.",
+
+  "calendar.title": "Year calendar",
+  "calendar.info": "Activity per day over the last year — the darker, the more events.",
+  "calendar.empty": "No activity yet.",
+  "calendar.events": "events",
+  "calendar.less": "less",
+  "calendar.more": "more",
 
   "search.label": "Search sessions and events",
   "search.placeholder": "Search…",

--- a/src/plugins/calendar-heatmap/widget.tsx
+++ b/src/plugins/calendar-heatmap/widget.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { CalendarRange } from "lucide-react";
+import { Panel } from "@/components/panel";
+import { WidgetState } from "@/components/widget-state";
+import { useLive } from "@/components/live-provider";
+import { useT } from "@/lib/i18n";
+import { formatCompact } from "@/lib/format";
+import { buildCalendar, type CalDayCount } from "@/lib/calendar";
+
+const LEVEL_BG = [
+  "var(--mc-heat-0, rgba(255,255,255,0.04))",
+  "rgba(79,140,255,0.28)",
+  "rgba(79,140,255,0.48)",
+  "rgba(79,140,255,0.7)",
+  "rgba(79,140,255,0.95)",
+];
+
+const PITCH = 13; // cell (10px) + gap (3px)
+
+export function CalendarHeatmap() {
+  const { tick } = useLive();
+  const { t, lang } = useT();
+  const [days, setDays] = useState<CalDayCount[] | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = () =>
+      fetch("/api/calendar?days=371")
+        .then((r) => r.json())
+        .then((d: { days: CalDayCount[] }) => {
+          if (!cancelled) setDays(d.days);
+        })
+        .catch(() => {});
+    load();
+    const poll = setInterval(load, 30_000);
+    return () => {
+      cancelled = true;
+      clearInterval(poll);
+    };
+  }, [tick]);
+
+  const cal = buildCalendar(days ?? []);
+  const monthName = (m: number) =>
+    new Date(Date.UTC(2026, m, 1)).toLocaleString(lang, { month: "short" });
+
+  const segments = cal.months.map((m, i) => {
+    const nextWeek = i + 1 < cal.months.length ? cal.months[i + 1].week : cal.weeks.length;
+    return { month: m.month, lead: i === 0 ? m.week * PITCH : 0, width: (nextWeek - m.week) * PITCH };
+  });
+
+  return (
+    <Panel
+      title={t("calendar.title")}
+      icon={<CalendarRange className="h-4 w-4 text-accent" />}
+      info={t("calendar.info")}
+      right={
+        days && cal.total > 0 ? (
+          <span className="text-xs text-muted">
+            {formatCompact(cal.total)} {t("calendar.events")}
+          </span>
+        ) : undefined
+      }
+    >
+      {!days ? (
+        <WidgetState icon={CalendarRange} title={t("common.loading")} loading />
+      ) : cal.total === 0 ? (
+        <WidgetState icon={CalendarRange} title={t("calendar.empty")} />
+      ) : (
+        <div className="flex h-full flex-col justify-center gap-2 overflow-auto p-4">
+          <div className="inline-flex min-w-min flex-col gap-1">
+            <div className="flex text-[9px] text-muted">
+              {segments.map((s, i) => (
+                <span
+                  key={i}
+                  className="overflow-hidden whitespace-nowrap"
+                  style={{ marginLeft: s.lead, width: s.width }}
+                >
+                  {monthName(s.month)}
+                </span>
+              ))}
+            </div>
+            <div className="flex gap-[3px]">
+              {cal.weeks.map((wk, wi) => (
+                <div key={wi} className="flex flex-col gap-[3px]">
+                  {wk.map((cell, di) => (
+                    <div
+                      key={di}
+                      title={cell ? `${cell.date}: ${cell.count}` : undefined}
+                      className="h-2.5 w-2.5 rounded-[2px]"
+                      style={{ backgroundColor: cell ? LEVEL_BG[cell.level] : "transparent" }}
+                    />
+                  ))}
+                </div>
+              ))}
+            </div>
+          </div>
+          <div className="flex items-center justify-end gap-1.5 text-[10px] text-muted">
+            <span>{t("calendar.less")}</span>
+            {LEVEL_BG.map((bg, i) => (
+              <span key={i} className="h-2.5 w-2.5 rounded-[2px]" style={{ backgroundColor: bg }} />
+            ))}
+            <span>{t("calendar.more")}</span>
+          </div>
+        </div>
+      )}
+    </Panel>
+  );
+}

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -22,6 +22,7 @@ import { McpServers } from "./mcp-servers/widget";
 import { CompactionTimeline } from "./compaction-timeline/widget";
 import { TagCloud } from "./tag-cloud/widget";
 import { TokenBurn } from "./token-burn/widget";
+import { CalendarHeatmap } from "./calendar-heatmap/widget";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // PLUGIN REGISTRY
@@ -204,5 +205,12 @@ export const widgets: Widget[] = [
     span: "lg:col-span-3",
     height: "h-[360px] min-[2560px]:h-[480px] min-[3840px]:h-[660px]",
     component: TokenBurn,
+  },
+  {
+    id: "calendar-heatmap",
+    title: "Jahres-Kalender",
+    span: "lg:col-span-6",
+    height: "h-auto",
+    component: CalendarHeatmap,
   },
 ];


### PR DESCRIPTION
## Summary
- New **Jahres-Kalender / Year calendar** widget (Run 56): a GitHub-style yearly contribution heatmap of daily activity — 53 week-columns × 7 weekday rows, discrete level colours, localized month labels, per-day tooltips (date + count), and a less→more legend. Full-width panel.
- Folds the hour `activity_buckets` into per-day counts, so the year view survives raw-event pruning.
- Adds `/api/calendar`, a `calendar` lib with a pure, unit-tested grid builder (`buildCalendar`) + `dailyActivity`, a `demoCalendar()` source, and de/en i18n.

Research note (per standing instruction): contribution calendars use week-columns, discrete level colours with gutter spacing, month labels along the top, and per-day tooltips — all applied here, reusing the dashboard's existing blue level ramp.

## Test plan
- [x] `npm run lint` — clean
- [x] `npx vitest run` — 247 tests pass (new `buildCalendar` + `dailyActivity` cases)
- [x] `npm run build` — succeeds (`/api/calendar` route present)
- [x] `npm run test:e2e` — 2 pass, widget `<section>` count bumped 22 → 23

https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk)_