### PR TITLE
Add velocity trend widget

### DIFF
--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -43,8 +43,8 @@ test("dashboard renders all four widgets and connects", async ({ page }) => {
 
   await expect(page.getByRole("heading", { name: "Claude Mission Control" })).toBeVisible();
 
-  // Twenty-three widget panels (+ calendar-heatmap).
-  await expect(page.locator("section")).toHaveCount(23);
+  // Twenty-four widget panels (+ velocity).
+  await expect(page.locator("section")).toHaveCount(24);
   // Two titles are identical in both locales — safe to assert regardless of language.
   await expect(page.getByText("Sessions", { exact: true })).toBeVisible();
   await expect(page.getByText("Live Stream", { exact: true })).toBeVisible();

--- a/src/app/api/velocity/route.ts
+++ b/src/app/api/velocity/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from "next/server";
+import { db } from "@/lib/db";
+import { velocitySeries } from "@/lib/velocity";
+import { log } from "@/lib/log";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+// Per-day velocity aggregates (tool calls, events, sessions, active minutes).
+export async function GET(req: Request) {
+  const url = new URL(req.url);
+  const days = Math.min(Math.max(Math.trunc(Number(url.searchParams.get("days")) || 30), 7), 180);
+  try {
+    return NextResponse.json({ days: velocitySeries(db, days) });
+  } catch (err) {
+    log.error("/api/velocity failed", err);
+    return NextResponse.json({ days: [] });
+  }
+}

--- a/src/lib/demo.ts
+++ b/src/lib/demo.ts
@@ -12,6 +12,7 @@ import type { McpServerUsage } from "./mcp-servers";
 import { streakStats, peakHour, type DayCount } from "./streak";
 import { topTerms } from "./tags";
 import type { ToolTokenBurn } from "./token-burn";
+import type { VelocityDay } from "./velocity";
 import type { SubagentGroup } from "./subagents";
 import type { EventRow, SessionRow, StreamMessage } from "./types";
 
@@ -694,6 +695,22 @@ export function demoCalendar() {
   return { days };
 }
 
+export function demoVelocity() {
+  const today = new Date();
+  const days: VelocityDay[] = [];
+  for (let i = 29; i >= 0; i--) {
+    const date = new Date(today.getTime() - i * 86_400_000).toISOString().slice(0, 10);
+    const sessions = 1 + Math.floor(Math.random() * 4);
+    const activeMinutes = sessions * (20 + Math.floor(Math.random() * 40));
+    // Mild downward drift in throughput over the window (a degradation signal).
+    const ratePerMin = (0.9 - (29 - i) * 0.012) * (0.8 + Math.random() * 0.4);
+    const toolCalls = Math.max(0, Math.round(activeMinutes * ratePerMin));
+    const events = toolCalls * 2 + sessions * 3 + Math.floor(Math.random() * 6);
+    days.push({ date, toolCalls, events, sessions, activeMinutes });
+  }
+  return { days };
+}
+
 export function demoSubscribe(fn: (m: StreamMessage) => void) {
   listeners.add(fn);
   return () => listeners.delete(fn);
@@ -729,6 +746,7 @@ export function installDemoBackend() {
     if (path.endsWith("/api/tags")) return json(demoTags());
     if (path.endsWith("/api/token-burn")) return json(demoTokenBurn());
     if (path.endsWith("/api/calendar")) return json(demoCalendar());
+    if (path.endsWith("/api/velocity")) return json(demoVelocity());
     if (path.endsWith("/api/budget")) return json(demoBudget());
     if (path.endsWith("/api/stats")) return json(demoStats());
     if (path.endsWith("/api/activity")) return json(demoActivity());

--- a/src/lib/i18n.tsx
+++ b/src/lib/i18n.tsx
@@ -203,6 +203,12 @@ const DE: Record<string, string> = {
   "calendar.less": "weniger",
   "calendar.more": "mehr",
 
+  "velocity.title": "Geschwindigkeits-Trend",
+  "velocity.info": "Tools/Minute und Events/Session über 30 Tage (Ø = 7-Tage-Mittel). Degradations-Signal.",
+  "velocity.empty": "Noch keine Daten.",
+  "velocity.toolsPerMin": "Tools / Minute",
+  "velocity.eventsPerSession": "Events / Session",
+
   "search.label": "Sessions und Events durchsuchen",
   "search.placeholder": "Suchen…",
   "search.clear": "Suche löschen",
@@ -467,6 +473,12 @@ const EN: Record<string, string> = {
   "calendar.events": "events",
   "calendar.less": "less",
   "calendar.more": "more",
+
+  "velocity.title": "Velocity trend",
+  "velocity.info": "Tools/minute and events/session over 30 days (Ø = 7-day mean). Degradation signal.",
+  "velocity.empty": "No data yet.",
+  "velocity.toolsPerMin": "Tools / minute",
+  "velocity.eventsPerSession": "Events / session",
 
   "search.label": "Search sessions and events",
   "search.placeholder": "Search…",

--- a/src/lib/velocity.test.ts
+++ b/src/lib/velocity.test.ts
@@ -1,0 +1,76 @@
+import Database from "better-sqlite3";
+import { afterEach, describe, expect, it } from "vitest";
+import { migrate } from "@/lib/migrations";
+import {
+  eventsPerSession,
+  movingAverage,
+  toolsPerMinute,
+  trendDelta,
+  velocitySeries,
+  type VelocityDay,
+} from "@/lib/velocity";
+
+const day = (over: Partial<VelocityDay> = {}): VelocityDay => ({
+  date: "2026-05-23",
+  toolCalls: 0,
+  events: 0,
+  sessions: 0,
+  activeMinutes: 0,
+  ...over,
+});
+
+describe("ratios", () => {
+  it("computes tools per minute and events per session, guarding divide-by-zero", () => {
+    expect(toolsPerMinute(day({ toolCalls: 30, activeMinutes: 10 }))).toBe(3);
+    expect(toolsPerMinute(day({ toolCalls: 5, activeMinutes: 0 }))).toBe(0);
+    expect(eventsPerSession(day({ events: 20, sessions: 4 }))).toBe(5);
+    expect(eventsPerSession(day({ events: 5, sessions: 0 }))).toBe(0);
+  });
+});
+
+describe("movingAverage", () => {
+  it("uses a trailing window, ramping up at the start", () => {
+    expect(movingAverage([2, 4, 6, 8], 2)).toEqual([2, 3, 5, 7]);
+  });
+});
+
+describe("trendDelta", () => {
+  it("compares the last window mean to the prior window mean", () => {
+    // prior [10,10] mean 10, recent [15,15] mean 15 → +0.5
+    expect(trendDelta([10, 10, 15, 15], 2)).toBeCloseTo(0.5);
+  });
+  it("returns 0 without enough history", () => {
+    expect(trendDelta([1, 2, 3], 2)).toBe(0);
+  });
+});
+
+describe("velocitySeries", () => {
+  let open: Database.Database | null = null;
+  afterEach(() => {
+    open?.close();
+    open = null;
+  });
+
+  it("gathers per-day aggregates, gap-filled oldest first", () => {
+    const db = (open = new Database(":memory:"));
+    migrate(db);
+    const now = new Date("2026-05-23T12:00:00Z");
+    db.prepare(
+      `INSERT INTO sessions (id, first_seen, last_seen) VALUES (?, ?, ?)`,
+    ).run("s1", "2026-05-23 10:00:00", "2026-05-23 10:30:00");
+    const tc = db.prepare(`INSERT INTO tool_calls (session_id, tool_name, created_at) VALUES (?, ?, ?)`);
+    tc.run("s1", "Read", "2026-05-23 10:05:00");
+    tc.run("s1", "Bash", "2026-05-23 10:06:00");
+    db.prepare(
+      `INSERT INTO events (session_id, event_type, payload_json, created_at) VALUES (?, ?, ?, ?)`,
+    ).run("s1", "PostToolUse", "{}", "2026-05-23 10:05:00");
+
+    const days = velocitySeries(db, 2, now);
+    expect(days.map((d) => d.date)).toEqual(["2026-05-22", "2026-05-23"]);
+    const today = days[1];
+    expect(today.toolCalls).toBe(2);
+    expect(today.sessions).toBe(1);
+    expect(today.activeMinutes).toBe(30);
+    expect(toolsPerMinute(today)).toBeCloseTo(2 / 30);
+  });
+});

--- a/src/lib/velocity.ts
+++ b/src/lib/velocity.ts
@@ -1,0 +1,81 @@
+import type Database from "better-sqlite3";
+
+// Velocity / degradation signal: per-day throughput (tool calls per active minute)
+// and density (events per session) over time, with a moving average to smooth
+// outliers and a window-over-window delta to flag drift. Pure derivations are
+// unit-tested; the DB function just gathers raw per-day aggregates.
+
+export interface VelocityDay {
+  date: string; // YYYY-MM-DD (UTC)
+  toolCalls: number;
+  events: number;
+  sessions: number;
+  activeMinutes: number;
+}
+
+export function velocitySeries(db: Database.Database, days: number, now: Date = new Date()): VelocityDay[] {
+  const startKey = new Date(now.getTime() - (days - 1) * 86_400_000).toISOString().slice(0, 10);
+  const since = `${startKey} 00:00:00`;
+  const byDay = (sql: string) =>
+    new Map(
+      (db.prepare(sql).all(since) as { date: string; n: number }[]).map((r) => [r.date, r.n] as const),
+    );
+
+  const tools = byDay(
+    `SELECT substr(created_at, 1, 10) AS date, COUNT(*) AS n FROM tool_calls WHERE created_at >= ? GROUP BY date`,
+  );
+  const events = byDay(
+    `SELECT substr(created_at, 1, 10) AS date, COUNT(*) AS n FROM events WHERE created_at >= ? GROUP BY date`,
+  );
+  const sessions = byDay(
+    `SELECT substr(first_seen, 1, 10) AS date, COUNT(*) AS n FROM sessions WHERE first_seen >= ? GROUP BY date`,
+  );
+  const minutes = byDay(
+    `SELECT substr(first_seen, 1, 10) AS date,
+            SUM((julianday(last_seen) - julianday(first_seen)) * 1440) AS n
+     FROM sessions WHERE first_seen >= ? GROUP BY date`,
+  );
+
+  const out: VelocityDay[] = [];
+  for (let i = days - 1; i >= 0; i--) {
+    const key = new Date(now.getTime() - i * 86_400_000).toISOString().slice(0, 10);
+    out.push({
+      date: key,
+      toolCalls: tools.get(key) ?? 0,
+      events: events.get(key) ?? 0,
+      sessions: sessions.get(key) ?? 0,
+      activeMinutes: Math.max(0, Math.round(minutes.get(key) ?? 0)),
+    });
+  }
+  return out;
+}
+
+export function toolsPerMinute(d: VelocityDay): number {
+  return d.activeMinutes > 0 ? d.toolCalls / d.activeMinutes : 0;
+}
+
+export function eventsPerSession(d: VelocityDay): number {
+  return d.sessions > 0 ? d.events / d.sessions : 0;
+}
+
+// Trailing moving average; the first values use as many points as available.
+export function movingAverage(values: number[], window: number): number[] {
+  const out: number[] = [];
+  for (let i = 0; i < values.length; i++) {
+    const start = Math.max(0, i - window + 1);
+    const slice = values.slice(start, i + 1);
+    out.push(slice.reduce((a, b) => a + b, 0) / slice.length);
+  }
+  return out;
+}
+
+// Relative change of the last `window` mean vs the previous `window` mean.
+// Returns 0 when there isn't enough history or the previous mean is 0.
+export function trendDelta(values: number[], window: number): number {
+  if (values.length < window * 2) return 0;
+  const mean = (arr: number[]) => arr.reduce((a, b) => a + b, 0) / arr.length;
+  const recent = mean(values.slice(-window));
+  const prior = mean(values.slice(-window * 2, -window));
+  if (prior === 0) return 0;
+  return (recent - prior) / prior;
+}

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -23,6 +23,7 @@ import { CompactionTimeline } from "./compaction-timeline/widget";
 import { TagCloud } from "./tag-cloud/widget";
 import { TokenBurn } from "./token-burn/widget";
 import { CalendarHeatmap } from "./calendar-heatmap/widget";
+import { Velocity } from "./velocity/widget";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // PLUGIN REGISTRY
@@ -212,5 +213,12 @@ export const widgets: Widget[] = [
     span: "lg:col-span-6",
     height: "h-auto",
     component: CalendarHeatmap,
+  },
+  {
+    id: "velocity",
+    title: "Geschwindigkeits-Trend",
+    span: "lg:col-span-3",
+    height: "h-[360px] min-[2560px]:h-[480px] min-[3840px]:h-[660px]",
+    component: Velocity,
   },
 ];

--- a/src/plugins/velocity/widget.tsx
+++ b/src/plugins/velocity/widget.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Line, LineChart, ResponsiveContainer, Tooltip, YAxis } from "recharts";
+import { Gauge, TrendingDown, TrendingUp } from "lucide-react";
+import { Panel } from "@/components/panel";
+import { WidgetState } from "@/components/widget-state";
+import { useLive } from "@/components/live-provider";
+import { useT } from "@/lib/i18n";
+import {
+  eventsPerSession,
+  movingAverage,
+  toolsPerMinute,
+  trendDelta,
+  type VelocityDay,
+} from "@/lib/velocity";
+
+const TOOLTIP = {
+  contentStyle: { background: "#0e1219", border: "1px solid #1c2230", borderRadius: 8, fontSize: 12 },
+  labelStyle: { color: "#8b94a7" },
+};
+
+function Delta({ value }: { value: number }) {
+  if (Math.abs(value) < 0.005) return <span className="text-[11px] text-muted">±0%</span>;
+  const up = value > 0;
+  const Icon = up ? TrendingUp : TrendingDown;
+  return (
+    <span className={`flex items-center gap-0.5 text-[11px] tabular-nums ${up ? "text-emerald-400" : "text-amber-400"}`}>
+      <Icon className="h-3 w-3" />
+      {up ? "+" : ""}
+      {(value * 100).toFixed(0)}%
+    </span>
+  );
+}
+
+function Trend({
+  label,
+  data,
+  delta,
+  format,
+}: {
+  label: string;
+  data: { date: string; v: number; avg: number }[];
+  delta: number;
+  format: (n: number) => string;
+}) {
+  return (
+    <div className="min-h-0 flex-1">
+      <div className="mb-0.5 flex items-baseline justify-between">
+        <span className="text-[11px] font-medium uppercase tracking-wide text-muted">{label}</span>
+        <Delta value={delta} />
+      </div>
+      <div className="h-[72px] w-full">
+        <ResponsiveContainer width="100%" height="100%">
+          <LineChart data={data} margin={{ top: 4, right: 4, bottom: 0, left: 0 }}>
+            <YAxis hide domain={[0, "dataMax"]} />
+            <Tooltip {...TOOLTIP} formatter={(val) => format(Number(val))} />
+            <Line type="monotone" dataKey="v" stroke="#475569" strokeWidth={1} dot={false} isAnimationActive={false} />
+            <Line type="monotone" dataKey="avg" stroke="#4f8cff" strokeWidth={2} dot={false} isAnimationActive={false} />
+          </LineChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  );
+}
+
+export function Velocity() {
+  const { tick } = useLive();
+  const { t } = useT();
+  const [days, setDays] = useState<VelocityDay[] | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = () =>
+      fetch("/api/velocity?days=30")
+        .then((r) => r.json())
+        .then((d: { days: VelocityDay[] }) => {
+          if (!cancelled) setDays(d.days);
+        })
+        .catch(() => {});
+    load();
+    const poll = setInterval(load, 30_000);
+    return () => {
+      cancelled = true;
+      clearInterval(poll);
+    };
+  }, [tick]);
+
+  const empty = days && days.every((d) => d.toolCalls === 0 && d.events === 0);
+
+  const tpm = (days ?? []).map(toolsPerMinute);
+  const eps = (days ?? []).map(eventsPerSession);
+  const tpmAvg = movingAverage(tpm, 7);
+  const epsAvg = movingAverage(eps, 7);
+  const chartTpm = (days ?? []).map((d, i) => ({ date: d.date, v: +tpm[i].toFixed(3), avg: +tpmAvg[i].toFixed(3) }));
+  const chartEps = (days ?? []).map((d, i) => ({ date: d.date, v: +eps[i].toFixed(2), avg: +epsAvg[i].toFixed(2) }));
+
+  return (
+    <Panel title={t("velocity.title")} icon={<Gauge className="h-4 w-4 text-accent" />} info={t("velocity.info")}>
+      {!days ? (
+        <WidgetState icon={Gauge} title={t("common.loading")} loading />
+      ) : empty ? (
+        <WidgetState icon={Gauge} title={t("velocity.empty")} />
+      ) : (
+        <div className="flex h-full flex-col gap-3 p-4">
+          <Trend
+            label={t("velocity.toolsPerMin")}
+            data={chartTpm}
+            delta={trendDelta(tpm, 7)}
+            format={(n) => n.toFixed(2)}
+          />
+          <Trend
+            label={t("velocity.eventsPerSession")}
+            data={chartEps}
+            delta={trendDelta(eps, 7)}
+            format={(n) => n.toFixed(1)}
+          />
+        </div>
+      )}
+    </Panel>
+  );
+}


### PR DESCRIPTION
## Summary
- New **Geschwindigkeits-Trend / Velocity trend** widget (Run 57): a degradation signal showing per-day **tools/minute** and **events/session** over 30 days, each as a raw line plus a **7-day moving-average** overlay, with a window-over-window **delta badge** (↑/↓ % vs the prior 7 days).
- Adds `/api/velocity`, a `velocity` lib — per-day aggregate query (`velocitySeries`) plus pure, unit-tested derivations (`toolsPerMinute`, `eventsPerSession`, `movingAverage`, `trendDelta`) — a `demoVelocity()` source (mild downward drift to show the signal), and de/en i18n.

Research note (per standing instruction): throughput/degradation trends read best with a smoothed moving-average line over the raw series plus a variance annotation vs the prior period — exactly the raw+Ø lines and delta badge here.

## Test plan
- [x] `npm run lint` — clean
- [x] `npx vitest run` — 252 tests pass (new velocity ratio/MA/delta + query cases)
- [x] `npm run build` — succeeds (`/api/velocity` route present)
- [x] `npm run test:e2e` — 2 pass, widget `<section>` count bumped 23 → 24

https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk)_