### PR TITLE
Add dashboard-wide facet filter (project/status)

### DIFF
--- a/src/components/dashboard.tsx
+++ b/src/components/dashboard.tsx
@@ -21,6 +21,7 @@ import { WidgetErrorBoundary } from "@/components/error-boundary";
 import { Landing } from "@/components/landing";
 import { SearchProvider, useSearch } from "@/components/search";
 import { TimeRangeProvider, useTimeRange } from "@/components/time-range";
+import { FacetProvider, useFacets } from "@/components/facets";
 import { useT } from "@/lib/i18n";
 import { TIME_RANGES } from "@/lib/time-range";
 import { DEMO, installDemoBackend } from "@/lib/demo";
@@ -196,6 +197,7 @@ export function Dashboard() {
     <LiveProvider>
       <SearchProvider>
         <TimeRangeProvider>
+        <FacetProvider>
         {DEMO && <Landing />}
         <div className="mx-auto flex min-h-screen max-w-[1600px] flex-col gap-4 p-4 sm:p-6 min-[2560px]:max-w-none min-[2560px]:gap-6 min-[2560px]:p-8 min-[3840px]:gap-8 min-[3840px]:p-12">
           <Header
@@ -262,6 +264,7 @@ export function Dashboard() {
             onClose={() => setGalleryOpen(false)}
           />
         )}
+        </FacetProvider>
         </TimeRangeProvider>
       </SearchProvider>
     </LiveProvider>
@@ -373,6 +376,7 @@ function Header({
             </button>
           )}
         </label>
+        <FacetBar />
         <TimeRangePicker />
         <button
           type="button"
@@ -417,6 +421,59 @@ function Header({
         </span>
       </div>
     </header>
+  );
+}
+
+function FacetBar() {
+  const { t } = useT();
+  const { tick } = useLive();
+  const { project, status, setProject, setStatus, active, clear } = useFacets();
+  const [projects, setProjects] = useState<string[]>([]);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch("/api/usage/projects")
+      .then((r) => r.json())
+      .then((d: { projects: { project: string }[] }) => {
+        if (!cancelled) setProjects((d.projects ?? []).map((p) => p.project).filter((p) => p && p !== "(unknown)"));
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [tick]);
+
+  const cls =
+    "hidden rounded-full border border-panel-border bg-background/40 px-2.5 py-1 text-xs text-muted outline-none transition-colors hover:border-accent/50 focus:border-accent sm:block";
+
+  return (
+    <>
+      <select value={project} onChange={(e) => setProject(e.target.value)} aria-label={t("facets.project")} title={t("facets.project")} className={cls}>
+        <option value="">{t("facets.allProjects")}</option>
+        {projects.map((p) => (
+          <option key={p} value={p}>
+            {p}
+          </option>
+        ))}
+      </select>
+      <select value={status} onChange={(e) => setStatus(e.target.value)} aria-label={t("facets.status")} title={t("facets.status")} className={cls}>
+        <option value="">{t("facets.allStatus")}</option>
+        <option value="active">{t("status.active")}</option>
+        <option value="waiting">{t("status.waiting")}</option>
+        <option value="ended">{t("status.ended")}</option>
+      </select>
+      {active && (
+        <button
+          type="button"
+          onClick={clear}
+          aria-label={t("facets.clear")}
+          title={t("facets.clear")}
+          className="hidden items-center rounded-full border border-accent/40 bg-accent/10 p-1.5 text-accent transition-colors hover:bg-accent/20 sm:flex"
+        >
+          <X className="h-3.5 w-3.5" />
+        </button>
+      )}
+    </>
   );
 }
 

--- a/src/components/facets.tsx
+++ b/src/components/facets.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react";
+import { EMPTY_FACETS, facetsActive, type Facets } from "@/lib/facets";
+
+interface FacetValue extends Facets {
+  setProject: (p: string) => void;
+  setStatus: (s: string) => void;
+  clear: () => void;
+  active: boolean;
+}
+
+const FacetContext = createContext<FacetValue>({
+  ...EMPTY_FACETS,
+  setProject: () => {},
+  setStatus: () => {},
+  clear: () => {},
+  active: false,
+});
+
+const KEY = "mc-facets";
+const STATUSES = ["active", "waiting", "ended"];
+
+// Dashboard-wide facets, synced to `?project=` / `?status=` (shareable, local)
+// and localStorage. Default empty (render-safe), adopted after hydration.
+export function FacetProvider({ children }: { children: React.ReactNode }) {
+  const [facets, setFacets] = useState<Facets>(EMPTY_FACETS);
+
+  useEffect(() => {
+    const id = requestAnimationFrame(() => {
+      let project = "";
+      let status = "";
+      try {
+        const q = new URLSearchParams(window.location.search);
+        project = q.get("project") ?? "";
+        const s = q.get("status") ?? "";
+        if (STATUSES.includes(s)) status = s;
+      } catch {
+        /* ignore */
+      }
+      if (!project && !status) {
+        try {
+          const raw = localStorage.getItem(KEY);
+          if (raw) {
+            const saved = JSON.parse(raw) as Partial<Facets>;
+            if (typeof saved.project === "string") project = saved.project;
+            if (typeof saved.status === "string" && STATUSES.includes(saved.status)) status = saved.status;
+          }
+        } catch {
+          /* ignore */
+        }
+      }
+      if (project || status) setFacets({ project, status });
+    });
+    return () => cancelAnimationFrame(id);
+  }, []);
+
+  const apply = useCallback((next: Facets) => {
+    setFacets(next);
+    try {
+      if (!next.project && !next.status) localStorage.removeItem(KEY);
+      else localStorage.setItem(KEY, JSON.stringify(next));
+    } catch {
+      /* ignore */
+    }
+    try {
+      const url = new URL(window.location.href);
+      if (next.project) url.searchParams.set("project", next.project);
+      else url.searchParams.delete("project");
+      if (next.status) url.searchParams.set("status", next.status);
+      else url.searchParams.delete("status");
+      window.history.replaceState(null, "", url.toString());
+    } catch {
+      /* ignore */
+    }
+  }, []);
+
+  const value = useMemo<FacetValue>(
+    () => ({
+      ...facets,
+      setProject: (p: string) => apply({ ...facets, project: p }),
+      setStatus: (s: string) => apply({ ...facets, status: s }),
+      clear: () => apply(EMPTY_FACETS),
+      active: facetsActive(facets),
+    }),
+    [facets, apply],
+  );
+
+  return <FacetContext.Provider value={value}>{children}</FacetContext.Provider>;
+}
+
+export function useFacets(): FacetValue {
+  return useContext(FacetContext);
+}

--- a/src/lib/facets.test.ts
+++ b/src/lib/facets.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { EMPTY_FACETS, facetsActive, sessionMatchesFacets } from "@/lib/facets";
+
+const s = (project_name: string | null, status: string) => ({ project_name, status });
+
+describe("facetsActive", () => {
+  it("is false when empty, true when any facet is set", () => {
+    expect(facetsActive(EMPTY_FACETS)).toBe(false);
+    expect(facetsActive({ project: "a", status: "" })).toBe(true);
+    expect(facetsActive({ project: "", status: "active" })).toBe(true);
+  });
+});
+
+describe("sessionMatchesFacets", () => {
+  it("matches everything with empty facets", () => {
+    expect(sessionMatchesFacets(s("alpha", "active"), EMPTY_FACETS)).toBe(true);
+  });
+
+  it("filters by project", () => {
+    expect(sessionMatchesFacets(s("alpha", "active"), { project: "alpha", status: "" })).toBe(true);
+    expect(sessionMatchesFacets(s("beta", "active"), { project: "alpha", status: "" })).toBe(false);
+  });
+
+  it("filters by status", () => {
+    expect(sessionMatchesFacets(s("alpha", "active"), { project: "", status: "active" })).toBe(true);
+    expect(sessionMatchesFacets(s("alpha", "ended"), { project: "", status: "active" })).toBe(false);
+  });
+
+  it("requires all set facets to match", () => {
+    expect(sessionMatchesFacets(s("alpha", "active"), { project: "alpha", status: "active" })).toBe(true);
+    expect(sessionMatchesFacets(s("alpha", "ended"), { project: "alpha", status: "active" })).toBe(false);
+  });
+
+  it("treats a null project as not matching a project facet", () => {
+    expect(sessionMatchesFacets(s(null, "active"), { project: "alpha", status: "" })).toBe(false);
+  });
+});

--- a/src/lib/facets.ts
+++ b/src/lib/facets.ts
@@ -1,0 +1,23 @@
+// Dashboard-wide facet filter (project + session status). Read-only over the
+// data — widgets narrow what they render. Pure matcher kept here so it's testable;
+// the context owns URL/storage and which controls are shown.
+
+export interface Facets {
+  project: string; // "" = any
+  status: string; // "" = any (active | waiting | ended)
+}
+
+export const EMPTY_FACETS: Facets = { project: "", status: "" };
+
+export function facetsActive(f: Facets): boolean {
+  return Boolean(f.project || f.status);
+}
+
+export function sessionMatchesFacets(
+  session: { project_name: string | null; status: string },
+  f: Facets,
+): boolean {
+  if (f.project && (session.project_name ?? "") !== f.project) return false;
+  if (f.status && session.status !== f.status) return false;
+  return true;
+}

--- a/src/lib/i18n.tsx
+++ b/src/lib/i18n.tsx
@@ -250,6 +250,12 @@ const DE: Record<string, string> = {
   "range.90d": "90 Tage",
   "range.all": "Gesamt",
 
+  "facets.project": "Projekt-Filter",
+  "facets.allProjects": "Alle Projekte",
+  "facets.status": "Status-Filter",
+  "facets.allStatus": "Alle Status",
+  "facets.clear": "Filter zurücksetzen",
+
   "gallery.title": "Widget-Galerie",
   "gallery.info": "Widgets ein- oder ausblenden. Reihenfolge und Größe änderst du direkt am Widget.",
   "gallery.close": "Schließen",
@@ -586,6 +592,12 @@ const EN: Record<string, string> = {
   "range.30d": "30 days",
   "range.90d": "90 days",
   "range.all": "All time",
+
+  "facets.project": "Project filter",
+  "facets.allProjects": "All projects",
+  "facets.status": "Status filter",
+  "facets.allStatus": "All statuses",
+  "facets.clear": "Clear filters",
 
   "gallery.title": "Widget gallery",
   "gallery.info": "Show or hide widgets. Reorder and resize directly on the widget.",

--- a/src/plugins/kanban/widget.tsx
+++ b/src/plugins/kanban/widget.tsx
@@ -6,7 +6,9 @@ import { KanbanSquare, Coins, ExternalLink, Folder, Hammer, Radio, X } from "luc
 import { Panel } from "@/components/panel";
 import { useLive } from "@/components/live-provider";
 import { useSearch, matchesQuery } from "@/components/search";
+import { useFacets } from "@/components/facets";
 import { useT } from "@/lib/i18n";
+import { sessionMatchesFacets } from "@/lib/facets";
 import { formatCompact, formatMoney, relativeTime, STATUS_META } from "@/lib/format";
 import type { EventRow, SessionRow, SessionStatus } from "@/lib/types";
 
@@ -17,9 +19,9 @@ const COLUMNS: SessionStatus[] = ["active", "waiting", "ended"];
 export function Kanban() {
   const { tick, events } = useLive();
   const { query } = useSearch();
+  const facets = useFacets();
   const { t } = useT();
   const [sessions, setSessions] = useState<SessionCard[]>([]);
-  const [project, setProject] = useState<string>("all");
   const [selected, setSelected] = useState<SessionCard | null>(null);
 
   useEffect(() => {
@@ -39,18 +41,12 @@ export function Kanban() {
     };
   }, [tick]);
 
-  const projects = useMemo(() => {
-    const set = new Set<string>();
-    for (const s of sessions) if (s.project_name) set.add(s.project_name);
-    return [...set].sort();
-  }, [sessions]);
-
   const filtered = useMemo(
     () =>
       sessions
-        .filter((s) => project === "all" || s.project_name === project)
+        .filter((s) => sessionMatchesFacets(s, facets))
         .filter((s) => matchesQuery(query, s.title, s.project_name, s.id)),
-    [sessions, project, query],
+    [sessions, facets, query],
   );
 
   // Keep the open detail in sync with refreshed data; close it if the session is gone.
@@ -64,21 +60,6 @@ export function Kanban() {
       title={t("kanban.title")}
       icon={<KanbanSquare className="h-4 w-4 text-accent" />}
       info={t("kanban.info")}
-      right={
-        <select
-          value={project}
-          onChange={(e) => setProject(e.target.value)}
-          aria-label={t("common.allProjects")}
-          className="rounded-md border border-panel-border bg-background px-2 py-1 text-xs text-foreground outline-none focus:border-accent"
-        >
-          <option value="all">{t("common.allProjects")}</option>
-          {projects.map((p) => (
-            <option key={p} value={p}>
-              {p}
-            </option>
-          ))}
-        </select>
-      }
     >
       <div className="grid h-full grid-cols-3 gap-px bg-panel-border/50">
         {COLUMNS.map((status) => {


### PR DESCRIPTION
## Summary
- **Facetten-Filter / Faceted filter** (Run 68): a dashboard-wide filter by **project** and **session status**, exposed via a `Facet` context with header dropdowns, a **clear** action (shown only when a facet is active), and shareable **`?project=` / `?status=` URL params** (also persisted). Read-only over the data.
- The kanban's local project dropdown is replaced by the global facet, and kanban now honors both project + status via a pure, unit-tested `sessionMatchesFacets` helper. Project options are sourced from `/api/usage/projects`. Other session-oriented widgets can opt in via `useFacets()`.
- Adds the `facets` lib (+ tests) and de/en i18n.

Research/UX note: faceted filters read best as compact header controls plus an explicit "clear" once active — implemented here (a chip row would be the next step for many simultaneous facets).

## Test plan
- [x] `npm run lint` — clean
- [x] `npx vitest run` — 292 tests pass (new `facets` cases)
- [x] `npm run build` — succeeds
- [x] `npm run test:e2e` — 2 pass (header controls only; `<section>` count stays 27)

https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk)_