### PR TITLE
Add tool-call inspector with Edit/Write diff

### DIFF
--- a/src/components/tool-call-inspector.tsx
+++ b/src/components/tool-call-inspector.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import { useT } from "@/lib/i18n";
+import { relativeTime } from "@/lib/format";
+import { diffLines, diffStat, type DiffLine } from "@/lib/diff";
+import { JsonTree } from "@/components/json-tree";
+import type { ToolCallDetail } from "@/lib/errors";
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : null;
+}
+
+// Detect an Edit-style change (old_string → new_string).
+function editPair(input: unknown): { old: string; next: string } | null {
+  const o = asRecord(input);
+  if (o && typeof o.old_string === "string" && typeof o.new_string === "string") {
+    return { old: o.old_string, next: o.new_string };
+  }
+  return null;
+}
+
+// Detect a Write/NotebookEdit-style full content payload.
+function writeContent(input: unknown): string | null {
+  const o = asRecord(input);
+  if (!o) return null;
+  if (typeof o.content === "string") return o.content;
+  if (typeof o.new_source === "string") return o.new_source;
+  return null;
+}
+
+export function ToolCallInspector({ detail }: { detail: ToolCallDetail }) {
+  const { t, lang } = useT();
+  const edit = editPair(detail.input);
+  const write = edit ? null : writeContent(detail.input);
+  const diff = edit ? diffLines(edit.old, edit.next) : write != null ? diffLines("", write) : null;
+
+  return (
+    <div className="space-y-2 text-[11px]">
+      <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-muted">
+        <span className="font-mono text-foreground">{detail.tool_name}</span>
+        {detail.target && (
+          <span className="truncate font-mono" title={detail.target}>
+            {detail.target}
+          </span>
+        )}
+        <span className={detail.success === 0 ? "text-red-400" : "text-emerald-400"}>
+          {detail.success === 0 ? t("inspector.failed") : t("inspector.ok")}
+        </span>
+        <span className="ml-auto whitespace-nowrap">{relativeTime(detail.created_at, lang)}</span>
+      </div>
+
+      {detail.error_text && (
+        <pre className="max-h-24 overflow-auto whitespace-pre-wrap break-words rounded bg-black/30 p-2 font-mono text-red-400/90">
+          {detail.error_text}
+        </pre>
+      )}
+
+      {diff ? (
+        <Diff lines={diff} label={edit ? t("inspector.diff") : t("inspector.newContent")} />
+      ) : (
+        <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+          <Pane label={t("inspector.input")} value={detail.input} />
+          <Pane label={t("inspector.output")} value={detail.output} />
+        </div>
+      )}
+    </div>
+  );
+}
+
+function Pane({ label, value }: { label: string; value: unknown }) {
+  return (
+    <div>
+      <p className="mb-0.5 uppercase tracking-wide text-muted">{label}</p>
+      <div className="max-h-40 overflow-auto rounded bg-black/30 p-2">
+        {value && typeof value === "object" ? (
+          <JsonTree data={value} />
+        ) : (
+          <span className="font-mono text-foreground">{value == null ? "—" : String(value)}</span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function Diff({ lines, label }: { lines: DiffLine[]; label: string }) {
+  const { added, removed } = diffStat(lines);
+  return (
+    <div>
+      <p className="mb-0.5 flex items-center gap-2 uppercase tracking-wide text-muted">
+        {label}
+        <span className="text-emerald-400">+{added}</span>
+        <span className="text-red-400">−{removed}</span>
+      </p>
+      <pre className="max-h-56 overflow-auto rounded bg-black/30 font-mono leading-relaxed">
+        {lines.map((l, i) => (
+          <div
+            key={i}
+            className={
+              l.type === "add"
+                ? "bg-emerald-500/10 text-emerald-300"
+                : l.type === "del"
+                  ? "bg-red-500/10 text-red-300"
+                  : "text-muted"
+            }
+          >
+            <span className="select-none px-2 text-muted/60">
+              {l.type === "add" ? "+" : l.type === "del" ? "−" : " "}
+            </span>
+            {l.text || " "}
+          </div>
+        ))}
+      </pre>
+    </div>
+  );
+}

--- a/src/lib/demo.ts
+++ b/src/lib/demo.ts
@@ -509,7 +509,17 @@ export function demoLatency() {
 
 const DEMO_ERRORS = [
   { id: 9001, tool_name: "Bash", target: "npm test", error_text: "exit code 1: 2 failing tests", input: { command: "npm test" } },
-  { id: 9002, tool_name: "Edit", target: "src/app/page.tsx", error_text: "String to replace not found in file.", input: { file_path: "src/app/page.tsx", old_string: "<Foo />" } },
+  {
+    id: 9002,
+    tool_name: "Edit",
+    target: "src/app/page.tsx",
+    error_text: "String to replace not found in file.",
+    input: {
+      file_path: "src/app/page.tsx",
+      old_string: "export function Page() {\n  return <Dashboard />;\n}",
+      new_string: "export default function Page() {\n  return <Dashboard live />;\n}",
+    },
+  },
   { id: 9003, tool_name: "WebFetch", target: "api.example.com", error_text: "fetch failed: ETIMEDOUT after 30000ms", input: { url: "https://api.example.com/v1/data" } },
   { id: 9004, tool_name: "Read", target: "missing.ts", error_text: "ENOENT: no such file or directory", input: { file_path: "src/missing.ts" } },
 ];

--- a/src/lib/diff.test.ts
+++ b/src/lib/diff.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { diffLines, diffStat } from "@/lib/diff";
+
+describe("diffLines", () => {
+  it("marks unchanged, added and removed lines", () => {
+    const lines = diffLines("a\nb\nc", "a\nB\nc\nd");
+    expect(lines).toEqual([
+      { type: "same", text: "a" },
+      { type: "del", text: "b" },
+      { type: "add", text: "B" },
+      { type: "same", text: "c" },
+      { type: "add", text: "d" },
+    ]);
+  });
+
+  it("treats an empty original as all-added", () => {
+    expect(diffLines("", "x\ny")).toEqual([
+      { type: "add", text: "x" },
+      { type: "add", text: "y" },
+    ]);
+  });
+
+  it("treats an empty target as all-removed", () => {
+    expect(diffLines("x\ny", "")).toEqual([
+      { type: "del", text: "x" },
+      { type: "del", text: "y" },
+    ]);
+  });
+
+  it("returns all-same for identical input", () => {
+    expect(diffLines("a\nb", "a\nb").every((l) => l.type === "same")).toBe(true);
+  });
+});
+
+describe("diffStat", () => {
+  it("counts additions and removals", () => {
+    expect(diffStat(diffLines("a\nb\nc", "a\nB\nc\nd"))).toEqual({ added: 2, removed: 1 });
+  });
+});

--- a/src/lib/diff.ts
+++ b/src/lib/diff.ts
@@ -1,0 +1,52 @@
+// Minimal LCS line diff for the tool-call inspector (Edit/Write changes). Pure
+// so it's unit-testable; the UI colours add/del/same lines green/red/grey.
+
+export interface DiffLine {
+  type: "add" | "del" | "same";
+  text: string;
+}
+
+export function diffLines(a: string, b: string): DiffLine[] {
+  const aL = a.length ? a.split("\n") : [];
+  const bL = b.length ? b.split("\n") : [];
+  const n = aL.length;
+  const m = bL.length;
+
+  // dp[i][j] = LCS length of aL[i:] and bL[j:].
+  const dp: number[][] = Array.from({ length: n + 1 }, () => new Array<number>(m + 1).fill(0));
+  for (let i = n - 1; i >= 0; i--) {
+    for (let j = m - 1; j >= 0; j--) {
+      dp[i][j] = aL[i] === bL[j] ? dp[i + 1][j + 1] + 1 : Math.max(dp[i + 1][j], dp[i][j + 1]);
+    }
+  }
+
+  const out: DiffLine[] = [];
+  let i = 0;
+  let j = 0;
+  while (i < n && j < m) {
+    if (aL[i] === bL[j]) {
+      out.push({ type: "same", text: aL[i] });
+      i++;
+      j++;
+    } else if (dp[i + 1][j] >= dp[i][j + 1]) {
+      out.push({ type: "del", text: aL[i] });
+      i++;
+    } else {
+      out.push({ type: "add", text: bL[j] });
+      j++;
+    }
+  }
+  while (i < n) out.push({ type: "del", text: aL[i++] });
+  while (j < m) out.push({ type: "add", text: bL[j++] });
+  return out;
+}
+
+export function diffStat(lines: DiffLine[]): { added: number; removed: number } {
+  let added = 0;
+  let removed = 0;
+  for (const l of lines) {
+    if (l.type === "add") added++;
+    else if (l.type === "del") removed++;
+  }
+  return { added, removed };
+}

--- a/src/lib/i18n.tsx
+++ b/src/lib/i18n.tsx
@@ -227,6 +227,13 @@ const DE: Record<string, string> = {
   "incidents.error": "Fehler",
   "incidents.loadError": "Detail konnte nicht geladen werden.",
 
+  "inspector.input": "Eingabe",
+  "inspector.output": "Ausgabe",
+  "inspector.diff": "Änderung",
+  "inspector.newContent": "Neuer Inhalt",
+  "inspector.ok": "OK",
+  "inspector.failed": "Fehlgeschlagen",
+
   "search.label": "Sessions und Events durchsuchen",
   "search.placeholder": "Suchen…",
   "search.clear": "Suche löschen",
@@ -541,6 +548,13 @@ const EN: Record<string, string> = {
   "incidents.input": "Input",
   "incidents.error": "Error",
   "incidents.loadError": "Could not load the detail.",
+
+  "inspector.input": "Input",
+  "inspector.output": "Output",
+  "inspector.diff": "Change",
+  "inspector.newContent": "New content",
+  "inspector.ok": "OK",
+  "inspector.failed": "Failed",
 
   "search.label": "Search sessions and events",
   "search.placeholder": "Search…",

--- a/src/plugins/incidents/widget.tsx
+++ b/src/plugins/incidents/widget.tsx
@@ -4,12 +4,11 @@ import { useEffect, useState } from "react";
 import { AlertTriangle, ChevronDown, ChevronRight } from "lucide-react";
 import { Panel } from "@/components/panel";
 import { WidgetState } from "@/components/widget-state";
-import { JsonTree } from "@/components/json-tree";
+import { ToolCallInspector } from "@/components/tool-call-inspector";
 import { useLive } from "@/components/live-provider";
 import { useSearch, matchesQuery } from "@/components/search";
 import { useT } from "@/lib/i18n";
 import { relativeTime } from "@/lib/format";
-import { isExpandable } from "@/lib/json-tree";
 import type { ErrorItem, ToolCallDetail } from "@/lib/errors";
 
 type Detail = ToolCallDetail | "loading" | "error";
@@ -99,30 +98,13 @@ export function Incidents() {
                   </span>
                 </button>
                 {open && (
-                  <div className="space-y-2 px-4 pb-3 pl-9 text-[11px]">
+                  <div className="px-4 pb-3 pl-9">
                     {detail === "loading" || detail === undefined ? (
-                      <p className="text-muted">{t("common.loading")}</p>
+                      <p className="text-[11px] text-muted">{t("common.loading")}</p>
                     ) : detail === "error" ? (
-                      <p className="text-muted">{t("incidents.loadError")}</p>
+                      <p className="text-[11px] text-muted">{t("incidents.loadError")}</p>
                     ) : (
-                      <>
-                        <div>
-                          <p className="mb-0.5 uppercase tracking-wide text-muted">{t("incidents.input")}</p>
-                          <div className="max-h-40 overflow-auto rounded bg-black/30 p-2">
-                            {isExpandable(detail.input) ? (
-                              <JsonTree data={detail.input} />
-                            ) : (
-                              <span className="font-mono text-foreground">{String(detail.input ?? "—")}</span>
-                            )}
-                          </div>
-                        </div>
-                        <Field
-                          label={t("incidents.error")}
-                          value={detail.error_text ?? toText(detail.output)}
-                          tone="text-red-400/90"
-                        />
-                        <p className="font-mono text-[10px] text-muted">{detail.session_id}</p>
-                      </>
+                      <ToolCallInspector detail={detail} />
                     )}
                   </div>
                 )}
@@ -132,26 +114,5 @@ export function Incidents() {
         </ul>
       )}
     </Panel>
-  );
-}
-
-function toText(value: unknown): string {
-  if (value == null) return "—";
-  if (typeof value === "string") return value;
-  try {
-    return JSON.stringify(value, null, 2);
-  } catch {
-    return String(value);
-  }
-}
-
-function Field({ label, value, tone = "text-foreground" }: { label: string; value: string; tone?: string }) {
-  return (
-    <div>
-      <p className="mb-0.5 uppercase tracking-wide text-muted">{label}</p>
-      <pre className={`max-h-28 overflow-auto whitespace-pre-wrap break-words rounded bg-black/30 p-2 font-mono ${tone}`}>
-        {value}
-      </pre>
-    </div>
   );
 }


### PR DESCRIPTION
## Summary
- **Tool-Call-Inspector** (Run 65): a reusable `ToolCallInspector` that shows a tool call's **input vs output side-by-side** (as collapsible JSON trees, reusing Run 64), plus a **unified line diff** for `Edit` (old_string → new_string) and `Write`/`NotebookEdit` content, and the error text when present. It replaces the incidents drill-down's ad-hoc input/error view.
- Adds a pure LCS line-diff lib (`diffLines`, `diffStat`) with unit tests, de/en i18n, and a demo `Edit` error now carrying a real before/after so the diff view is visible in the demo.

Research/UX note: diffs use the standard green-add / red-delete / grey-same convention with a +/− gutter and an add/remove stat; side-by-side panes for non-edit calls.

## Test plan
- [x] `npm run lint` — clean
- [x] `npx vitest run` — 279 tests pass (new `diffLines`/`diffStat` cases)
- [x] `npm run build` — succeeds
- [x] `npm run test:e2e` — 2 pass (no new widget; `<section>` count stays 27)

https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk)_