### PR TITLE
Add reliability-per-project widget

### DIFF
--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -43,8 +43,8 @@ test("dashboard renders all four widgets and connects", async ({ page }) => {
 
   await expect(page.getByRole("heading", { name: "Claude Mission Control" })).toBeVisible();
 
-  // Twenty-five widget panels (+ session-duration).
-  await expect(page.locator("section")).toHaveCount(25);
+  // Twenty-six widget panels (+ reliability).
+  await expect(page.locator("section")).toHaveCount(26);
   // Two titles are identical in both locales — safe to assert regardless of language.
   await expect(page.getByText("Sessions", { exact: true })).toBeVisible();
   await expect(page.getByText("Live Stream", { exact: true })).toBeVisible();

--- a/src/app/api/reliability/route.ts
+++ b/src/app/api/reliability/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from "next/server";
+import { db } from "@/lib/db";
+import { projectReliability } from "@/lib/reliability";
+import { log } from "@/lib/log";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+// Tool-call success rate per project (most active first).
+export async function GET(req: Request) {
+  const url = new URL(req.url);
+  const limit = Math.min(Math.max(Math.trunc(Number(url.searchParams.get("limit")) || 100), 1), 500);
+  try {
+    return NextResponse.json({ projects: projectReliability(db, limit) });
+  } catch (err) {
+    log.error("/api/reliability failed", err);
+    return NextResponse.json({ projects: [] });
+  }
+}

--- a/src/lib/demo.ts
+++ b/src/lib/demo.ts
@@ -12,6 +12,7 @@ import type { McpServerUsage } from "./mcp-servers";
 import { streakStats, peakHour, type DayCount } from "./streak";
 import { topTerms } from "./tags";
 import type { ToolTokenBurn } from "./token-burn";
+import type { ProjectReliability } from "./reliability";
 import { durationStats } from "./session-duration";
 import type { VelocityDay } from "./velocity";
 import type { SubagentGroup } from "./subagents";
@@ -723,6 +724,23 @@ export function demoSessionDuration() {
   return durationStats(values);
 }
 
+export function demoReliability() {
+  const base = [
+    { project: "my_dash", total: 318, successRate: 0.97 },
+    { project: "shopify-bot", total: 211, successRate: 0.91 },
+    { project: "infra-scripts", total: 96, successRate: 0.82 },
+    { project: "docs-site", total: 41, successRate: 0.99 },
+    { project: "(unknown)", total: 12, successRate: 0.75 },
+  ];
+  const projects: ProjectReliability[] = base.map((b) => ({
+    project: b.project,
+    total: b.total,
+    failures: Math.round(b.total * (1 - b.successRate)),
+    successRate: b.successRate,
+  }));
+  return { projects };
+}
+
 export function demoSubscribe(fn: (m: StreamMessage) => void) {
   listeners.add(fn);
   return () => listeners.delete(fn);
@@ -760,6 +778,7 @@ export function installDemoBackend() {
     if (path.endsWith("/api/calendar")) return json(demoCalendar());
     if (path.endsWith("/api/velocity")) return json(demoVelocity());
     if (path.endsWith("/api/session-duration")) return json(demoSessionDuration());
+    if (path.endsWith("/api/reliability")) return json(demoReliability());
     if (path.endsWith("/api/budget")) return json(demoBudget());
     if (path.endsWith("/api/stats")) return json(demoStats());
     if (path.endsWith("/api/activity")) return json(demoActivity());

--- a/src/lib/i18n.tsx
+++ b/src/lib/i18n.tsx
@@ -215,6 +215,11 @@ const DE: Record<string, string> = {
   "sessionDur.median": "Median",
   "sessionDur.max": "Max",
 
+  "reliability.title": "Zuverlässigkeit je Projekt",
+  "reliability.info": "Anteil erfolgreicher Tool-Aufrufe pro Projekt. Grün ≥95 %, Gelb ≥85 %, sonst Rot.",
+  "reliability.empty": "Noch keine Tool-Aufrufe.",
+  "reliability.fail": "Fehler",
+
   "search.label": "Sessions und Events durchsuchen",
   "search.placeholder": "Suchen…",
   "search.clear": "Suche löschen",
@@ -491,6 +496,11 @@ const EN: Record<string, string> = {
   "sessionDur.empty": "No completed sessions yet.",
   "sessionDur.median": "Median",
   "sessionDur.max": "Max",
+
+  "reliability.title": "Reliability per project",
+  "reliability.info": "Share of successful tool calls per project. Green ≥95%, amber ≥85%, else red.",
+  "reliability.empty": "No tool calls yet.",
+  "reliability.fail": "fail",
 
   "search.label": "Search sessions and events",
   "search.placeholder": "Search…",

--- a/src/lib/reliability.test.ts
+++ b/src/lib/reliability.test.ts
@@ -1,0 +1,51 @@
+import Database from "better-sqlite3";
+import { afterEach, describe, expect, it } from "vitest";
+import { migrate } from "@/lib/migrations";
+import { projectReliability } from "@/lib/reliability";
+
+let open: Database.Database | null = null;
+afterEach(() => {
+  open?.close();
+  open = null;
+});
+
+function seed(): Database.Database {
+  const db = (open = new Database(":memory:"));
+  migrate(db);
+  db.prepare(`INSERT INTO sessions (id, project_name) VALUES (?, ?)`).run("a1", "alpha");
+  db.prepare(`INSERT INTO sessions (id, project_name) VALUES (?, ?)`).run("b1", "beta");
+  db.prepare(`INSERT INTO sessions (id, project_name) VALUES (?, ?)`).run("u1", null);
+  const tc = db.prepare(`INSERT INTO tool_calls (session_id, tool_name, success) VALUES (?, ?, ?)`);
+  // alpha: 4 calls, 1 failure → 0.75
+  tc.run("a1", "Read", 1);
+  tc.run("a1", "Edit", 1);
+  tc.run("a1", "Bash", 0);
+  tc.run("a1", "Read", 1);
+  // beta: 2 calls, all ok → 1.0
+  tc.run("b1", "Read", 1);
+  tc.run("b1", "Grep", 1);
+  // unknown project: 1 failed call
+  tc.run("u1", "Bash", 0);
+  return db;
+}
+
+describe("projectReliability", () => {
+  it("computes success rate per project, most active first", () => {
+    const rows = projectReliability(seed());
+    expect(rows.map((r) => r.project)).toEqual(["alpha", "beta", "(unknown)"]);
+    const alpha = rows.find((r) => r.project === "alpha")!;
+    expect(alpha.total).toBe(4);
+    expect(alpha.failures).toBe(1);
+    expect(alpha.successRate).toBeCloseTo(0.75);
+  });
+
+  it("labels null projects and reports a perfect rate", () => {
+    const rows = projectReliability(seed());
+    expect(rows.find((r) => r.project === "beta")!.successRate).toBe(1);
+    expect(rows.find((r) => r.project === "(unknown)")!.successRate).toBe(0);
+  });
+
+  it("respects the limit", () => {
+    expect(projectReliability(seed(), 1)).toHaveLength(1);
+  });
+});

--- a/src/lib/reliability.ts
+++ b/src/lib/reliability.ts
@@ -1,0 +1,32 @@
+import type Database from "better-sqlite3";
+
+// Per-project reliability: share of tool calls that succeeded. Joined via session
+// → project. Powers the reliability-per-project widget. Surfaces which projects
+// are error-prone rather than a single server-wide average.
+
+export interface ProjectReliability {
+  project: string;
+  total: number;
+  failures: number;
+  successRate: number; // 0..1
+}
+
+export function projectReliability(db: Database.Database, limit = 100): ProjectReliability[] {
+  const rows = db
+    .prepare(
+      `SELECT COALESCE(NULLIF(s.project_name, ''), '(unknown)') AS project,
+              COUNT(*) AS total,
+              SUM(CASE WHEN tc.success = 0 THEN 1 ELSE 0 END) AS failures
+       FROM tool_calls tc
+       JOIN sessions s ON s.id = tc.session_id
+       GROUP BY project
+       ORDER BY total DESC, project ASC
+       LIMIT ?`,
+    )
+    .all(limit) as { project: string; total: number; failures: number }[];
+
+  return rows.map((r) => ({
+    ...r,
+    successRate: r.total ? (r.total - r.failures) / r.total : 1,
+  }));
+}

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -25,6 +25,7 @@ import { TokenBurn } from "./token-burn/widget";
 import { CalendarHeatmap } from "./calendar-heatmap/widget";
 import { Velocity } from "./velocity/widget";
 import { SessionDuration } from "./session-duration/widget";
+import { Reliability } from "./reliability/widget";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // PLUGIN REGISTRY
@@ -228,5 +229,12 @@ export const widgets: Widget[] = [
     span: "lg:col-span-3",
     height: "h-[360px] min-[2560px]:h-[480px] min-[3840px]:h-[660px]",
     component: SessionDuration,
+  },
+  {
+    id: "reliability",
+    title: "Zuverlässigkeit je Projekt",
+    span: "lg:col-span-3",
+    height: "h-[360px] min-[2560px]:h-[480px] min-[3840px]:h-[660px]",
+    component: Reliability,
   },
 ];

--- a/src/plugins/reliability/widget.tsx
+++ b/src/plugins/reliability/widget.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { ShieldCheck } from "lucide-react";
+import { Panel } from "@/components/panel";
+import { WidgetState } from "@/components/widget-state";
+import { useLive } from "@/components/live-provider";
+import { useSearch, matchesQuery } from "@/components/search";
+import { useT } from "@/lib/i18n";
+import { formatCompact } from "@/lib/format";
+import type { ProjectReliability } from "@/lib/reliability";
+
+function rateColor(rate: number): { bar: string; text: string } {
+  if (rate >= 0.95) return { bar: "bg-emerald-400", text: "text-emerald-400" };
+  if (rate >= 0.85) return { bar: "bg-amber-400", text: "text-amber-400" };
+  return { bar: "bg-red-400", text: "text-red-400" };
+}
+
+export function Reliability() {
+  const { tick } = useLive();
+  const { query } = useSearch();
+  const { t } = useT();
+  const [projects, setProjects] = useState<ProjectReliability[] | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = () =>
+      fetch("/api/reliability?limit=100")
+        .then((r) => r.json())
+        .then((d: { projects: ProjectReliability[] }) => {
+          if (!cancelled) setProjects(d.projects);
+        })
+        .catch(() => {});
+    load();
+    const poll = setInterval(load, 15_000);
+    return () => {
+      cancelled = true;
+      clearInterval(poll);
+    };
+  }, [tick]);
+
+  const filtered = (projects ?? []).filter((p) => matchesQuery(query, p.project));
+
+  return (
+    <Panel title={t("reliability.title")} icon={<ShieldCheck className="h-4 w-4 text-accent" />} info={t("reliability.info")}>
+      {!projects ? (
+        <WidgetState icon={ShieldCheck} title={t("common.loading")} loading />
+      ) : projects.length === 0 ? (
+        <WidgetState icon={ShieldCheck} title={t("reliability.empty")} />
+      ) : filtered.length === 0 ? (
+        <WidgetState icon={ShieldCheck} title={t("common.noResults")} />
+      ) : (
+        <ul className="flex h-full flex-col justify-center gap-2.5 overflow-auto p-4">
+          {filtered.map((p) => {
+            const c = rateColor(p.successRate);
+            return (
+              <li key={p.project} className="mc-stream-in">
+                <div className="mb-0.5 flex items-baseline justify-between gap-2 text-xs">
+                  <span className="truncate font-mono text-foreground" title={p.project}>
+                    {p.project}
+                  </span>
+                  <span className="shrink-0 tabular-nums text-muted">
+                    <span className={c.text}>{(p.successRate * 100).toFixed(0)}%</span> ·{" "}
+                    {formatCompact(p.total)} · {p.failures} {t("reliability.fail")}
+                  </span>
+                </div>
+                <div className="h-2 w-full overflow-hidden rounded-full bg-white/[0.05]">
+                  <div className={`h-full rounded-full ${c.bar} transition-[width]`} style={{ width: `${p.successRate * 100}%` }} />
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </Panel>
+  );
+}


### PR DESCRIPTION
## Summary
- New **Zuverlässigkeit je Projekt / Reliability per project** widget (Run 59): the share of successful tool calls per project as threshold-coloured horizontal bars (green ≥95%, amber ≥85%, else red), with total-call and failure counts, most active first. Integrates with the dashboard-wide search filter.
- Adds `/api/reliability`, a `projectReliability` lib (+ unit tests), a `demoReliability()` source, and de/en i18n.

Research note (per standing instruction): per-category reliability reads best as horizontal bars anchored at 0% with green/red threshold colours (avoiding hard-to-compare stacked segments) — applied here.

## Test plan
- [x] `npm run lint` — clean
- [x] `npx vitest run` — 259 tests pass (new `projectReliability` cases)
- [x] `npm run build` — succeeds (`/api/reliability` route present)
- [x] `npm run test:e2e` — 2 pass, widget `<section>` count bumped 25 → 26

https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk)_