### PR TITLE
Add widget gallery (show/hide widgets)

### DIFF
--- a/src/components/dashboard.tsx
+++ b/src/components/dashboard.tsx
@@ -1,7 +1,18 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { Activity, GripHorizontal, MoveHorizontal, MoveVertical, RotateCcw, Search, X } from "lucide-react";
+import {
+  Activity,
+  Eye,
+  EyeOff,
+  GripHorizontal,
+  LayoutGrid,
+  MoveHorizontal,
+  MoveVertical,
+  RotateCcw,
+  Search,
+  X,
+} from "lucide-react";
 import { LiveProvider, useLive } from "@/components/live-provider";
 import { RadarLogo } from "@/components/radar-logo";
 import { LangToggle } from "@/components/lang-toggle";
@@ -11,7 +22,14 @@ import { Landing } from "@/components/landing";
 import { SearchProvider, useSearch } from "@/components/search";
 import { useT } from "@/lib/i18n";
 import { DEMO, installDemoBackend } from "@/lib/demo";
-import { HEIGHT_PRESETS, nextPreset, sanitizeSizes, SPAN_PRESETS, type SizeMap } from "@/lib/layout";
+import {
+  HEIGHT_PRESETS,
+  nextPreset,
+  sanitizeIdList,
+  sanitizeSizes,
+  SPAN_PRESETS,
+  type SizeMap,
+} from "@/lib/layout";
 import { widgets } from "@/plugins/registry";
 
 // In the static demo build, start the in-browser engine + patch fetch before any
@@ -21,6 +39,7 @@ if (DEMO) installDemoBackend();
 const DEFAULT_ORDER = widgets.map((w) => w.id);
 const ORDER_KEY = "mc-widget-order";
 const SIZE_KEY = "mc-widget-sizes";
+const HIDDEN_KEY = "mc-widget-hidden";
 
 function loadSizes(): SizeMap {
   try {
@@ -29,6 +48,16 @@ function loadSizes(): SizeMap {
     return sanitizeSizes(JSON.parse(raw), DEFAULT_ORDER);
   } catch {
     return {};
+  }
+}
+
+function loadHidden(): string[] {
+  try {
+    const raw = localStorage.getItem(HIDDEN_KEY);
+    if (!raw) return [];
+    return sanitizeIdList(JSON.parse(raw), DEFAULT_ORDER);
+  } catch {
+    return [];
   }
 }
 
@@ -53,6 +82,8 @@ export function Dashboard() {
   // Start from the default order (hydration-safe), then adopt any saved order.
   const [order, setOrder] = useState<string[]>(DEFAULT_ORDER);
   const [sizes, setSizes] = useState<SizeMap>({});
+  const [hidden, setHidden] = useState<string[]>([]);
+  const [galleryOpen, setGalleryOpen] = useState(false);
   const [dragId, setDragId] = useState<string | null>(null);
 
   useEffect(() => {
@@ -61,11 +92,13 @@ export function Dashboard() {
     const id = requestAnimationFrame(() => {
       setOrder(loadOrder());
       setSizes(loadSizes());
+      setHidden(loadHidden());
     });
     return () => cancelAnimationFrame(id);
   }, []);
 
-  const isCustom = order.join(",") !== DEFAULT_ORDER.join(",") || Object.keys(sizes).length > 0;
+  const isCustom =
+    order.join(",") !== DEFAULT_ORDER.join(",") || Object.keys(sizes).length > 0 || hidden.length > 0;
 
   const persist = useCallback((next: string[]) => {
     setOrder(next);
@@ -99,10 +132,37 @@ export function Dashboard() {
     [sizes, persistSizes],
   );
 
+  const persistHidden = useCallback((next: string[]) => {
+    setHidden(next);
+    try {
+      if (next.length === 0) localStorage.removeItem(HIDDEN_KEY);
+      else localStorage.setItem(HIDDEN_KEY, JSON.stringify(next));
+    } catch {
+      /* storage unavailable — visibility still applies for this session */
+    }
+  }, []);
+
+  const toggleHidden = useCallback(
+    (id: string) => {
+      setHidden((prev) => {
+        const next = prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id];
+        try {
+          if (next.length === 0) localStorage.removeItem(HIDDEN_KEY);
+          else localStorage.setItem(HIDDEN_KEY, JSON.stringify(next));
+        } catch {
+          /* storage unavailable */
+        }
+        return next;
+      });
+    },
+    [],
+  );
+
   const resetLayout = useCallback(() => {
     persist(DEFAULT_ORDER);
     persistSizes({});
-  }, [persist, persistSizes]);
+    persistHidden([]);
+  }, [persist, persistSizes, persistHidden]);
 
   const onDropOn = useCallback(
     (targetId: string) => {
@@ -123,8 +183,11 @@ export function Dashboard() {
 
   const byId = useMemo(() => new Map(widgets.map((w) => [w.id, w])), []);
   const ordered = useMemo(
-    () => order.map((id) => byId.get(id)).filter((w): w is (typeof widgets)[number] => Boolean(w)),
-    [order, byId],
+    () =>
+      order
+        .map((id) => byId.get(id))
+        .filter((w): w is (typeof widgets)[number] => Boolean(w) && !hidden.includes(w!.id)),
+    [order, byId, hidden],
   );
 
   return (
@@ -132,7 +195,16 @@ export function Dashboard() {
       <SearchProvider>
         {DEMO && <Landing />}
         <div className="mx-auto flex min-h-screen max-w-[1600px] flex-col gap-4 p-4 sm:p-6 min-[2560px]:max-w-none min-[2560px]:gap-6 min-[2560px]:p-8 min-[3840px]:gap-8 min-[3840px]:p-12">
-          <Header isCustomLayout={isCustom} onResetLayout={resetLayout} />
+          <Header
+            isCustomLayout={isCustom}
+            onResetLayout={resetLayout}
+            onOpenGallery={() => setGalleryOpen(true)}
+          />
+          {ordered.length === 0 && (
+            <div className="rounded-xl border border-dashed border-panel-border bg-panel/40 p-10 text-center text-sm text-muted">
+              {t("gallery.allHidden")}
+            </div>
+          )}
           <div className="grid grid-cols-1 gap-4 min-[2560px]:gap-6 min-[3840px]:gap-8 lg:grid-cols-6">
             {ordered.map((w, i) => {
               const span = sizes[w.id]?.span ?? w.span;
@@ -177,6 +249,16 @@ export function Dashboard() {
             {t("footer.text")} · <span className="text-muted">by Belkis Aslani</span>
           </footer>
         </div>
+        {galleryOpen && (
+          <WidgetGallery
+            order={order}
+            byId={byId}
+            hidden={hidden}
+            onToggle={toggleHidden}
+            onShowAll={() => persistHidden([])}
+            onClose={() => setGalleryOpen(false)}
+          />
+        )}
       </SearchProvider>
     </LiveProvider>
   );
@@ -232,9 +314,11 @@ function WidgetToolbar({
 function Header({
   isCustomLayout,
   onResetLayout,
+  onOpenGallery,
 }: {
   isCustomLayout: boolean;
   onResetLayout: () => void;
+  onOpenGallery: () => void;
 }) {
   const { connected, events } = useLive();
   const { t, lang } = useT();
@@ -285,6 +369,15 @@ function Header({
             </button>
           )}
         </label>
+        <button
+          type="button"
+          onClick={onOpenGallery}
+          aria-label={t("gallery.title")}
+          title={t("gallery.title")}
+          className="hidden items-center rounded-full border border-panel-border bg-background/40 p-1.5 text-muted transition-colors hover:border-accent/50 hover:text-foreground sm:flex"
+        >
+          <LayoutGrid className="h-3.5 w-3.5" />
+        </button>
         {isCustomLayout && (
           <button
             type="button"
@@ -319,5 +412,89 @@ function Header({
         </span>
       </div>
     </header>
+  );
+}
+
+function WidgetGallery({
+  order,
+  byId,
+  hidden,
+  onToggle,
+  onShowAll,
+  onClose,
+}: {
+  order: string[];
+  byId: Map<string, (typeof widgets)[number]>;
+  hidden: string[];
+  onToggle: (id: string) => void;
+  onShowAll: () => void;
+  onClose: () => void;
+}) {
+  const { t } = useT();
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  const items = order
+    .map((id) => byId.get(id))
+    .filter((w): w is (typeof widgets)[number] => Boolean(w));
+  const visibleCount = items.filter((w) => !hidden.includes(w.id)).length;
+
+  return (
+    <div role="dialog" aria-modal="true" aria-label={t("gallery.title")} className="fixed inset-0 z-50 flex items-center justify-center p-4">
+      <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" onClick={onClose} aria-hidden />
+      <div className="relative z-10 flex max-h-[80vh] w-full max-w-md flex-col overflow-hidden rounded-xl border border-panel-border bg-panel shadow-2xl shadow-black/50">
+        <header className="flex items-center justify-between border-b border-panel-border px-4 py-3">
+          <div className="flex items-center gap-2 text-sm font-semibold text-foreground">
+            <LayoutGrid className="h-4 w-4 text-accent" />
+            {t("gallery.title")}
+            <span className="text-xs font-normal text-muted">
+              {visibleCount}/{items.length}
+            </span>
+          </div>
+          <button type="button" onClick={onClose} aria-label={t("gallery.close")} title={t("gallery.close")} className="text-muted hover:text-foreground">
+            <X className="h-4 w-4" />
+          </button>
+        </header>
+        <p className="px-4 pt-3 text-xs text-muted">{t("gallery.info")}</p>
+        <ul className="min-h-0 flex-1 overflow-auto p-2">
+          {items.map((w) => {
+            const isHidden = hidden.includes(w.id);
+            return (
+              <li key={w.id}>
+                <button
+                  type="button"
+                  onClick={() => onToggle(w.id)}
+                  aria-pressed={!isHidden}
+                  className="flex w-full items-center gap-3 rounded-lg px-3 py-2 text-left text-sm transition-colors hover:bg-white/[0.04]"
+                >
+                  {isHidden ? (
+                    <EyeOff className="h-4 w-4 shrink-0 text-muted" />
+                  ) : (
+                    <Eye className="h-4 w-4 shrink-0 text-accent" />
+                  )}
+                  <span className={`flex-1 truncate ${isHidden ? "text-muted line-through" : "text-foreground"}`}>
+                    {w.title}
+                  </span>
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+        <footer className="flex justify-end gap-2 border-t border-panel-border px-4 py-3">
+          <button type="button" onClick={onShowAll} className="rounded-md border border-panel-border px-3 py-1.5 text-xs text-muted transition-colors hover:text-foreground">
+            {t("gallery.showAll")}
+          </button>
+          <button type="button" onClick={onClose} className="rounded-md bg-accent px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-accent/90">
+            {t("gallery.done")}
+          </button>
+        </footer>
+      </div>
+    </div>
   );
 }

--- a/src/lib/i18n.tsx
+++ b/src/lib/i18n.tsx
@@ -236,6 +236,13 @@ const DE: Record<string, string> = {
   "layout.width": "Breite ändern",
   "layout.height": "Höhe ändern",
 
+  "gallery.title": "Widget-Galerie",
+  "gallery.info": "Widgets ein- oder ausblenden. Reihenfolge und Größe änderst du direkt am Widget.",
+  "gallery.close": "Schließen",
+  "gallery.showAll": "Alle anzeigen",
+  "gallery.done": "Fertig",
+  "gallery.allHidden": "Alle Widgets ausgeblendet. Öffne die Galerie, um welche einzublenden.",
+
   "status.active": "Aktiv",
   "status.waiting": "Wartet",
   "status.ended": "Beendet",
@@ -526,6 +533,13 @@ const EN: Record<string, string> = {
   "layout.reset": "Reset layout",
   "layout.width": "Change width",
   "layout.height": "Change height",
+
+  "gallery.title": "Widget gallery",
+  "gallery.info": "Show or hide widgets. Reorder and resize directly on the widget.",
+  "gallery.close": "Close",
+  "gallery.showAll": "Show all",
+  "gallery.done": "Done",
+  "gallery.allHidden": "All widgets hidden. Open the gallery to show some.",
 
   "status.active": "Active",
   "status.waiting": "Waiting",

--- a/src/lib/layout.test.ts
+++ b/src/lib/layout.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { HEIGHT_PRESETS, nextPreset, sanitizeSizes, SPAN_PRESETS } from "@/lib/layout";
+import { HEIGHT_PRESETS, nextPreset, sanitizeIdList, sanitizeSizes, SPAN_PRESETS } from "@/lib/layout";
 
 describe("nextPreset", () => {
   it("advances and wraps around", () => {
@@ -30,5 +30,16 @@ describe("sanitizeSizes", () => {
   it("returns an empty map for non-object input", () => {
     expect(sanitizeSizes(null, valid)).toEqual({});
     expect(sanitizeSizes("nope", valid)).toEqual({});
+  });
+});
+
+describe("sanitizeIdList", () => {
+  it("keeps known string ids and dedupes them", () => {
+    expect(sanitizeIdList(["a", "b", "a", "x", 5], ["a", "b"])).toEqual(["a", "b"]);
+  });
+
+  it("returns an empty array for non-array input", () => {
+    expect(sanitizeIdList(null, ["a"])).toEqual([]);
+    expect(sanitizeIdList({}, ["a"])).toEqual([]);
   });
 });

--- a/src/lib/layout.ts
+++ b/src/lib/layout.ts
@@ -30,6 +30,16 @@ export function nextPreset(list: string[], current: string): string {
   return list[(i + 1) % list.length] ?? list[0];
 }
 
+// Keep only known string ids (deduped), e.g. the hidden-widget list.
+export function sanitizeIdList(raw: unknown, validIds: string[]): string[] {
+  if (!Array.isArray(raw)) return [];
+  const seen = new Set<string>();
+  for (const id of raw) {
+    if (typeof id === "string" && validIds.includes(id)) seen.add(id);
+  }
+  return [...seen];
+}
+
 // Keep only overrides for known widgets that carry a valid span + height.
 export function sanitizeSizes(raw: unknown, validIds: string[]): SizeMap {
   if (!raw || typeof raw !== "object") return {};


### PR DESCRIPTION
## Summary
- **Widget-Galerie / Widget gallery** (Run 62, completes Phase D): a header button opens an in-app modal picker that lists every registered widget with an eye toggle to show/hide it (plus a visible/total count, "show all", and Escape/backdrop to close). Hidden widgets persist to `localStorage` (`mc-widget-hidden`) and are excluded from the grid; an empty-state hint appears when all are hidden. **Reset layout** now also restores visibility (order + size + hidden).
- Adds a pure `sanitizeIdList` layout helper (+ unit tests) and de/en i18n.

The dashboard is now composable: every widget can be reordered (Run 38-era drag), resized (Run 61), and shown/hidden (this run) — all persisted locally, all reversible via Reset.

Research/UX note: the gallery is a single integrated modal of simple per-widget toggles (the picker pattern recommended for ≤ a few dozen items), keeping customization discoverable without cluttering the panels.

## Test plan
- [x] `npm run lint` — clean
- [x] `npx vitest run` — 267 tests pass (new `sanitizeIdList` cases)
- [x] `npm run build` — succeeds
- [x] `npm run test:e2e` — 2 pass (default visibility unchanged → widget `<section>` count stays 27)

https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk)_