### PR TITLE
Add session-duration distribution widget

### DIFF
--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -43,8 +43,8 @@ test("dashboard renders all four widgets and connects", async ({ page }) => {
 
   await expect(page.getByRole("heading", { name: "Claude Mission Control" })).toBeVisible();
 
-  // Twenty-four widget panels (+ velocity).
-  await expect(page.locator("section")).toHaveCount(24);
+  // Twenty-five widget panels (+ session-duration).
+  await expect(page.locator("section")).toHaveCount(25);
   // Two titles are identical in both locales — safe to assert regardless of language.
   await expect(page.getByText("Sessions", { exact: true })).toBeVisible();
   await expect(page.getByText("Live Stream", { exact: true })).toBeVisible();

--- a/src/app/api/session-duration/route.ts
+++ b/src/app/api/session-duration/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from "next/server";
+import { db } from "@/lib/db";
+import { durationStats, sessionDurationsMs } from "@/lib/session-duration";
+import { log } from "@/lib/log";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+// Distribution of session lengths (histogram + median/p95).
+export async function GET() {
+  try {
+    return NextResponse.json(durationStats(sessionDurationsMs(db)));
+  } catch (err) {
+    log.error("/api/session-duration failed", err);
+    return NextResponse.json({ count: 0, median: 0, p95: 0, max: 0, buckets: [] });
+  }
+}

--- a/src/lib/demo.ts
+++ b/src/lib/demo.ts
@@ -12,6 +12,7 @@ import type { McpServerUsage } from "./mcp-servers";
 import { streakStats, peakHour, type DayCount } from "./streak";
 import { topTerms } from "./tags";
 import type { ToolTokenBurn } from "./token-burn";
+import { durationStats } from "./session-duration";
 import type { VelocityDay } from "./velocity";
 import type { SubagentGroup } from "./subagents";
 import type { EventRow, SessionRow, StreamMessage } from "./types";
@@ -711,6 +712,17 @@ export function demoVelocity() {
   return { days };
 }
 
+export function demoSessionDuration() {
+  const values: number[] = [];
+  for (let i = 0; i < 160; i++) {
+    // Right-skewed: most sessions short, a long tail of multi-hour ones.
+    const r = Math.random();
+    const minutes = r < 0.55 ? Math.random() * 15 : r < 0.85 ? 15 + Math.random() * 75 : 90 + Math.random() * 300;
+    values.push(Math.round(minutes * 60_000));
+  }
+  return durationStats(values);
+}
+
 export function demoSubscribe(fn: (m: StreamMessage) => void) {
   listeners.add(fn);
   return () => listeners.delete(fn);
@@ -747,6 +759,7 @@ export function installDemoBackend() {
     if (path.endsWith("/api/token-burn")) return json(demoTokenBurn());
     if (path.endsWith("/api/calendar")) return json(demoCalendar());
     if (path.endsWith("/api/velocity")) return json(demoVelocity());
+    if (path.endsWith("/api/session-duration")) return json(demoSessionDuration());
     if (path.endsWith("/api/budget")) return json(demoBudget());
     if (path.endsWith("/api/stats")) return json(demoStats());
     if (path.endsWith("/api/activity")) return json(demoActivity());

--- a/src/lib/i18n.tsx
+++ b/src/lib/i18n.tsx
@@ -209,6 +209,12 @@ const DE: Record<string, string> = {
   "velocity.toolsPerMin": "Tools / Minute",
   "velocity.eventsPerSession": "Events / Session",
 
+  "sessionDur.title": "Session-Dauer",
+  "sessionDur.info": "Verteilung der Session-Längen (Spanne erster bis letzter Event), plus Median und p95.",
+  "sessionDur.empty": "Noch keine abgeschlossenen Sessions.",
+  "sessionDur.median": "Median",
+  "sessionDur.max": "Max",
+
   "search.label": "Sessions und Events durchsuchen",
   "search.placeholder": "Suchen…",
   "search.clear": "Suche löschen",
@@ -479,6 +485,12 @@ const EN: Record<string, string> = {
   "velocity.empty": "No data yet.",
   "velocity.toolsPerMin": "Tools / minute",
   "velocity.eventsPerSession": "Events / session",
+
+  "sessionDur.title": "Session duration",
+  "sessionDur.info": "Distribution of session lengths (first to last event span), plus median and p95.",
+  "sessionDur.empty": "No completed sessions yet.",
+  "sessionDur.median": "Median",
+  "sessionDur.max": "Max",
 
   "search.label": "Search sessions and events",
   "search.placeholder": "Search…",

--- a/src/lib/session-duration.test.ts
+++ b/src/lib/session-duration.test.ts
@@ -1,0 +1,48 @@
+import Database from "better-sqlite3";
+import { afterEach, describe, expect, it } from "vitest";
+import { migrate } from "@/lib/migrations";
+import { durationStats, sessionDurationsMs } from "@/lib/session-duration";
+
+const MIN = 60_000;
+
+describe("durationStats", () => {
+  it("buckets durations, summing to the input length", () => {
+    const values = [30_000, 90_000, 10 * MIN, 45 * MIN, 3 * 60 * MIN]; // 30s, 1.5m, 10m, 45m, 3h
+    const s = durationStats(values);
+    expect(s.count).toBe(5);
+    expect(s.buckets).toHaveLength(8); // 7 edges + overflow
+    expect(s.buckets.reduce((a, b) => a + b.count, 0)).toBe(5);
+    expect(s.buckets[0].count).toBe(1); // <1m → the 30s session
+    expect(s.max).toBe(3 * 60 * MIN);
+  });
+
+  it("computes median and p95", () => {
+    const values = Array.from({ length: 100 }, (_, i) => (i + 1) * MIN); // 1..100 minutes
+    const s = durationStats(values);
+    expect(s.median).toBe(50 * MIN);
+    expect(s.p95).toBe(95 * MIN);
+  });
+
+  it("handles an empty input", () => {
+    expect(durationStats([])).toMatchObject({ count: 0, median: 0, p95: 0, max: 0 });
+  });
+});
+
+describe("sessionDurationsMs", () => {
+  let open: Database.Database | null = null;
+  afterEach(() => {
+    open?.close();
+    open = null;
+  });
+
+  it("returns positive per-session spans only", () => {
+    const db = (open = new Database(":memory:"));
+    migrate(db);
+    const ins = db.prepare(`INSERT INTO sessions (id, first_seen, last_seen) VALUES (?, ?, ?)`);
+    ins.run("s1", "2026-05-23 10:00:00", "2026-05-23 10:30:00"); // 30 min
+    ins.run("s2", "2026-05-23 11:00:00", "2026-05-23 11:00:00"); // zero → dropped
+    const ms = sessionDurationsMs(db);
+    expect(ms).toHaveLength(1);
+    expect(ms[0]).toBe(30 * MIN);
+  });
+});

--- a/src/lib/session-duration.ts
+++ b/src/lib/session-duration.ts
@@ -1,0 +1,59 @@
+import type Database from "better-sqlite3";
+import { percentile } from "./latency";
+import { formatDuration } from "./format";
+
+// Session-length distribution: each session's wall-clock span (last_seen −
+// first_seen). Long-tailed, so fixed time buckets + percentiles rather than a mean.
+
+export interface DurationBucket {
+  label: string;
+  count: number;
+}
+
+export interface DurationStats {
+  count: number;
+  median: number; // ms
+  p95: number; // ms
+  max: number; // ms
+  buckets: DurationBucket[];
+}
+
+const EDGES_MS = [1, 5, 15, 30, 60, 120, 240].map((m) => m * 60_000);
+
+function bucketize(values: number[]): DurationBucket[] {
+  const counts = new Array<number>(EDGES_MS.length + 1).fill(0);
+  for (const v of values) {
+    let i = EDGES_MS.findIndex((e) => v < e);
+    if (i === -1) i = EDGES_MS.length;
+    counts[i]++;
+  }
+  return counts.map((count, i) => ({
+    label: i < EDGES_MS.length ? `<${formatDuration(EDGES_MS[i])}` : `${formatDuration(EDGES_MS[EDGES_MS.length - 1])}+`,
+    count,
+  }));
+}
+
+export function durationStats(values: number[]): DurationStats {
+  const sorted = [...values].sort((a, b) => a - b);
+  return {
+    count: values.length,
+    median: percentile(sorted, 50),
+    p95: percentile(sorted, 95),
+    max: sorted.length ? sorted[sorted.length - 1] : 0,
+    buckets: bucketize(values),
+  };
+}
+
+// Per-session durations in ms (only sessions with a positive span).
+export function sessionDurationsMs(db: Database.Database, limit = 5000): number[] {
+  const rows = db
+    .prepare(
+      `SELECT (julianday(last_seen) - julianday(first_seen)) * 86400000 AS ms
+       FROM sessions
+       WHERE last_seen IS NOT NULL AND first_seen IS NOT NULL
+       ORDER BY first_seen DESC
+       LIMIT ?`,
+    )
+    .all(limit) as { ms: number | null }[];
+  return rows.map((r) => Math.round(r.ms ?? 0)).filter((ms) => ms > 0);
+}

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -24,6 +24,7 @@ import { TagCloud } from "./tag-cloud/widget";
 import { TokenBurn } from "./token-burn/widget";
 import { CalendarHeatmap } from "./calendar-heatmap/widget";
 import { Velocity } from "./velocity/widget";
+import { SessionDuration } from "./session-duration/widget";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // PLUGIN REGISTRY
@@ -220,5 +221,12 @@ export const widgets: Widget[] = [
     span: "lg:col-span-3",
     height: "h-[360px] min-[2560px]:h-[480px] min-[3840px]:h-[660px]",
     component: Velocity,
+  },
+  {
+    id: "session-duration",
+    title: "Session-Dauer",
+    span: "lg:col-span-3",
+    height: "h-[360px] min-[2560px]:h-[480px] min-[3840px]:h-[660px]",
+    component: SessionDuration,
   },
 ];

--- a/src/plugins/session-duration/widget.tsx
+++ b/src/plugins/session-duration/widget.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { BarChart, Bar, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
+import { Hourglass } from "lucide-react";
+import { Panel } from "@/components/panel";
+import { WidgetState } from "@/components/widget-state";
+import { useLive } from "@/components/live-provider";
+import { useT } from "@/lib/i18n";
+import { formatDuration } from "@/lib/format";
+import type { DurationStats } from "@/lib/session-duration";
+
+const tooltipStyle = {
+  background: "#0e1219",
+  border: "1px solid #1c2230",
+  borderRadius: 8,
+  fontSize: 12,
+} as const;
+
+export function SessionDuration() {
+  const { t } = useT();
+  const { tick } = useLive();
+  const [stats, setStats] = useState<DurationStats | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = () =>
+      fetch("/api/session-duration")
+        .then((r) => r.json())
+        .then((d: DurationStats) => {
+          if (!cancelled) setStats(d);
+        })
+        .catch(() => {});
+    load();
+    const poll = setInterval(load, 30_000);
+    return () => {
+      cancelled = true;
+      clearInterval(poll);
+    };
+  }, [tick]);
+
+  return (
+    <Panel title={t("sessionDur.title")} icon={<Hourglass className="h-4 w-4 text-accent" />} info={t("sessionDur.info")}>
+      {!stats ? (
+        <WidgetState icon={Hourglass} title={t("common.loading")} loading />
+      ) : stats.count === 0 ? (
+        <WidgetState icon={Hourglass} title={t("sessionDur.empty")} />
+      ) : (
+        <div className="flex h-full flex-col gap-2 p-3">
+          <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs">
+            <Stat label={t("sessionDur.median")} value={formatDuration(stats.median)} tone="text-emerald-400" />
+            <Stat label="p95" value={formatDuration(stats.p95)} tone="text-amber-400" />
+            <Stat label={t("sessionDur.max")} value={formatDuration(stats.max)} tone="text-muted" />
+            <Stat label="n" value={String(stats.count)} tone="text-muted" />
+          </div>
+          <div className="min-h-0 flex-1">
+            <ResponsiveContainer width="100%" height="100%">
+              <BarChart data={stats.buckets} margin={{ top: 6, right: 8, bottom: 0, left: -8 }}>
+                <CartesianGrid stroke="#1c2230" vertical={false} />
+                <XAxis dataKey="label" stroke="#8b94a7" fontSize={10} tickLine={false} interval={0} angle={-30} textAnchor="end" height={42} />
+                <YAxis stroke="#8b94a7" fontSize={11} tickLine={false} allowDecimals={false} width={36} />
+                <Tooltip contentStyle={tooltipStyle} cursor={{ fill: "rgba(255,255,255,0.04)" }} />
+                <Bar dataKey="count" fill="#4f8cff" radius={[3, 3, 0, 0]} isAnimationActive />
+              </BarChart>
+            </ResponsiveContainer>
+          </div>
+        </div>
+      )}
+    </Panel>
+  );
+}
+
+function Stat({ label, value, tone }: { label: string; value: string; tone: string }) {
+  return (
+    <span className="flex items-baseline gap-1">
+      <span className="text-muted">{label}</span>
+      <span className={`font-mono font-semibold tabular-nums ${tone}`}>{value}</span>
+    </span>
+  );
+}


### PR DESCRIPTION
## Summary
- New **Session-Dauer / Session duration** widget (Run 58): a histogram of session lengths (the first-to-last-event span per session) using fixed time buckets (<1m … 4h+), plus median, p95, max and count stat tiles.
- Adds `/api/session-duration`, a `session-duration` lib — `durationStats` (reuses the latency `percentile` helper and `formatDuration`) + `sessionDurationsMs` — with unit tests, a `demoSessionDuration()` source (right-skewed distribution), and de/en i18n.

Research note (per standing instruction): duration distributions read best with equal/fixed time buckets and percentile markers (median, p95) rather than a mean that hides the long tail — applied here, consistent with the existing latency widget.

## Test plan
- [x] `npm run lint` — clean
- [x] `npx vitest run` — 256 tests pass (new `durationStats` + `sessionDurationsMs` cases)
- [x] `npm run build` — succeeds (`/api/session-duration` route present)
- [x] `npm run test:e2e` — 2 pass, widget `<section>` count bumped 24 → 25

https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk)_