### PR TITLE
Add global time-range filter

### DIFF
--- a/src/components/dashboard.tsx
+++ b/src/components/dashboard.tsx
@@ -20,7 +20,9 @@ import { InfoHint } from "@/components/info-hint";
 import { WidgetErrorBoundary } from "@/components/error-boundary";
 import { Landing } from "@/components/landing";
 import { SearchProvider, useSearch } from "@/components/search";
+import { TimeRangeProvider, useTimeRange } from "@/components/time-range";
 import { useT } from "@/lib/i18n";
+import { TIME_RANGES } from "@/lib/time-range";
 import { DEMO, installDemoBackend } from "@/lib/demo";
 import {
   HEIGHT_PRESETS,
@@ -193,6 +195,7 @@ export function Dashboard() {
   return (
     <LiveProvider>
       <SearchProvider>
+        <TimeRangeProvider>
         {DEMO && <Landing />}
         <div className="mx-auto flex min-h-screen max-w-[1600px] flex-col gap-4 p-4 sm:p-6 min-[2560px]:max-w-none min-[2560px]:gap-6 min-[2560px]:p-8 min-[3840px]:gap-8 min-[3840px]:p-12">
           <Header
@@ -259,6 +262,7 @@ export function Dashboard() {
             onClose={() => setGalleryOpen(false)}
           />
         )}
+        </TimeRangeProvider>
       </SearchProvider>
     </LiveProvider>
   );
@@ -369,6 +373,7 @@ function Header({
             </button>
           )}
         </label>
+        <TimeRangePicker />
         <button
           type="button"
           onClick={onOpenGallery}
@@ -412,6 +417,26 @@ function Header({
         </span>
       </div>
     </header>
+  );
+}
+
+function TimeRangePicker() {
+  const { t } = useT();
+  const { range, setRange } = useTimeRange();
+  return (
+    <select
+      value={range}
+      onChange={(e) => setRange(e.target.value as (typeof TIME_RANGES)[number])}
+      aria-label={t("range.label")}
+      title={t("range.label")}
+      className="hidden rounded-full border border-panel-border bg-background/40 px-2.5 py-1 text-xs text-muted outline-none transition-colors hover:border-accent/50 focus:border-accent sm:block"
+    >
+      {TIME_RANGES.map((r) => (
+        <option key={r} value={r}>
+          {t(`range.${r}`)}
+        </option>
+      ))}
+    </select>
   );
 }
 

--- a/src/components/time-range.tsx
+++ b/src/components/time-range.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react";
+import { isTimeRange, rangeToDays, type TimeRange } from "@/lib/time-range";
+
+interface TimeRangeValue {
+  range: TimeRange;
+  days: number;
+  setRange: (r: TimeRange) => void;
+}
+
+const TimeRangeContext = createContext<TimeRangeValue>({
+  range: "all",
+  days: rangeToDays("all"),
+  setRange: () => {},
+});
+
+const KEY = "mc-time-range";
+
+// Dashboard-wide date range. Read-only over the data — widgets just narrow their
+// window. Synced to the `?range=` query param (shareable, local) and localStorage.
+export function TimeRangeProvider({ children }: { children: React.ReactNode }) {
+  const [range, setRangeState] = useState<TimeRange>("all");
+
+  useEffect(() => {
+    // Adopt the saved/URL range after hydration (default "all" is render-safe).
+    const id = requestAnimationFrame(() => {
+      let initial: TimeRange | null = null;
+      try {
+        const q = new URLSearchParams(window.location.search).get("range");
+        if (isTimeRange(q)) initial = q;
+      } catch {
+        /* ignore */
+      }
+      if (!initial) {
+        try {
+          const s = localStorage.getItem(KEY);
+          if (isTimeRange(s)) initial = s;
+        } catch {
+          /* ignore */
+        }
+      }
+      if (initial) setRangeState(initial);
+    });
+    return () => cancelAnimationFrame(id);
+  }, []);
+
+  const setRange = useCallback((r: TimeRange) => {
+    setRangeState(r);
+    try {
+      localStorage.setItem(KEY, r);
+    } catch {
+      /* ignore */
+    }
+    try {
+      const url = new URL(window.location.href);
+      if (r === "all") url.searchParams.delete("range");
+      else url.searchParams.set("range", r);
+      window.history.replaceState(null, "", url.toString());
+    } catch {
+      /* ignore */
+    }
+  }, []);
+
+  const value = useMemo(() => ({ range, days: rangeToDays(range), setRange }), [range, setRange]);
+  return <TimeRangeContext.Provider value={value}>{children}</TimeRangeContext.Provider>;
+}
+
+export function useTimeRange(): TimeRangeValue {
+  return useContext(TimeRangeContext);
+}

--- a/src/lib/i18n.tsx
+++ b/src/lib/i18n.tsx
@@ -243,6 +243,13 @@ const DE: Record<string, string> = {
   "layout.width": "Breite ändern",
   "layout.height": "Höhe ändern",
 
+  "range.label": "Zeitbereich",
+  "range.24h": "24 Std.",
+  "range.7d": "7 Tage",
+  "range.30d": "30 Tage",
+  "range.90d": "90 Tage",
+  "range.all": "Gesamt",
+
   "gallery.title": "Widget-Galerie",
   "gallery.info": "Widgets ein- oder ausblenden. Reihenfolge und Größe änderst du direkt am Widget.",
   "gallery.close": "Schließen",
@@ -572,6 +579,13 @@ const EN: Record<string, string> = {
   "layout.reset": "Reset layout",
   "layout.width": "Change width",
   "layout.height": "Change height",
+
+  "range.label": "Time range",
+  "range.24h": "24h",
+  "range.7d": "7 days",
+  "range.30d": "30 days",
+  "range.90d": "90 days",
+  "range.all": "All time",
 
   "gallery.title": "Widget gallery",
   "gallery.info": "Show or hide widgets. Reorder and resize directly on the widget.",

--- a/src/lib/time-range.test.ts
+++ b/src/lib/time-range.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { isTimeRange, rangeSinceIso, rangeToDays, TIME_RANGES } from "@/lib/time-range";
+
+describe("isTimeRange", () => {
+  it("accepts known ranges and rejects others", () => {
+    for (const r of TIME_RANGES) expect(isTimeRange(r)).toBe(true);
+    expect(isTimeRange("1h")).toBe(false);
+    expect(isTimeRange(7)).toBe(false);
+    expect(isTimeRange(null)).toBe(false);
+  });
+});
+
+describe("rangeToDays", () => {
+  it("maps each range to a day count", () => {
+    expect(rangeToDays("24h")).toBe(1);
+    expect(rangeToDays("7d")).toBe(7);
+    expect(rangeToDays("30d")).toBe(30);
+    expect(rangeToDays("90d")).toBe(90);
+    expect(rangeToDays("all")).toBe(3650);
+  });
+});
+
+describe("rangeSinceIso", () => {
+  const now = new Date("2026-05-24T12:00:00Z");
+
+  it("returns null for all", () => {
+    expect(rangeSinceIso("all", now)).toBeNull();
+  });
+
+  it("subtracts the window as a SQLite-style UTC timestamp", () => {
+    expect(rangeSinceIso("7d", now)).toBe("2026-05-17 12:00:00");
+    expect(rangeSinceIso("24h", now)).toBe("2026-05-23 12:00:00");
+  });
+});

--- a/src/lib/time-range.ts
+++ b/src/lib/time-range.ts
@@ -1,0 +1,34 @@
+// Shared dashboard time range. Widgets that aggregate over a window read the
+// active range (via the TimeRange context) and pass its `days` to their API.
+// Kept pure here so the mapping is unit-testable; the context owns URL/storage.
+
+export type TimeRange = "24h" | "7d" | "30d" | "90d" | "all";
+
+export const TIME_RANGES: TimeRange[] = ["24h", "7d", "30d", "90d", "all"];
+
+export function isTimeRange(value: unknown): value is TimeRange {
+  return typeof value === "string" && (TIME_RANGES as string[]).includes(value);
+}
+
+// Days the range spans; "all" is a large bound that API routes clamp as needed.
+export function rangeToDays(range: TimeRange): number {
+  switch (range) {
+    case "24h":
+      return 1;
+    case "7d":
+      return 7;
+    case "30d":
+      return 30;
+    case "90d":
+      return 90;
+    case "all":
+      return 3650;
+  }
+}
+
+// Inclusive lower bound as a SQLite-style UTC timestamp, or null for "all".
+export function rangeSinceIso(range: TimeRange, now: Date = new Date()): string | null {
+  if (range === "all") return null;
+  const ms = now.getTime() - rangeToDays(range) * 86_400_000;
+  return new Date(ms).toISOString().replace("T", " ").slice(0, 19);
+}

--- a/src/plugins/error-rate/widget.tsx
+++ b/src/plugins/error-rate/widget.tsx
@@ -6,6 +6,7 @@ import { ShieldAlert } from "lucide-react";
 import { Panel } from "@/components/panel";
 import { WidgetState } from "@/components/widget-state";
 import { useLive } from "@/components/live-provider";
+import { useTimeRange } from "@/components/time-range";
 import { useT } from "@/lib/i18n";
 
 interface ErrorPoint {
@@ -25,10 +26,6 @@ interface Response {
   topTools: FailingTool[];
 }
 
-type Range = "7" | "30";
-const RANGES: Range[] = ["7", "30"];
-const RANGE_LABEL: Record<Range, string> = { "7": "tools.range7d", "30": "tools.range30d" };
-
 function tone(rate: number): string {
   if (rate >= 0.2) return "text-red-400";
   if (rate >= 0.05) return "text-amber-400";
@@ -45,13 +42,13 @@ const tooltipStyle = {
 export function ErrorRate() {
   const { t } = useT();
   const { tick } = useLive();
-  const [range, setRange] = useState<Range>("7");
+  const { days } = useTimeRange();
   const [data, setData] = useState<Response | null>(null);
 
   useEffect(() => {
     let cancelled = false;
     const load = () =>
-      fetch(`/api/errors?days=${range}`)
+      fetch(`/api/errors?days=${days}`)
         .then((r) => r.json())
         .then((d: Response) => {
           if (!cancelled) setData(d);
@@ -63,7 +60,7 @@ export function ErrorRate() {
       cancelled = true;
       clearInterval(poll);
     };
-  }, [range, tick]);
+  }, [days, tick]);
 
   const chart = (data?.series ?? []).map((p) => ({ date: p.date.slice(5), failures: p.failures }));
 
@@ -72,19 +69,6 @@ export function ErrorRate() {
       title={t("errors.title")}
       icon={<ShieldAlert className="h-4 w-4 text-accent" />}
       info={t("errors.info")}
-      right={
-        <div className="flex rounded-md border border-panel-border text-xs">
-          {RANGES.map((r) => (
-            <button
-              key={r}
-              onClick={() => setRange(r)}
-              className={`px-2 py-1 ${range === r ? "bg-accent/20 text-accent" : "text-muted hover:text-foreground"}`}
-            >
-              {t(RANGE_LABEL[r])}
-            </button>
-          ))}
-        </div>
-      }
     >
       {!data ? (
         <WidgetState icon={ShieldAlert} title={t("common.loading")} loading />

--- a/src/plugins/velocity/widget.tsx
+++ b/src/plugins/velocity/widget.tsx
@@ -6,6 +6,7 @@ import { Gauge, TrendingDown, TrendingUp } from "lucide-react";
 import { Panel } from "@/components/panel";
 import { WidgetState } from "@/components/widget-state";
 import { useLive } from "@/components/live-provider";
+import { useTimeRange } from "@/components/time-range";
 import { useT } from "@/lib/i18n";
 import {
   eventsPerSession,
@@ -67,12 +68,13 @@ function Trend({
 export function Velocity() {
   const { tick } = useLive();
   const { t } = useT();
+  const { days: rangeDays } = useTimeRange();
   const [days, setDays] = useState<VelocityDay[] | null>(null);
 
   useEffect(() => {
     let cancelled = false;
     const load = () =>
-      fetch("/api/velocity?days=30")
+      fetch(`/api/velocity?days=${rangeDays}`)
         .then((r) => r.json())
         .then((d: { days: VelocityDay[] }) => {
           if (!cancelled) setDays(d.days);
@@ -84,7 +86,7 @@ export function Velocity() {
       cancelled = true;
       clearInterval(poll);
     };
-  }, [tick]);
+  }, [rangeDays, tick]);
 
   const empty = days && days.every((d) => d.toolCalls === 0 && d.events === 0);
 


### PR DESCRIPTION
## Summary
- **Globaler Zeitbereich-Filter / Global time-range filter** (Run 67): a shared dashboard date range (24h / 7d / 30d / 90d / all) exposed via a `TimeRange` context, a header dropdown, and a shareable **`?range=` URL query param** (also persisted to localStorage). Read-only over the data — widgets just narrow their window.
- The **error-rate** widget's local 7/30 toggle is replaced by the global range, and **velocity** now respects it too; both API routes already clamp the day window so "all"/"90d" stay bounded. Other widgets can opt in via `useTimeRange()` (the seam is in place).
- Adds a pure `time-range` lib (`rangeToDays`, `rangeSinceIso`, `isTimeRange`) with unit tests and de/en i18n.

Research/UX note: a single compact range control in the header with a shareable URL state is the standard dashboard pattern; the default ("all") is render-safe for hydration and adopted from URL/storage after mount.

## Test plan
- [x] `npm run lint` — clean
- [x] `npx vitest run` — 286 tests pass (new time-range cases)
- [x] `npm run build` — succeeds
- [x] `npm run test:e2e` — 2 pass (header control only; `<section>` count stays 27)

https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk)_