### PR TITLE
Add per-widget resize (width/height)

### DIFF
--- a/src/components/dashboard.tsx
+++ b/src/components/dashboard.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { Activity, GripHorizontal, RotateCcw, Search, X } from "lucide-react";
+import { Activity, GripHorizontal, MoveHorizontal, MoveVertical, RotateCcw, Search, X } from "lucide-react";
 import { LiveProvider, useLive } from "@/components/live-provider";
 import { RadarLogo } from "@/components/radar-logo";
 import { LangToggle } from "@/components/lang-toggle";
@@ -11,6 +11,7 @@ import { Landing } from "@/components/landing";
 import { SearchProvider, useSearch } from "@/components/search";
 import { useT } from "@/lib/i18n";
 import { DEMO, installDemoBackend } from "@/lib/demo";
+import { HEIGHT_PRESETS, nextPreset, sanitizeSizes, SPAN_PRESETS, type SizeMap } from "@/lib/layout";
 import { widgets } from "@/plugins/registry";
 
 // In the static demo build, start the in-browser engine + patch fetch before any
@@ -19,6 +20,17 @@ if (DEMO) installDemoBackend();
 
 const DEFAULT_ORDER = widgets.map((w) => w.id);
 const ORDER_KEY = "mc-widget-order";
+const SIZE_KEY = "mc-widget-sizes";
+
+function loadSizes(): SizeMap {
+  try {
+    const raw = localStorage.getItem(SIZE_KEY);
+    if (!raw) return {};
+    return sanitizeSizes(JSON.parse(raw), DEFAULT_ORDER);
+  } catch {
+    return {};
+  }
+}
 
 // Read a saved panel order, keeping only known ids and appending any new widgets
 // so the layout survives plugin additions/removals.
@@ -40,16 +52,20 @@ export function Dashboard() {
   const { t } = useT();
   // Start from the default order (hydration-safe), then adopt any saved order.
   const [order, setOrder] = useState<string[]>(DEFAULT_ORDER);
+  const [sizes, setSizes] = useState<SizeMap>({});
   const [dragId, setDragId] = useState<string | null>(null);
 
   useEffect(() => {
-    // Defer to a frame so the saved order is adopted after hydration (avoids a
-    // server/client DOM-order mismatch when a custom layout is stored).
-    const id = requestAnimationFrame(() => setOrder(loadOrder()));
+    // Defer to a frame so the saved layout is adopted after hydration (avoids a
+    // server/client DOM mismatch when a custom layout is stored).
+    const id = requestAnimationFrame(() => {
+      setOrder(loadOrder());
+      setSizes(loadSizes());
+    });
     return () => cancelAnimationFrame(id);
   }, []);
 
-  const isCustom = order.join(",") !== DEFAULT_ORDER.join(",");
+  const isCustom = order.join(",") !== DEFAULT_ORDER.join(",") || Object.keys(sizes).length > 0;
 
   const persist = useCallback((next: string[]) => {
     setOrder(next);
@@ -60,6 +76,33 @@ export function Dashboard() {
       /* storage unavailable — order still applies for this session */
     }
   }, []);
+
+  const persistSizes = useCallback((next: SizeMap) => {
+    setSizes(next);
+    try {
+      if (Object.keys(next).length === 0) localStorage.removeItem(SIZE_KEY);
+      else localStorage.setItem(SIZE_KEY, JSON.stringify(next));
+    } catch {
+      /* storage unavailable — sizes still apply for this session */
+    }
+  }, []);
+
+  // Set a widget's size, dropping the override when it matches the registry default.
+  const setSize = useCallback(
+    (id: string, span: string, height: string) => {
+      const def = widgets.find((w) => w.id === id);
+      const next = { ...sizes };
+      if (def && span === def.span && height === def.height) delete next[id];
+      else next[id] = { span, height };
+      persistSizes(next);
+    },
+    [sizes, persistSizes],
+  );
+
+  const resetLayout = useCallback(() => {
+    persist(DEFAULT_ORDER);
+    persistSizes({});
+  }, [persist, persistSizes]);
 
   const onDropOn = useCallback(
     (targetId: string) => {
@@ -89,9 +132,12 @@ export function Dashboard() {
       <SearchProvider>
         {DEMO && <Landing />}
         <div className="mx-auto flex min-h-screen max-w-[1600px] flex-col gap-4 p-4 sm:p-6 min-[2560px]:max-w-none min-[2560px]:gap-6 min-[2560px]:p-8 min-[3840px]:gap-8 min-[3840px]:p-12">
-          <Header isCustomLayout={isCustom} onResetLayout={() => persist(DEFAULT_ORDER)} />
+          <Header isCustomLayout={isCustom} onResetLayout={resetLayout} />
           <div className="grid grid-cols-1 gap-4 min-[2560px]:gap-6 min-[3840px]:gap-8 lg:grid-cols-6">
-            {ordered.map((w, i) => (
+            {ordered.map((w, i) => {
+              const span = sizes[w.id]?.span ?? w.span;
+              const height = sizes[w.id]?.height ?? w.height;
+              return (
               <div
                 key={w.id}
                 // The 3D graph goes fullscreen via position:fixed, which breaks if an
@@ -99,17 +145,21 @@ export function Dashboard() {
                 // (no transform) while the others keep the subtle rise. `relative`
                 // does not establish a containing block for fixed children, so the
                 // drag handle below is safe for the fullscreen graph.
-                className={`group relative ${w.id === "tool-graph" ? "mc-fade-in" : "mc-fade-up"} ${w.span} ${w.height} ${dragId === w.id ? "opacity-50" : ""}`}
+                className={`group relative ${w.id === "tool-graph" ? "mc-fade-in" : "mc-fade-up"} ${span} ${height} ${dragId === w.id ? "opacity-50" : ""}`}
                 style={{ animationDelay: `${i * 80}ms` }}
                 onDragOver={(e) => {
                   if (dragId) e.preventDefault();
                 }}
                 onDrop={() => onDropOn(w.id)}
               >
-                <DragHandle
-                  label={t("layout.drag")}
+                <WidgetToolbar
+                  dragLabel={t("layout.drag")}
+                  widthLabel={t("layout.width")}
+                  heightLabel={t("layout.height")}
                   onStart={() => setDragId(w.id)}
                   onEnd={() => setDragId(null)}
+                  onWidth={() => setSize(w.id, nextPreset(SPAN_PRESETS, span), height)}
+                  onHeight={() => setSize(w.id, span, nextPreset(HEIGHT_PRESETS, height))}
                 />
                 <WidgetErrorBoundary
                   label={w.title}
@@ -120,7 +170,8 @@ export function Dashboard() {
                   <w.component />
                 </WidgetErrorBoundary>
               </div>
-            ))}
+              );
+            })}
           </div>
           <footer className="pt-2 text-center text-[11px] text-muted/60">
             {t("footer.text")} · <span className="text-muted">by Belkis Aslani</span>
@@ -131,24 +182,50 @@ export function Dashboard() {
   );
 }
 
-function DragHandle({ label, onStart, onEnd }: { label: string; onStart: () => void; onEnd: () => void }) {
+function WidgetToolbar({
+  dragLabel,
+  widthLabel,
+  heightLabel,
+  onStart,
+  onEnd,
+  onWidth,
+  onHeight,
+}: {
+  dragLabel: string;
+  widthLabel: string;
+  heightLabel: string;
+  onStart: () => void;
+  onEnd: () => void;
+  onWidth: () => void;
+  onHeight: () => void;
+}) {
+  const btn =
+    "rounded p-0.5 text-muted transition-colors hover:text-foreground focus-visible:text-foreground";
   return (
-    <button
-      type="button"
-      draggable
-      aria-label={label}
-      title={label}
-      onDragStart={(e) => {
-        e.dataTransfer.effectAllowed = "move";
-        // Some browsers require data to be set for a drag to begin.
-        e.dataTransfer.setData("text/plain", "");
-        onStart();
-      }}
-      onDragEnd={onEnd}
-      className="absolute left-1/2 top-1 z-20 -translate-x-1/2 cursor-grab rounded-md border border-panel-border bg-panel/90 px-2 py-0.5 text-muted opacity-0 shadow-md shadow-black/30 backdrop-blur transition-opacity duration-150 hover:text-foreground focus-visible:opacity-100 group-hover:opacity-100 active:cursor-grabbing"
-    >
-      <GripHorizontal className="h-3.5 w-3.5" />
-    </button>
+    <div className="absolute left-1/2 top-1 z-20 flex -translate-x-1/2 items-center gap-0.5 rounded-md border border-panel-border bg-panel/90 px-1 py-0.5 opacity-0 shadow-md shadow-black/30 backdrop-blur transition-opacity duration-150 focus-within:opacity-100 group-hover:opacity-100">
+      <button
+        type="button"
+        draggable
+        aria-label={dragLabel}
+        title={dragLabel}
+        onDragStart={(e) => {
+          e.dataTransfer.effectAllowed = "move";
+          // Some browsers require data to be set for a drag to begin.
+          e.dataTransfer.setData("text/plain", "");
+          onStart();
+        }}
+        onDragEnd={onEnd}
+        className={`${btn} cursor-grab active:cursor-grabbing`}
+      >
+        <GripHorizontal className="h-3.5 w-3.5" />
+      </button>
+      <button type="button" aria-label={widthLabel} title={widthLabel} onClick={onWidth} className={btn}>
+        <MoveHorizontal className="h-3.5 w-3.5" />
+      </button>
+      <button type="button" aria-label={heightLabel} title={heightLabel} onClick={onHeight} className={btn}>
+        <MoveVertical className="h-3.5 w-3.5" />
+      </button>
+    </div>
   );
 }
 

--- a/src/lib/i18n.tsx
+++ b/src/lib/i18n.tsx
@@ -233,6 +233,8 @@ const DE: Record<string, string> = {
 
   "layout.drag": "Zum Umordnen ziehen",
   "layout.reset": "Layout zurücksetzen",
+  "layout.width": "Breite ändern",
+  "layout.height": "Höhe ändern",
 
   "status.active": "Aktiv",
   "status.waiting": "Wartet",
@@ -522,6 +524,8 @@ const EN: Record<string, string> = {
 
   "layout.drag": "Drag to reorder",
   "layout.reset": "Reset layout",
+  "layout.width": "Change width",
+  "layout.height": "Change height",
 
   "status.active": "Active",
   "status.waiting": "Waiting",

--- a/src/lib/layout.test.ts
+++ b/src/lib/layout.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { HEIGHT_PRESETS, nextPreset, sanitizeSizes, SPAN_PRESETS } from "@/lib/layout";
+
+describe("nextPreset", () => {
+  it("advances and wraps around", () => {
+    expect(nextPreset(SPAN_PRESETS, "lg:col-span-2")).toBe("lg:col-span-3");
+    expect(nextPreset(SPAN_PRESETS, SPAN_PRESETS[SPAN_PRESETS.length - 1])).toBe(SPAN_PRESETS[0]);
+  });
+
+  it("falls back to the first entry for an unknown current value", () => {
+    expect(nextPreset(HEIGHT_PRESETS, "h-[999px]")).toBe(HEIGHT_PRESETS[0]);
+  });
+});
+
+describe("sanitizeSizes", () => {
+  const valid = ["a", "b"];
+
+  it("keeps only known ids with valid span + height", () => {
+    const out = sanitizeSizes(
+      {
+        a: { span: "lg:col-span-4", height: "h-auto" },
+        b: { span: 123, height: "h-auto" }, // bad span
+        c: { span: "lg:col-span-2", height: "h-auto" }, // unknown id
+      },
+      valid,
+    );
+    expect(out).toEqual({ a: { span: "lg:col-span-4", height: "h-auto" } });
+  });
+
+  it("returns an empty map for non-object input", () => {
+    expect(sanitizeSizes(null, valid)).toEqual({});
+    expect(sanitizeSizes("nope", valid)).toEqual({});
+  });
+});

--- a/src/lib/layout.ts
+++ b/src/lib/layout.ts
@@ -1,0 +1,45 @@
+// Per-widget size overrides for the dashboard grid. Widths map to the 6-col
+// desktop grid; heights cycle through a few presets. Kept here (pure) so the
+// cycling + persistence-sanitising logic is unit-testable.
+
+export const SPAN_PRESETS = [
+  "lg:col-span-2",
+  "lg:col-span-3",
+  "lg:col-span-4",
+  "lg:col-span-6",
+];
+
+export const HEIGHT_PRESETS = [
+  "h-[300px]",
+  "h-[360px] min-[2560px]:h-[480px] min-[3840px]:h-[660px]",
+  "h-[520px] min-[2560px]:h-[680px] min-[3840px]:h-[900px]",
+  "h-auto",
+];
+
+export interface WidgetSize {
+  span: string;
+  height: string;
+}
+
+export type SizeMap = Record<string, WidgetSize>;
+
+// Next entry in a preset list, wrapping around. Falls back to the first entry
+// when the current value isn't a known preset (e.g. a widget's default span).
+export function nextPreset(list: string[], current: string): string {
+  const i = list.indexOf(current);
+  return list[(i + 1) % list.length] ?? list[0];
+}
+
+// Keep only overrides for known widgets that carry a valid span + height.
+export function sanitizeSizes(raw: unknown, validIds: string[]): SizeMap {
+  if (!raw || typeof raw !== "object") return {};
+  const out: SizeMap = {};
+  for (const [id, v] of Object.entries(raw as Record<string, unknown>)) {
+    if (!validIds.includes(id)) continue;
+    const o = v as { span?: unknown; height?: unknown };
+    if (typeof o.span === "string" && typeof o.height === "string") {
+      out[id] = { span: o.span, height: o.height };
+    }
+  }
+  return out;
+}


### PR DESCRIPTION
## Summary
- **Anpassbare Widget-Größe / Per-widget resize** (Run 61): extends the existing drag-reorder with a per-widget hover toolbar — a grip to reorder (unchanged) plus **width** and **height** buttons that cycle through span/height presets. Overrides persist to `localStorage` (`mc-widget-sizes`), are dropped when they match the registry default, and the existing **Reset layout** button now clears both order and sizes.
- Adds a pure `layout` lib (`nextPreset`, `sanitizeSizes`, presets) with unit tests, and de/en i18n (`layout.width`, `layout.height`).

### On "can everything be moved?"
Verified in code: every widget cell renders the toolbar with a draggable grip, so **all 27 widgets are drag-reorderable** (and now resizable). I can't perform a real click-drag in this headless environment, but the mechanism is wired uniformly for every widget and all gates pass.

Research/UX note: resize affordances live in the same hover toolbar as the drag grip, keeping per-widget controls discoverable without cluttering the panels.

## Test plan
- [x] `npm run lint` — clean
- [x] `npx vitest run` — 265 tests pass (new `nextPreset` + `sanitizeSizes` cases)
- [x] `npm run build` — succeeds
- [x] `npm run test:e2e` — 2 pass (widget count unchanged at 27; this is a layout feature, not a new widget)

https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk)_