### PR TITLE
Add collapsible JSON tree viewer

### DIFF
--- a/src/components/json-tree.tsx
+++ b/src/components/json-tree.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { useState } from "react";
+import { ChevronDown, ChevronRight } from "lucide-react";
+import { isExpandable, nodeSummary, valueKind, type JsonKind } from "@/lib/json-tree";
+
+const COLOR: Record<JsonKind, string> = {
+  string: "text-emerald-400",
+  number: "text-sky-400",
+  boolean: "text-amber-400",
+  null: "text-muted",
+  object: "text-foreground",
+  array: "text-foreground",
+};
+
+// Collapsible JSON viewer. Containers lazily render children only when open;
+// each node is type-coloured. `defaultDepth` controls how deep it starts open.
+export function JsonTree({ data, defaultDepth = 1 }: { data: unknown; defaultDepth?: number }) {
+  return (
+    <div className="font-mono text-[11px] leading-relaxed">
+      <JsonNode value={data} name={null} depth={0} defaultDepth={defaultDepth} />
+    </div>
+  );
+}
+
+function JsonNode({
+  value,
+  name,
+  depth,
+  defaultDepth,
+}: {
+  value: unknown;
+  name: string | null;
+  depth: number;
+  defaultDepth: number;
+}) {
+  const [open, setOpen] = useState(depth < defaultDepth);
+  const kind = valueKind(value);
+  const key = name !== null ? <span className="text-violet-300">{name}: </span> : null;
+
+  if (!isExpandable(value)) {
+    return (
+      <div className="py-px" style={{ paddingLeft: depth * 12 + 16 }}>
+        {key}
+        <span className={COLOR[kind]}>{nodeSummary(value)}</span>
+      </div>
+    );
+  }
+
+  const entries = Array.isArray(value)
+    ? value.map((v, i) => [String(i), v] as const)
+    : Object.entries(value as Record<string, unknown>);
+
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        aria-expanded={open}
+        className="flex w-full items-center gap-1 py-px text-left transition-colors hover:bg-white/[0.03]"
+        style={{ paddingLeft: depth * 12 }}
+      >
+        {open ? (
+          <ChevronDown className="h-3 w-3 shrink-0 text-muted" />
+        ) : (
+          <ChevronRight className="h-3 w-3 shrink-0 text-muted" />
+        )}
+        {key}
+        <span className="text-muted">{nodeSummary(value)}</span>
+      </button>
+      {open &&
+        entries.map(([k, v]) => (
+          <JsonNode key={k} value={v} name={k} depth={depth + 1} defaultDepth={defaultDepth} />
+        ))}
+    </div>
+  );
+}

--- a/src/lib/json-tree.test.ts
+++ b/src/lib/json-tree.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { isExpandable, nodeSummary, valueKind } from "@/lib/json-tree";
+
+describe("valueKind", () => {
+  it("classifies JSON values", () => {
+    expect(valueKind({})).toBe("object");
+    expect(valueKind([])).toBe("array");
+    expect(valueKind("x")).toBe("string");
+    expect(valueKind(3)).toBe("number");
+    expect(valueKind(true)).toBe("boolean");
+    expect(valueKind(null)).toBe("null");
+    expect(valueKind(undefined)).toBe("null");
+  });
+});
+
+describe("isExpandable", () => {
+  it("is true only for non-empty containers", () => {
+    expect(isExpandable({ a: 1 })).toBe(true);
+    expect(isExpandable([1])).toBe(true);
+    expect(isExpandable({})).toBe(false);
+    expect(isExpandable([])).toBe(false);
+    expect(isExpandable("x")).toBe(false);
+  });
+});
+
+describe("nodeSummary", () => {
+  it("summarizes containers by size", () => {
+    expect(nodeSummary({ a: 1, b: 2 })).toBe("{2}");
+    expect(nodeSummary([1, 2, 3])).toBe("[3]");
+  });
+
+  it("renders primitives, quoting strings", () => {
+    expect(nodeSummary("hi")).toBe('"hi"');
+    expect(nodeSummary(42)).toBe("42");
+    expect(nodeSummary(false)).toBe("false");
+    expect(nodeSummary(null)).toBe("null");
+    expect(nodeSummary(undefined)).toBe("undefined");
+  });
+});

--- a/src/lib/json-tree.ts
+++ b/src/lib/json-tree.ts
@@ -1,0 +1,31 @@
+// Pure helpers for the collapsible JSON tree viewer: classify a value and render
+// a short summary (collapsed containers show their size; primitives render inline).
+
+export type JsonKind = "object" | "array" | "string" | "number" | "boolean" | "null";
+
+export function valueKind(value: unknown): JsonKind {
+  if (value === null || value === undefined) return "null";
+  if (Array.isArray(value)) return "array";
+  const t = typeof value;
+  if (t === "object") return "object";
+  if (t === "number") return "number";
+  if (t === "boolean") return "boolean";
+  return "string";
+}
+
+export function isExpandable(value: unknown): boolean {
+  const k = valueKind(value);
+  if (k === "array") return (value as unknown[]).length > 0;
+  if (k === "object") return Object.keys(value as object).length > 0;
+  return false;
+}
+
+// Collapsed-container summary ("{3}", "[5]") or a short primitive rendering.
+export function nodeSummary(value: unknown): string {
+  const k = valueKind(value);
+  if (k === "array") return `[${(value as unknown[]).length}]`;
+  if (k === "object") return `{${Object.keys(value as object).length}}`;
+  if (k === "string") return JSON.stringify(value);
+  if (k === "null") return value === undefined ? "undefined" : "null";
+  return String(value);
+}

--- a/src/plugins/incidents/widget.tsx
+++ b/src/plugins/incidents/widget.tsx
@@ -4,23 +4,15 @@ import { useEffect, useState } from "react";
 import { AlertTriangle, ChevronDown, ChevronRight } from "lucide-react";
 import { Panel } from "@/components/panel";
 import { WidgetState } from "@/components/widget-state";
+import { JsonTree } from "@/components/json-tree";
 import { useLive } from "@/components/live-provider";
 import { useSearch, matchesQuery } from "@/components/search";
 import { useT } from "@/lib/i18n";
 import { relativeTime } from "@/lib/format";
+import { isExpandable } from "@/lib/json-tree";
 import type { ErrorItem, ToolCallDetail } from "@/lib/errors";
 
 type Detail = ToolCallDetail | "loading" | "error";
-
-function pretty(value: unknown): string {
-  if (value == null) return "—";
-  if (typeof value === "string") return value;
-  try {
-    return JSON.stringify(value, null, 2);
-  } catch {
-    return String(value);
-  }
-}
 
 export function Incidents() {
   const { tick } = useLive();
@@ -114,10 +106,19 @@ export function Incidents() {
                       <p className="text-muted">{t("incidents.loadError")}</p>
                     ) : (
                       <>
-                        <Field label={t("incidents.input")} value={pretty(detail.input)} />
+                        <div>
+                          <p className="mb-0.5 uppercase tracking-wide text-muted">{t("incidents.input")}</p>
+                          <div className="max-h-40 overflow-auto rounded bg-black/30 p-2">
+                            {isExpandable(detail.input) ? (
+                              <JsonTree data={detail.input} />
+                            ) : (
+                              <span className="font-mono text-foreground">{String(detail.input ?? "—")}</span>
+                            )}
+                          </div>
+                        </div>
                         <Field
                           label={t("incidents.error")}
-                          value={detail.error_text ?? pretty(detail.output)}
+                          value={detail.error_text ?? toText(detail.output)}
                           tone="text-red-400/90"
                         />
                         <p className="font-mono text-[10px] text-muted">{detail.session_id}</p>
@@ -132,6 +133,16 @@ export function Incidents() {
       )}
     </Panel>
   );
+}
+
+function toText(value: unknown): string {
+  if (value == null) return "—";
+  if (typeof value === "string") return value;
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
 }
 
 function Field({ label, value, tone = "text-foreground" }: { label: string; value: string; tone?: string }) {


### PR DESCRIPTION
## Summary
- **JSON-Tree-Viewer** (Run 64): a reusable `JsonTree` component — lazily rendered, type-coloured (string/number/boolean/null distinct), collapsible nodes with per-container size summaries (`{3}`, `[5]`) and depth-based default expansion. Children only render when a node is open.
- Wired into the **incidents drill-down**: a failed tool's input now renders as an explorable JSON tree (falls back to plain text for primitives); the error text stays inline.
- Adds pure `json-tree` helpers (`valueKind`, `isExpandable`, `nodeSummary`) with unit tests.

Research/UX note: collapsible JSON viewers read best with start-collapsed-then-drill-down, type-based colour coding, and lazy child rendering — all applied here.

## Test plan
- [x] `npm run lint` — clean
- [x] `npx vitest run` — 274 tests pass (new json-tree cases)
- [x] `npm run build` — succeeds
- [x] `npm run test:e2e` — 2 pass (no new widget; `<section>` count stays 27)

https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk)_