### PR TITLE
Add "what went wrong" incidents widget

### DIFF
--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -43,8 +43,8 @@ test("dashboard renders all four widgets and connects", async ({ page }) => {
 
   await expect(page.getByRole("heading", { name: "Claude Mission Control" })).toBeVisible();
 
-  // Twenty-six widget panels (+ reliability).
-  await expect(page.locator("section")).toHaveCount(26);
+  // Twenty-seven widget panels (+ incidents).
+  await expect(page.locator("section")).toHaveCount(27);
   // Two titles are identical in both locales — safe to assert regardless of language.
   await expect(page.getByText("Sessions", { exact: true })).toBeVisible();
   await expect(page.getByText("Live Stream", { exact: true })).toBeVisible();

--- a/src/app/api/tool-calls/[id]/route.ts
+++ b/src/app/api/tool-calls/[id]/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from "next/server";
+import { db } from "@/lib/db";
+import { toolCallDetail } from "@/lib/errors";
+import { log } from "@/lib/log";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+// A single tool call with its parsed I/O — the read path behind the error drill-down.
+export async function GET(_req: Request, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const callId = Number(id);
+  if (!Number.isInteger(callId) || callId <= 0) {
+    return NextResponse.json({ error: "invalid id" }, { status: 400 });
+  }
+  try {
+    const detail = toolCallDetail(db, callId);
+    if (!detail) return NextResponse.json({ error: "not found" }, { status: 404 });
+    return NextResponse.json({ detail });
+  } catch (err) {
+    log.error("/api/tool-calls/[id] failed", err);
+    return NextResponse.json({ error: "lookup failed" }, { status: 500 });
+  }
+}

--- a/src/lib/demo.ts
+++ b/src/lib/demo.ts
@@ -12,6 +12,7 @@ import type { McpServerUsage } from "./mcp-servers";
 import { streakStats, peakHour, type DayCount } from "./streak";
 import { topTerms } from "./tags";
 import type { ToolTokenBurn } from "./token-burn";
+import type { ToolCallDetail } from "./errors";
 import type { ProjectReliability } from "./reliability";
 import { durationStats } from "./session-duration";
 import type { VelocityDay } from "./velocity";
@@ -470,6 +471,29 @@ export function demoLatency() {
   return { stats: latencyStats(values), tools: ["Read", "Edit", "Bash", "Grep", "WebFetch"] };
 }
 
+const DEMO_ERRORS = [
+  { id: 9001, tool_name: "Bash", target: "npm test", error_text: "exit code 1: 2 failing tests", input: { command: "npm test" } },
+  { id: 9002, tool_name: "Edit", target: "src/app/page.tsx", error_text: "String to replace not found in file.", input: { file_path: "src/app/page.tsx", old_string: "<Foo />" } },
+  { id: 9003, tool_name: "WebFetch", target: "api.example.com", error_text: "fetch failed: ETIMEDOUT after 30000ms", input: { url: "https://api.example.com/v1/data" } },
+  { id: 9004, tool_name: "Read", target: "missing.ts", error_text: "ENOENT: no such file or directory", input: { file_path: "src/missing.ts" } },
+];
+
+export function demoToolCallDetail(id: number): ToolCallDetail | null {
+  const e = DEMO_ERRORS.find((x) => x.id === id);
+  if (!e) return null;
+  return {
+    id: e.id,
+    session_id: "demo-incident",
+    tool_name: e.tool_name,
+    target: e.target,
+    success: 0,
+    created_at: dbNow(),
+    input: e.input,
+    output: null,
+    error_text: e.error_text,
+  };
+}
+
 export function demoErrors() {
   const today = Date.now();
   const series = Array.from({ length: 14 }, (_, i) => {
@@ -487,7 +511,14 @@ export function demoErrors() {
       { tool: "WebFetch", failures: 3, total: 11, rate: 3 / 11 },
       { tool: "Edit", failures: 2, total: 98, rate: 2 / 98 },
     ],
-    recent: [],
+    recent: DEMO_ERRORS.map((e, i) => ({
+      id: e.id,
+      session_id: "demo-incident",
+      tool_name: e.tool_name,
+      target: e.target,
+      error_text: e.error_text,
+      created_at: new Date(today - i * 1_800_000).toISOString().slice(0, 19).replace("T", " "),
+    })),
   };
 }
 
@@ -779,6 +810,11 @@ export function installDemoBackend() {
     if (path.endsWith("/api/velocity")) return json(demoVelocity());
     if (path.endsWith("/api/session-duration")) return json(demoSessionDuration());
     if (path.endsWith("/api/reliability")) return json(demoReliability());
+    if (path.includes("/api/tool-calls/")) {
+      const id = Number(path.split("/api/tool-calls/")[1]);
+      const detail = demoToolCallDetail(id);
+      return detail ? json({ detail }) : new Response("{}", { status: 404 });
+    }
     if (path.endsWith("/api/budget")) return json(demoBudget());
     if (path.endsWith("/api/stats")) return json(demoStats());
     if (path.endsWith("/api/activity")) return json(demoActivity());

--- a/src/lib/errors.test.ts
+++ b/src/lib/errors.test.ts
@@ -1,6 +1,6 @@
 import Database from "better-sqlite3";
 import { afterEach, describe, expect, it } from "vitest";
-import { errorSeries, errorStats, recentErrors, topFailingTools } from "@/lib/errors";
+import { errorSeries, errorStats, recentErrors, toolCallDetail, topFailingTools } from "@/lib/errors";
 import { migrate } from "@/lib/migrations";
 
 let open: Database.Database | null = null;
@@ -92,5 +92,37 @@ describe("topFailingTools", () => {
   it("respects the since window", () => {
     const rows = topFailingTools(dated(), 6, "2026-05-23 00:00:00");
     expect(rows.map((r) => r.tool)).toEqual(["Bash"]); // only the 05-23 failure remains
+  });
+});
+
+describe("toolCallDetail", () => {
+  let open: Database.Database | null = null;
+  afterEach(() => {
+    open?.close();
+    open = null;
+  });
+
+  it("returns the call with parsed I/O", () => {
+    const db = (open = new Database(":memory:"));
+    migrate(db);
+    const info = db
+      .prepare(`INSERT INTO tool_calls (session_id, tool_name, target, success) VALUES (?, ?, ?, 0)`)
+      .run("s1", "Bash", "npm test");
+    const id = Number(info.lastInsertRowid);
+    db.prepare(
+      `INSERT INTO tool_io (tool_call_id, input_json, output_json, is_error, error_text) VALUES (?, ?, ?, 1, ?)`,
+    ).run(id, '{"command":"npm test"}', '{"code":1}', "exit 1");
+
+    const detail = toolCallDetail(db, id)!;
+    expect(detail.tool_name).toBe("Bash");
+    expect(detail.input).toEqual({ command: "npm test" });
+    expect(detail.output).toEqual({ code: 1 });
+    expect(detail.error_text).toBe("exit 1");
+  });
+
+  it("returns null for an unknown id", () => {
+    const db = (open = new Database(":memory:"));
+    migrate(db);
+    expect(toolCallDetail(db, 999)).toBeNull();
   });
 });

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -106,3 +106,60 @@ export function recentErrors(db: Database.Database, limit: number): ErrorItem[] 
     )
     .all(limit) as ErrorItem[];
 }
+
+// One tool call with its parsed I/O — the read path behind the error drill-down.
+export interface ToolCallDetail {
+  id: number;
+  session_id: string;
+  tool_name: string;
+  target: string | null;
+  success: number | null;
+  created_at: string;
+  input: unknown;
+  output: unknown;
+  error_text: string | null;
+}
+
+export function toolCallDetail(db: Database.Database, id: number): ToolCallDetail | null {
+  const row = db
+    .prepare(
+      `SELECT tc.id, tc.session_id, tc.tool_name, tc.target, tc.success, tc.created_at,
+              io.input_json, io.output_json, io.error_text
+       FROM tool_calls tc
+       LEFT JOIN tool_io io ON io.tool_call_id = tc.id
+       WHERE tc.id = ?`,
+    )
+    .get(id) as
+    | {
+        id: number;
+        session_id: string;
+        tool_name: string;
+        target: string | null;
+        success: number | null;
+        created_at: string;
+        input_json: string | null;
+        output_json: string | null;
+        error_text: string | null;
+      }
+    | undefined;
+  if (!row) return null;
+  const parse = (s: string | null): unknown => {
+    if (!s) return null;
+    try {
+      return JSON.parse(s);
+    } catch {
+      return s;
+    }
+  };
+  return {
+    id: row.id,
+    session_id: row.session_id,
+    tool_name: row.tool_name,
+    target: row.target,
+    success: row.success,
+    created_at: row.created_at,
+    input: parse(row.input_json),
+    output: parse(row.output_json),
+    error_text: row.error_text,
+  };
+}

--- a/src/lib/i18n.tsx
+++ b/src/lib/i18n.tsx
@@ -220,6 +220,13 @@ const DE: Record<string, string> = {
   "reliability.empty": "Noch keine Tool-Aufrufe.",
   "reliability.fail": "Fehler",
 
+  "incidents.title": "Was lief schief",
+  "incidents.info": "Letzte fehlgeschlagene Tool-Aufrufe. Klick öffnet Eingabe und Fehlertext.",
+  "incidents.empty": "Keine Fehler – alles grün. 🎉",
+  "incidents.input": "Eingabe",
+  "incidents.error": "Fehler",
+  "incidents.loadError": "Detail konnte nicht geladen werden.",
+
   "search.label": "Sessions und Events durchsuchen",
   "search.placeholder": "Suchen…",
   "search.clear": "Suche löschen",
@@ -501,6 +508,13 @@ const EN: Record<string, string> = {
   "reliability.info": "Share of successful tool calls per project. Green ≥95%, amber ≥85%, else red.",
   "reliability.empty": "No tool calls yet.",
   "reliability.fail": "fail",
+
+  "incidents.title": "What went wrong",
+  "incidents.info": "Latest failed tool calls. Click to reveal the input and error text.",
+  "incidents.empty": "No errors — all green. 🎉",
+  "incidents.input": "Input",
+  "incidents.error": "Error",
+  "incidents.loadError": "Could not load the detail.",
 
   "search.label": "Search sessions and events",
   "search.placeholder": "Search…",

--- a/src/plugins/incidents/widget.tsx
+++ b/src/plugins/incidents/widget.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { AlertTriangle, ChevronDown, ChevronRight } from "lucide-react";
+import { Panel } from "@/components/panel";
+import { WidgetState } from "@/components/widget-state";
+import { useLive } from "@/components/live-provider";
+import { useSearch, matchesQuery } from "@/components/search";
+import { useT } from "@/lib/i18n";
+import { relativeTime } from "@/lib/format";
+import type { ErrorItem, ToolCallDetail } from "@/lib/errors";
+
+type Detail = ToolCallDetail | "loading" | "error";
+
+function pretty(value: unknown): string {
+  if (value == null) return "—";
+  if (typeof value === "string") return value;
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}
+
+export function Incidents() {
+  const { tick } = useLive();
+  const { query } = useSearch();
+  const { t, lang } = useT();
+  const [recent, setRecent] = useState<ErrorItem[] | null>(null);
+  const [openId, setOpenId] = useState<number | null>(null);
+  const [details, setDetails] = useState<Record<number, Detail>>({});
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = () =>
+      fetch("/api/errors?limit=30")
+        .then((r) => r.json())
+        .then((d: { recent: ErrorItem[] }) => {
+          if (!cancelled) setRecent(d.recent ?? []);
+        })
+        .catch(() => {});
+    load();
+    const poll = setInterval(load, 15_000);
+    return () => {
+      cancelled = true;
+      clearInterval(poll);
+    };
+  }, [tick]);
+
+  const toggle = (id: number) => {
+    const next = openId === id ? null : id;
+    setOpenId(next);
+    if (next !== null && details[id] === undefined) {
+      setDetails((d) => ({ ...d, [id]: "loading" }));
+      fetch(`/api/tool-calls/${id}`)
+        .then((r) => (r.ok ? r.json() : Promise.reject()))
+        .then((d: { detail: ToolCallDetail }) => setDetails((prev) => ({ ...prev, [id]: d.detail })))
+        .catch(() => setDetails((prev) => ({ ...prev, [id]: "error" })));
+    }
+  };
+
+  const filtered = (recent ?? []).filter((e) =>
+    matchesQuery(query, e.tool_name, e.target, e.error_text, e.session_id),
+  );
+
+  return (
+    <Panel title={t("incidents.title")} icon={<AlertTriangle className="h-4 w-4 text-accent" />} info={t("incidents.info")}>
+      {!recent ? (
+        <WidgetState icon={AlertTriangle} title={t("common.loading")} loading />
+      ) : recent.length === 0 ? (
+        <WidgetState icon={AlertTriangle} title={t("incidents.empty")} />
+      ) : filtered.length === 0 ? (
+        <WidgetState icon={AlertTriangle} title={t("common.noResults")} />
+      ) : (
+        <ul className="divide-y divide-panel-border/60">
+          {filtered.map((e) => {
+            const open = openId === e.id;
+            const detail = details[e.id];
+            return (
+              <li key={e.id} className="mc-stream-in">
+                <button
+                  onClick={() => toggle(e.id)}
+                  aria-expanded={open}
+                  className="flex w-full items-start gap-2 px-4 py-2 text-left transition-colors hover:bg-white/[0.03]"
+                >
+                  {open ? (
+                    <ChevronDown className="mt-0.5 h-3.5 w-3.5 shrink-0 text-muted" />
+                  ) : (
+                    <ChevronRight className="mt-0.5 h-3.5 w-3.5 shrink-0 text-muted" />
+                  )}
+                  <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0 text-red-400" />
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-baseline gap-2">
+                      <span className="font-mono text-sm text-foreground">{e.tool_name}</span>
+                      {e.target && (
+                        <span className="truncate font-mono text-[11px] text-muted" title={e.target}>
+                          {e.target}
+                        </span>
+                      )}
+                    </div>
+                    {e.error_text && (
+                      <p className={`truncate text-[11px] text-red-400/90 ${open ? "hidden" : ""}`}>{e.error_text}</p>
+                    )}
+                  </div>
+                  <span className="shrink-0 whitespace-nowrap text-[11px] text-muted">
+                    {relativeTime(e.created_at, lang)}
+                  </span>
+                </button>
+                {open && (
+                  <div className="space-y-2 px-4 pb-3 pl-9 text-[11px]">
+                    {detail === "loading" || detail === undefined ? (
+                      <p className="text-muted">{t("common.loading")}</p>
+                    ) : detail === "error" ? (
+                      <p className="text-muted">{t("incidents.loadError")}</p>
+                    ) : (
+                      <>
+                        <Field label={t("incidents.input")} value={pretty(detail.input)} />
+                        <Field
+                          label={t("incidents.error")}
+                          value={detail.error_text ?? pretty(detail.output)}
+                          tone="text-red-400/90"
+                        />
+                        <p className="font-mono text-[10px] text-muted">{detail.session_id}</p>
+                      </>
+                    )}
+                  </div>
+                )}
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </Panel>
+  );
+}
+
+function Field({ label, value, tone = "text-foreground" }: { label: string; value: string; tone?: string }) {
+  return (
+    <div>
+      <p className="mb-0.5 uppercase tracking-wide text-muted">{label}</p>
+      <pre className={`max-h-28 overflow-auto whitespace-pre-wrap break-words rounded bg-black/30 p-2 font-mono ${tone}`}>
+        {value}
+      </pre>
+    </div>
+  );
+}

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -26,6 +26,7 @@ import { CalendarHeatmap } from "./calendar-heatmap/widget";
 import { Velocity } from "./velocity/widget";
 import { SessionDuration } from "./session-duration/widget";
 import { Reliability } from "./reliability/widget";
+import { Incidents } from "./incidents/widget";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // PLUGIN REGISTRY
@@ -236,5 +237,12 @@ export const widgets: Widget[] = [
     span: "lg:col-span-3",
     height: "h-[360px] min-[2560px]:h-[480px] min-[3840px]:h-[660px]",
     component: Reliability,
+  },
+  {
+    id: "incidents",
+    title: "Was lief schief",
+    span: "lg:col-span-3",
+    height: "h-[360px] min-[2560px]:h-[480px] min-[3840px]:h-[660px]",
+    component: Incidents,
   },
 ];


### PR DESCRIPTION
## Summary
- New **Was lief schief / What went wrong** widget (Run 60): the latest failed tool calls as expandable rows. Clicking a row drills down (one click) into that tool call's **input** and **error text**, fetched from a new `/api/tool-calls/[id]` route — keeping you in place in the list. Integrates with the dashboard-wide search filter.
- Adds the drill-down route, a `toolCallDetail` lib helper (parses stored tool I/O) with unit tests, demo errors + a `demoToolCallDetail()` source (with a demo fetch patch for the id route), and de/en i18n.

Research note (per standing instruction): error/incident feeds read best as expandable rows with a chevron that reveal detail in place, with monospace formatting for the error text — applied here.

## Test plan
- [x] `npm run lint` — clean
- [x] `npx vitest run` — 261 tests pass (new `toolCallDetail` cases)
- [x] `npm run build` — succeeds (`/api/tool-calls/[id]` route present)
- [x] `npm run test:e2e` — 2 pass, widget `<section>` count bumped 26 → 27

https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk)_