### PR TITLE
Add FTS5 full-text search; record dual-license plan

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -345,6 +345,28 @@ sein.
      Pages-Demo mit allen Widgets.
      *Ergebnis:* das beste Claude-Code-Observability-Tool — ausgeliefert.
 
+## Lizenzmodell (dual / source-available)
+
+**Privat & nicht-kommerziell: kostenlos. Firmen & kommerzieller Einsatz:
+kostenpflichtige Lizenz.** Das ist als *source-available* Dual-Lizenz gut
+umsetzbar (kein OSI-„Open Source", aber Quelltext einsehbar):
+
+- **Standardweg:** `LICENSE` = **PolyForm Noncommercial 1.0.0** (erlaubt jede
+  nicht-kommerzielle Nutzung gratis; kommerzielle Nutzung ausdrücklich
+  ausgenommen) **+** eine `COMMERCIAL.md`, die den Erwerb einer kommerziellen
+  Lizenz beschreibt (Kontakt/Preis). Dieselbe Codebasis wird damit doppelt
+  lizenziert.
+- **Alternative:** **Business Source License (BSL 1.1)** mit „Additional Use
+  Grant" (nicht-kommerziell frei) und Change-Date → fällt nach X Jahren auf
+  eine OSS-Lizenz zurück.
+- **Hinweis:** Solche Lizenzen sind durchsetzbar, aber rechtlich verbindliche
+  Beratung gehört vor das Release. Bis dahin keine widersprüchliche Lizenz
+  committen.
+
+Umsetzung erfolgt in der Release-Phase (Run 120): `LICENSE` + `COMMERCIAL.md`
+hinzufügen, Lizenz-Header/`package.json`-`license`-Feld setzen, README-Abschnitt
+„Lizenz" ergänzen.
+
 ---
 
 ## Überblick: Phasen auf einen Blick

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from "next/server";
+import { db } from "@/lib/db";
+import { searchFts } from "@/lib/search-index";
+import { log } from "@/lib/log";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+// Full-text search (FTS5) across event summaries and prompts.
+export async function GET(req: Request) {
+  const url = new URL(req.url);
+  const q = url.searchParams.get("q") ?? "";
+  const limit = Math.min(Math.max(Math.trunc(Number(url.searchParams.get("limit")) || 20), 1), 100);
+  try {
+    return NextResponse.json({ hits: searchFts(db, q, limit) });
+  } catch (err) {
+    log.error("/api/search failed", err);
+    return NextResponse.json({ hits: [] });
+  }
+}

--- a/src/components/dashboard.tsx
+++ b/src/components/dashboard.tsx
@@ -1,12 +1,14 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useState } from "react";
+import Link from "next/link";
 import {
   Activity,
   Eye,
   EyeOff,
   GripHorizontal,
   LayoutGrid,
+  MessageSquare,
   MoveHorizontal,
   MoveVertical,
   RotateCcw,
@@ -24,6 +26,7 @@ import { TimeRangeProvider, useTimeRange } from "@/components/time-range";
 import { FacetProvider, useFacets } from "@/components/facets";
 import { useT } from "@/lib/i18n";
 import { TIME_RANGES } from "@/lib/time-range";
+import type { SearchHit } from "@/lib/search-index";
 import { DEMO, installDemoBackend } from "@/lib/demo";
 import {
   HEIGHT_PRESETS,
@@ -331,6 +334,7 @@ function Header({
   const { t, lang } = useT();
   const { query, setQuery } = useSearch();
   const [clock, setClock] = useState("");
+  const [hits, setHits] = useState<SearchHit[]>([]);
 
   useEffect(() => {
     const update = () => setClock(new Date().toLocaleTimeString(lang === "en" ? "en-GB" : "de-DE"));
@@ -338,6 +342,27 @@ function Header({
     const id = setInterval(update, 1000);
     return () => clearInterval(id);
   }, [lang]);
+
+  // Debounced full-text search across the whole DB (FTS5) for the results dropdown.
+  useEffect(() => {
+    const term = query.trim();
+    if (term.length < 2) return;
+    let cancelled = false;
+    const id = setTimeout(() => {
+      fetch(`/api/search?q=${encodeURIComponent(term)}`)
+        .then((r) => r.json())
+        .then((d: { hits: SearchHit[] }) => {
+          if (!cancelled) setHits(d.hits ?? []);
+        })
+        .catch(() => {});
+    }, 250);
+    return () => {
+      cancelled = true;
+      clearTimeout(id);
+    };
+  }, [query]);
+
+  const shownHits = query.trim().length >= 2 ? hits : [];
 
   return (
     <header className="mc-fade-in flex items-center justify-between gap-3 rounded-xl border border-panel-border bg-panel/60 px-5 py-3 backdrop-blur">
@@ -374,6 +399,31 @@ function Header({
             >
               <X className="h-3.5 w-3.5" />
             </button>
+          )}
+          {shownHits.length > 0 && (
+            <div className="absolute right-0 top-9 z-50 max-h-80 w-72 overflow-auto rounded-lg border border-panel-border bg-panel shadow-2xl shadow-black/50 lg:w-80">
+              <p className="border-b border-panel-border px-3 py-1.5 text-[10px] uppercase tracking-wide text-muted">
+                {t("search.results")}
+              </p>
+              <ul>
+                {shownHits.map((h) => (
+                  <li key={`${h.kind}-${h.ref_id}-${h.session_id}`}>
+                    <Link
+                      href={`/session?id=${encodeURIComponent(h.session_id)}`}
+                      onMouseDown={() => setQuery("")}
+                      className="flex items-start gap-2 px-3 py-2 transition-colors hover:bg-white/[0.04]"
+                    >
+                      {h.kind === "prompt" ? (
+                        <MessageSquare className="mt-0.5 h-3.5 w-3.5 shrink-0 text-sky-400" />
+                      ) : (
+                        <Activity className="mt-0.5 h-3.5 w-3.5 shrink-0 text-accent" />
+                      )}
+                      <span className="line-clamp-2 text-xs text-foreground">{h.text}</span>
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            </div>
           )}
         </label>
         <FacetBar />

--- a/src/lib/demo.ts
+++ b/src/lib/demo.ts
@@ -14,6 +14,7 @@ import { topTerms } from "./tags";
 import type { ToolTokenBurn } from "./token-burn";
 import type { ToolCallDetail } from "./errors";
 import type { ProjectReliability } from "./reliability";
+import type { SearchHit } from "./search-index";
 import type { SessionDetail } from "./session-detail";
 import type { TranscriptBlock, TranscriptMessage } from "./transcript";
 import { durationStats } from "./session-duration";
@@ -848,6 +849,28 @@ export function demoReliability() {
   return { projects };
 }
 
+export function demoSearch(q: string): { hits: SearchHit[] } {
+  const terms = q.toLowerCase().match(/[\p{L}\p{N}]+/gu) ?? [];
+  if (terms.length === 0) return { hits: [] };
+  const match = (text: string) => {
+    const lc = text.toLowerCase();
+    return terms.every((t) => lc.includes(t));
+  };
+  const hits: SearchHit[] = [];
+  for (let i = allEvents.length - 1; i >= 0 && hits.length < 20; i--) {
+    const e = allEvents[i];
+    if (e.summary && match(e.summary))
+      hits.push({ kind: "event", ref_id: e.id, session_id: e.session_id, text: e.summary });
+  }
+  for (const s of sessions) {
+    for (const p of s.prompts) {
+      if (hits.length >= 20) break;
+      if (match(p.text)) hits.push({ kind: "prompt", ref_id: 0, session_id: s.id, text: p.text });
+    }
+  }
+  return { hits: hits.slice(0, 20) };
+}
+
 export function demoSubscribe(fn: (m: StreamMessage) => void) {
   listeners.add(fn);
   return () => listeners.delete(fn);
@@ -896,6 +919,10 @@ export function installDemoBackend() {
     if (path.endsWith("/api/velocity")) return json(demoVelocity());
     if (path.endsWith("/api/session-duration")) return json(demoSessionDuration());
     if (path.endsWith("/api/reliability")) return json(demoReliability());
+    if (path.endsWith("/api/search")) {
+      const u = new URL(raw, window.location.href);
+      return json(demoSearch(u.searchParams.get("q") ?? ""));
+    }
     if (path.includes("/api/tool-calls/")) {
       const id = Number(path.split("/api/tool-calls/")[1]);
       const detail = demoToolCallDetail(id);

--- a/src/lib/i18n.tsx
+++ b/src/lib/i18n.tsx
@@ -237,6 +237,7 @@ const DE: Record<string, string> = {
   "search.label": "Sessions und Events durchsuchen",
   "search.placeholder": "Suchen…",
   "search.clear": "Suche löschen",
+  "search.results": "Volltext-Treffer",
 
   "layout.drag": "Zum Umordnen ziehen",
   "layout.reset": "Layout zurücksetzen",
@@ -580,6 +581,7 @@ const EN: Record<string, string> = {
   "search.label": "Search sessions and events",
   "search.placeholder": "Search…",
   "search.clear": "Clear search",
+  "search.results": "Full-text matches",
 
   "layout.drag": "Drag to reorder",
   "layout.reset": "Reset layout",

--- a/src/lib/ingest.ts
+++ b/src/lib/ingest.ts
@@ -174,6 +174,10 @@ const insertPrompt = db.prepare<[string, number, string, number]>(`
   VALUES (?, ?, ?, ?)
 `);
 
+const insertSearch = db.prepare<[string, string, number, string]>(`
+  INSERT INTO search_fts (text, kind, ref_id, session_id) VALUES (?, ?, ?, ?)
+`);
+
 const bumpActivity = db.prepare<[string, string]>(`
   INSERT INTO activity_buckets (bucket, event_type, count) VALUES (?, ?, 1)
   ON CONFLICT(bucket, event_type) DO UPDATE SET count = count + 1
@@ -347,8 +351,11 @@ export function ingest(headerEvent: string, payload: HookPayload): IngestResult 
       JSON.stringify(stored),
     ) as EventRow;
 
+    if (summary) insertSearch.run(summary, "event", event.id, sessionId);
+
     if (prepared) {
-      insertPrompt.run(sessionId, event.id, prepared.capped, prepared.tokenEstimate);
+      const p = insertPrompt.run(sessionId, event.id, prepared.capped, prepared.tokenEstimate);
+      insertSearch.run(prepared.capped, "prompt", Number(p.lastInsertRowid), sessionId);
     }
 
     bumpActivity.run(hourBucket(event.created_at), eventType);

--- a/src/lib/migrations-sql.mjs
+++ b/src/lib/migrations-sql.mjs
@@ -150,4 +150,20 @@ export const MIGRATIONS = [
   `
   ALTER TABLE sessions ADD COLUMN transcript_path TEXT;
   `,
+
+  // v13 — FTS5 full-text index over event summaries + prompt text, kept in sync at
+  // ingest. Standalone (not external-content) so a single MATCH spans both sources.
+  // Backfilled once from existing rows.
+  `
+  CREATE VIRTUAL TABLE IF NOT EXISTS search_fts USING fts5(
+    text,
+    kind UNINDEXED,
+    ref_id UNINDEXED,
+    session_id UNINDEXED
+  );
+  INSERT INTO search_fts (text, kind, ref_id, session_id)
+    SELECT summary, 'event', id, session_id FROM events WHERE summary IS NOT NULL AND summary <> '';
+  INSERT INTO search_fts (text, kind, ref_id, session_id)
+    SELECT text, 'prompt', id, session_id FROM prompts WHERE text IS NOT NULL AND text <> '';
+  `,
 ];

--- a/src/lib/search-index.test.ts
+++ b/src/lib/search-index.test.ts
@@ -1,0 +1,55 @@
+import Database from "better-sqlite3";
+import { afterEach, describe, expect, it } from "vitest";
+import { migrate } from "@/lib/migrations";
+import { ftsQuery, searchFts } from "@/lib/search-index";
+
+describe("ftsQuery", () => {
+  it("builds AND-ed quoted prefix terms", () => {
+    expect(ftsQuery("ingest pipeline")).toBe('"ingest"* "pipeline"*');
+  });
+
+  it("strips punctuation that would break MATCH", () => {
+    expect(ftsQuery('foo: "bar" (baz)')).toBe('"foo"* "bar"* "baz"*');
+  });
+
+  it("returns null when nothing is searchable", () => {
+    expect(ftsQuery("")).toBeNull();
+    expect(ftsQuery("!!! ??? ...")).toBeNull();
+  });
+});
+
+describe("searchFts", () => {
+  let open: Database.Database | null = null;
+  afterEach(() => {
+    open?.close();
+    open = null;
+  });
+
+  function seed(): Database.Database {
+    const db = (open = new Database(":memory:"));
+    migrate(db);
+    const ins = db.prepare(
+      `INSERT INTO search_fts (text, kind, ref_id, session_id) VALUES (?, ?, ?, ?)`,
+    );
+    ins.run("Refactor the ingest pipeline", "event", 1, "s1");
+    ins.run("Fix the sankey chart colors", "event", 2, "s2");
+    ins.run("add retention tests", "prompt", 3, "s1");
+    return db;
+  }
+
+  it("matches by prefix across sources", () => {
+    const hits = searchFts(seed(), "ingest");
+    expect(hits).toHaveLength(1);
+    expect(hits[0]).toMatchObject({ kind: "event", session_id: "s1" });
+  });
+
+  it("requires all terms (AND)", () => {
+    expect(searchFts(seed(), "sankey colors")).toHaveLength(1);
+    expect(searchFts(seed(), "sankey ingest")).toHaveLength(0);
+  });
+
+  it("returns nothing for an empty or junk query", () => {
+    expect(searchFts(seed(), "")).toEqual([]);
+    expect(searchFts(seed(), "@@@")).toEqual([]);
+  });
+});

--- a/src/lib/search-index.ts
+++ b/src/lib/search-index.ts
@@ -1,0 +1,37 @@
+import type Database from "better-sqlite3";
+
+// Full-text search over event summaries + prompts (FTS5 `search_fts`). User input
+// is tokenised into prefix terms so arbitrary characters can't break MATCH syntax.
+
+export interface SearchHit {
+  kind: string; // "event" | "prompt"
+  ref_id: number;
+  session_id: string;
+  text: string;
+}
+
+// Build a safe FTS5 MATCH expression: each word becomes a quoted prefix term,
+// AND-ed together. Returns null when there's nothing searchable.
+export function ftsQuery(input: string): string | null {
+  const tokens = input.toLowerCase().match(/[\p{L}\p{N}]+/gu) ?? [];
+  if (tokens.length === 0) return null;
+  return tokens.map((t) => `"${t}"*`).join(" ");
+}
+
+export function searchFts(db: Database.Database, input: string, limit = 20): SearchHit[] {
+  const q = ftsQuery(input);
+  if (!q) return [];
+  try {
+    return db
+      .prepare(
+        `SELECT text, kind, ref_id, session_id
+         FROM search_fts
+         WHERE search_fts MATCH ?
+         ORDER BY rank
+         LIMIT ?`,
+      )
+      .all(q, limit) as SearchHit[];
+  } catch {
+    return []; // malformed query / missing FTS — degrade to no results
+  }
+}


### PR DESCRIPTION
## Summary
- **Volltextsuche (FTS5) / Full-text search** (Run 69): an FTS5 index (`search_fts`, migration **v13**) over event summaries + prompt text, kept in sync at ingest and backfilled once from existing rows. New `/api/search` and a **header search results dropdown** (whole-DB matches, each linking to the session page) upgrade the existing live filter.
- Adds a safe `ftsQuery` builder (tokenises input into quoted prefix terms so arbitrary characters can't break MATCH) + `searchFts` lib with unit tests, a `demoSearch()` source (+ patch), and de/en i18n.
- **Roadmap / licensing:** documents a *source-available dual license* — **free for private/non-commercial use, paid for commercial/company use** — with two concrete options (PolyForm Noncommercial 1.0.0 + a `COMMERCIAL.md`, or BSL 1.1), to be applied in the release phase (Run 120). (Answering your question: yes, this model is standard and enforceable; final wording should get legal review before release.)

## Test plan
- [x] `npm run lint` — clean
- [x] `npx vitest run` — 298 tests pass (new `ftsQuery`/`searchFts` cases; migrations tracked by length)
- [x] `npm run build` — succeeds (`/api/search` route present)
- [x] `npm run test:e2e` — 2 pass (`<section>` count stays 27)

https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk)_