### PR TITLE
Add saved views (named filter+layout presets)

### DIFF
--- a/src/components/dashboard.tsx
+++ b/src/components/dashboard.tsx
@@ -4,6 +4,8 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import {
   Activity,
+  Bookmark,
+  BookmarkPlus,
   Eye,
   EyeOff,
   GripHorizontal,
@@ -13,6 +15,7 @@ import {
   MoveVertical,
   RotateCcw,
   Search,
+  Trash2,
   X,
 } from "lucide-react";
 import { LiveProvider, useLive } from "@/components/live-provider";
@@ -27,6 +30,7 @@ import { FacetProvider, useFacets } from "@/components/facets";
 import { useT } from "@/lib/i18n";
 import { TIME_RANGES } from "@/lib/time-range";
 import type { SearchHit } from "@/lib/search-index";
+import { sanitizeViews, upsertView, type SavedView } from "@/lib/views";
 import { DEMO, installDemoBackend } from "@/lib/demo";
 import {
   HEIGHT_PRESETS,
@@ -170,6 +174,17 @@ export function Dashboard() {
     persistHidden([]);
   }, [persist, persistSizes, persistHidden]);
 
+  // Apply a saved view's layout, reconciling any widgets added since it was saved.
+  const applyLayout = useCallback(
+    (nextOrder: string[], nextSizes: SizeMap, nextHidden: string[]) => {
+      const full = [...nextOrder, ...DEFAULT_ORDER.filter((id) => !nextOrder.includes(id))];
+      persist(full);
+      persistSizes(nextSizes);
+      persistHidden(nextHidden);
+    },
+    [persist, persistSizes, persistHidden],
+  );
+
   const onDropOn = useCallback(
     (targetId: string) => {
       setDragId((current) => {
@@ -207,6 +222,10 @@ export function Dashboard() {
             isCustomLayout={isCustom}
             onResetLayout={resetLayout}
             onOpenGallery={() => setGalleryOpen(true)}
+            order={order}
+            sizes={sizes}
+            hidden={hidden}
+            onApplyLayout={applyLayout}
           />
           {ordered.length === 0 && (
             <div className="rounded-xl border border-dashed border-panel-border bg-panel/40 p-10 text-center text-sm text-muted">
@@ -325,10 +344,18 @@ function Header({
   isCustomLayout,
   onResetLayout,
   onOpenGallery,
+  order,
+  sizes,
+  hidden,
+  onApplyLayout,
 }: {
   isCustomLayout: boolean;
   onResetLayout: () => void;
   onOpenGallery: () => void;
+  order: string[];
+  sizes: SizeMap;
+  hidden: string[];
+  onApplyLayout: (order: string[], sizes: SizeMap, hidden: string[]) => void;
 }) {
   const { connected, events } = useLive();
   const { t, lang } = useT();
@@ -428,6 +455,7 @@ function Header({
         </label>
         <FacetBar />
         <TimeRangePicker />
+        <ViewsMenu order={order} sizes={sizes} hidden={hidden} onApplyLayout={onApplyLayout} />
         <button
           type="button"
           onClick={onOpenGallery}
@@ -471,6 +499,126 @@ function Header({
         </span>
       </div>
     </header>
+  );
+}
+
+const VIEWS_KEY = "mc-views";
+
+function ViewsMenu({
+  order,
+  sizes,
+  hidden,
+  onApplyLayout,
+}: {
+  order: string[];
+  sizes: SizeMap;
+  hidden: string[];
+  onApplyLayout: (order: string[], sizes: SizeMap, hidden: string[]) => void;
+}) {
+  const { t } = useT();
+  const { project, status, setProject, setStatus } = useFacets();
+  const { range, setRange } = useTimeRange();
+  const [views, setViews] = useState<SavedView[]>([]);
+  const [open, setOpen] = useState(false);
+  const [name, setName] = useState("");
+
+  useEffect(() => {
+    const id = requestAnimationFrame(() => {
+      try {
+        const raw = localStorage.getItem(VIEWS_KEY);
+        if (raw) setViews(sanitizeViews(JSON.parse(raw), DEFAULT_ORDER));
+      } catch {
+        /* ignore */
+      }
+    });
+    return () => cancelAnimationFrame(id);
+  }, []);
+
+  const persistViews = (next: SavedView[]) => {
+    setViews(next);
+    try {
+      if (next.length === 0) localStorage.removeItem(VIEWS_KEY);
+      else localStorage.setItem(VIEWS_KEY, JSON.stringify(next));
+    } catch {
+      /* ignore */
+    }
+  };
+
+  const save = () => {
+    const n = name.trim();
+    if (!n) return;
+    persistViews(upsertView(views, { name: n, order, sizes, hidden, project, status, range }));
+    setName("");
+  };
+
+  const apply = (v: SavedView) => {
+    onApplyLayout(v.order, v.sizes, v.hidden);
+    setProject(v.project);
+    setStatus(v.status);
+    setRange(v.range);
+    setOpen(false);
+  };
+
+  return (
+    <div className="relative hidden sm:block">
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        aria-label={t("views.title")}
+        title={t("views.title")}
+        className="flex items-center rounded-full border border-panel-border bg-background/40 p-1.5 text-muted transition-colors hover:border-accent/50 hover:text-foreground"
+      >
+        <Bookmark className="h-3.5 w-3.5" />
+      </button>
+      {open && (
+        <div className="absolute right-0 top-9 z-50 w-64 rounded-lg border border-panel-border bg-panel p-2 shadow-2xl shadow-black/50">
+          <div className="flex gap-1.5">
+            <input
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              onKeyDown={(e) => e.key === "Enter" && save()}
+              placeholder={t("views.namePlaceholder")}
+              aria-label={t("views.save")}
+              className="min-w-0 flex-1 rounded-md border border-panel-border bg-background/40 px-2 py-1 text-xs text-foreground outline-none focus:border-accent"
+            />
+            <button
+              type="button"
+              onClick={save}
+              title={t("views.save")}
+              className="shrink-0 rounded-md border border-accent/40 bg-accent/10 px-2 text-accent transition-colors hover:bg-accent/20"
+            >
+              <BookmarkPlus className="h-3.5 w-3.5" />
+            </button>
+          </div>
+          {views.length === 0 ? (
+            <p className="px-1 py-3 text-center text-[11px] text-muted">{t("views.empty")}</p>
+          ) : (
+            <ul className="mt-1.5 max-h-64 overflow-auto">
+              {views.map((v) => (
+                <li key={v.name} className="flex items-center gap-1">
+                  <button
+                    type="button"
+                    onClick={() => apply(v)}
+                    className="min-w-0 flex-1 truncate rounded-md px-2 py-1.5 text-left text-xs text-foreground transition-colors hover:bg-white/[0.04]"
+                  >
+                    {v.name}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => persistViews(views.filter((x) => x.name !== v.name))}
+                    aria-label={t("views.delete")}
+                    title={t("views.delete")}
+                    className="shrink-0 p-1 text-muted hover:text-red-400"
+                  >
+                    <Trash2 className="h-3.5 w-3.5" />
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+    </div>
   );
 }
 

--- a/src/lib/i18n.tsx
+++ b/src/lib/i18n.tsx
@@ -264,6 +264,12 @@ const DE: Record<string, string> = {
   "gallery.done": "Fertig",
   "gallery.allHidden": "Alle Widgets ausgeblendet. Öffne die Galerie, um welche einzublenden.",
 
+  "views.title": "Gespeicherte Ansichten",
+  "views.save": "Ansicht speichern",
+  "views.namePlaceholder": "Name der Ansicht…",
+  "views.empty": "Noch keine Ansichten gespeichert.",
+  "views.delete": "Ansicht löschen",
+
   "status.active": "Aktiv",
   "status.waiting": "Wartet",
   "status.ended": "Beendet",
@@ -607,6 +613,12 @@ const EN: Record<string, string> = {
   "gallery.showAll": "Show all",
   "gallery.done": "Done",
   "gallery.allHidden": "All widgets hidden. Open the gallery to show some.",
+
+  "views.title": "Saved views",
+  "views.save": "Save view",
+  "views.namePlaceholder": "View name…",
+  "views.empty": "No saved views yet.",
+  "views.delete": "Delete view",
 
   "status.active": "Active",
   "status.waiting": "Waiting",

--- a/src/lib/views.test.ts
+++ b/src/lib/views.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { sanitizeViews, upsertView, type SavedView } from "@/lib/views";
+
+const valid = ["a", "b", "c"];
+
+const view = (over: Partial<SavedView> = {}): SavedView => ({
+  name: "v",
+  order: ["a", "b"],
+  sizes: {},
+  hidden: [],
+  project: "",
+  status: "",
+  range: "all",
+  ...over,
+});
+
+describe("sanitizeViews", () => {
+  it("keeps valid views and scrubs unknown ids / bad fields", () => {
+    const out = sanitizeViews(
+      [
+        {
+          name: "Mine",
+          order: ["a", "zzz", "b"],
+          sizes: { a: { span: "lg:col-span-4", height: "h-auto" }, zzz: { span: "x", height: "y" } },
+          hidden: ["c", 5],
+          project: "alpha",
+          status: "active",
+          range: "7d",
+        },
+      ],
+      valid,
+    );
+    expect(out).toHaveLength(1);
+    expect(out[0].order).toEqual(["a", "b"]);
+    expect(out[0].sizes).toEqual({ a: { span: "lg:col-span-4", height: "h-auto" } });
+    expect(out[0].hidden).toEqual(["c"]);
+    expect(out[0].project).toBe("alpha");
+    expect(out[0].range).toBe("7d");
+  });
+
+  it("drops nameless views and falls back to safe defaults", () => {
+    const out = sanitizeViews([{ name: "  " }, { name: "ok", range: "bogus", status: "weird" }], valid);
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({ name: "ok", range: "all", status: "" });
+  });
+
+  it("returns an empty array for non-array input", () => {
+    expect(sanitizeViews(null, valid)).toEqual([]);
+  });
+});
+
+describe("upsertView", () => {
+  it("appends a new view", () => {
+    expect(upsertView([], view({ name: "x" }))).toHaveLength(1);
+  });
+
+  it("replaces an existing view by case-insensitive name", () => {
+    const out = upsertView([view({ name: "Home", range: "7d" })], view({ name: "home", range: "30d" }));
+    expect(out).toHaveLength(1);
+    expect(out[0].range).toBe("30d");
+  });
+});

--- a/src/lib/views.ts
+++ b/src/lib/views.ts
@@ -1,0 +1,53 @@
+import { sanitizeIdList, sanitizeSizes, type SizeMap } from "./layout";
+import { isTimeRange, type TimeRange } from "./time-range";
+
+// A saved view = a named snapshot of the dashboard's layout (order/sizes/hidden)
+// plus the active facets and time range. Persisted locally; pure (de)serialisation
+// lives here so it's unit-testable.
+
+export interface SavedView {
+  name: string;
+  order: string[];
+  sizes: SizeMap;
+  hidden: string[];
+  project: string;
+  status: string;
+  range: TimeRange;
+}
+
+const STATUSES = ["", "active", "waiting", "ended"];
+
+function sanitizeView(raw: unknown, validIds: string[]): SavedView | null {
+  if (!raw || typeof raw !== "object") return null;
+  const o = raw as Record<string, unknown>;
+  const name = typeof o.name === "string" ? o.name.trim() : "";
+  if (!name) return null;
+  return {
+    name: name.slice(0, 60),
+    order: sanitizeIdList(o.order, validIds),
+    sizes: sanitizeSizes(o.sizes, validIds),
+    hidden: sanitizeIdList(o.hidden, validIds),
+    project: typeof o.project === "string" ? o.project : "",
+    status: typeof o.status === "string" && STATUSES.includes(o.status) ? o.status : "",
+    range: isTimeRange(o.range) ? o.range : "all",
+  };
+}
+
+export function sanitizeViews(raw: unknown, validIds: string[]): SavedView[] {
+  if (!Array.isArray(raw)) return [];
+  const out: SavedView[] = [];
+  for (const item of raw) {
+    const v = sanitizeView(item, validIds);
+    if (v) out.push(v);
+  }
+  return out;
+}
+
+// Insert or replace a view by name (case-insensitive), keeping name order stable.
+export function upsertView(views: SavedView[], view: SavedView): SavedView[] {
+  const i = views.findIndex((v) => v.name.toLowerCase() === view.name.toLowerCase());
+  if (i === -1) return [...views, view];
+  const next = [...views];
+  next[i] = view;
+  return next;
+}


### PR DESCRIPTION
## Summary
- **Gespeicherte Ansichten / Saved views** (Run 70): a header **Views** menu (bookmark icon) that saves the current dashboard layout (order / sizes / hidden widgets) **plus** the active facets (project/status) and time range under a name, and restores the whole combo in one click. Views persist to `localStorage`; deleting is one click. Applying a view reconciles widgets added since it was saved (so nothing disappears).
- Adds a pure `views` lib (`sanitizeViews`, `upsertView`) with unit tests and de/en i18n. The menu reads facets + range via their contexts and the layout via props from the dashboard coordinator.

Research/UX note: saved views are the standard "switch quickly between filter+layout presets" pattern; the menu offers name-to-save, a list to apply, and per-view delete.

## Test plan
- [x] `npm run lint` — clean
- [x] `npx vitest run` — 303 tests pass (new `sanitizeViews`/`upsertView` cases)
- [x] `npm run build` — succeeds
- [x] `npm run test:e2e` — 2 pass (header control only; `<section>` count stays 27)

https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk)_