### PR TITLE
Add deep-links (URL-addressable filter state)

### DIFF
--- a/src/components/dashboard.tsx
+++ b/src/components/dashboard.tsx
@@ -6,10 +6,12 @@ import {
   Activity,
   Bookmark,
   BookmarkPlus,
+  Check,
   Eye,
   EyeOff,
   GripHorizontal,
   LayoutGrid,
+  Link2,
   MessageSquare,
   MoveHorizontal,
   MoveVertical,
@@ -456,6 +458,7 @@ function Header({
         <FacetBar />
         <TimeRangePicker />
         <ViewsMenu order={order} sizes={sizes} hidden={hidden} onApplyLayout={onApplyLayout} />
+        <CopyLinkButton />
         <button
           type="button"
           onClick={onOpenGallery}
@@ -672,6 +675,31 @@ function FacetBar() {
         </button>
       )}
     </>
+  );
+}
+
+function CopyLinkButton() {
+  const { t } = useT();
+  const [copied, setCopied] = useState(false);
+  const copy = () => {
+    try {
+      void navigator.clipboard?.writeText(window.location.href);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      /* clipboard unavailable */
+    }
+  };
+  return (
+    <button
+      type="button"
+      onClick={copy}
+      aria-label={t("deeplink.copy")}
+      title={copied ? t("deeplink.copied") : t("deeplink.copy")}
+      className="hidden items-center rounded-full border border-panel-border bg-background/40 p-1.5 text-muted transition-colors hover:border-accent/50 hover:text-foreground sm:flex"
+    >
+      {copied ? <Check className="h-3.5 w-3.5 text-emerald-400" /> : <Link2 className="h-3.5 w-3.5" />}
+    </button>
   );
 }
 

--- a/src/components/search.tsx
+++ b/src/components/search.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { createContext, useContext, useMemo, useState } from "react";
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react";
+import { getParam, setParam } from "@/lib/deep-link";
 
 interface SearchValue {
   query: string;
@@ -11,9 +12,33 @@ const SearchContext = createContext<SearchValue>({ query: "", setQuery: () => {}
 
 // Dashboard-wide free-text filter. Widgets read `query` to narrow what they show;
 // the header owns the input. Read-only — it only filters the view, never the data.
+// The query is URL-addressable (?q=) so a filtered view is shareable/deep-linkable.
 export function SearchProvider({ children }: { children: React.ReactNode }) {
-  const [query, setQuery] = useState("");
-  const value = useMemo(() => ({ query, setQuery }), [query]);
+  const [query, setQueryState] = useState("");
+
+  useEffect(() => {
+    const id = requestAnimationFrame(() => {
+      try {
+        const q = getParam(window.location.search, "q");
+        if (q) setQueryState(q);
+      } catch {
+        /* ignore */
+      }
+    });
+    return () => cancelAnimationFrame(id);
+  }, []);
+
+  const setQuery = useCallback((q: string) => {
+    setQueryState(q);
+    try {
+      const next = setParam(window.location.search, "q", q.trim());
+      window.history.replaceState(null, "", `${window.location.pathname}${next}`);
+    } catch {
+      /* ignore */
+    }
+  }, []);
+
+  const value = useMemo(() => ({ query, setQuery }), [query, setQuery]);
   return <SearchContext.Provider value={value}>{children}</SearchContext.Provider>;
 }
 

--- a/src/lib/deep-link.test.ts
+++ b/src/lib/deep-link.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { getParam, setParam } from "@/lib/deep-link";
+
+describe("setParam", () => {
+  it("adds a param to an empty query", () => {
+    expect(setParam("", "q", "hello")).toBe("?q=hello");
+  });
+
+  it("updates a param without clobbering others", () => {
+    expect(setParam("?range=7d&project=alpha", "q", "ingest")).toBe("?range=7d&project=alpha&q=ingest");
+    expect(setParam("?range=7d&q=old", "q", "new")).toBe("?range=7d&q=new");
+  });
+
+  it("removes a param when the value is empty, collapsing to '' when none remain", () => {
+    expect(setParam("?q=hello", "q", "")).toBe("");
+    expect(setParam("?range=7d&q=hello", "q", "")).toBe("?range=7d");
+  });
+
+  it("encodes special characters", () => {
+    expect(setParam("", "q", "a b")).toBe("?q=a+b");
+  });
+});
+
+describe("getParam", () => {
+  it("reads a present param and returns '' when absent", () => {
+    expect(getParam("?q=hello&range=7d", "q")).toBe("hello");
+    expect(getParam("?range=7d", "q")).toBe("");
+  });
+});

--- a/src/lib/deep-link.ts
+++ b/src/lib/deep-link.ts
@@ -1,0 +1,17 @@
+// Helpers for URL-addressable (deep-linkable) dashboard state. Pure so the
+// param-merging logic is unit-testable; providers call setParam to keep their
+// slice of the query string in sync without clobbering the others.
+
+// Return a query string (with leading "?", or "" when empty) where `key` is set
+// to `value`, or removed when `value` is falsy.
+export function setParam(search: string, key: string, value: string): string {
+  const params = new URLSearchParams(search);
+  if (value) params.set(key, value);
+  else params.delete(key);
+  const s = params.toString();
+  return s ? `?${s}` : "";
+}
+
+export function getParam(search: string, key: string): string {
+  return new URLSearchParams(search).get(key) ?? "";
+}

--- a/src/lib/i18n.tsx
+++ b/src/lib/i18n.tsx
@@ -239,6 +239,9 @@ const DE: Record<string, string> = {
   "search.clear": "Suche löschen",
   "search.results": "Volltext-Treffer",
 
+  "deeplink.copy": "Link zu dieser Ansicht kopieren",
+  "deeplink.copied": "Link kopiert!",
+
   "layout.drag": "Zum Umordnen ziehen",
   "layout.reset": "Layout zurücksetzen",
   "layout.width": "Breite ändern",
@@ -588,6 +591,9 @@ const EN: Record<string, string> = {
   "search.placeholder": "Search…",
   "search.clear": "Clear search",
   "search.results": "Full-text matches",
+
+  "deeplink.copy": "Copy link to this view",
+  "deeplink.copied": "Link copied!",
 
   "layout.drag": "Drag to reorder",
   "layout.reset": "Reset layout",


### PR DESCRIPTION
## Summary
- **Deep-Links / URL-addressable state** (Run 71): the dashboard search query now syncs to **`?q=`** (read on load, written on change), joining the existing `?range=` / `?project=` / `?status=` params — so any filtered view of the dashboard is shareable/bookmarkable (locally). Each provider merges only its own param without clobbering the others.
- Adds a header **"copy link"** button (copies the current URL, with a copied-confirmation), and a pure `deep-link` helper (`setParam`/`getParam`) with unit tests.

Research/UX note: deep-linkable filter state + a one-click copy is the standard "share this exact view" pattern; state lives in the URL so reload/bookmark restores it.

## Test plan
- [x] `npm run lint` — clean
- [x] `npx vitest run` — 308 tests pass (new `setParam`/`getParam` cases)
- [x] `npm run build` — succeeds
- [x] `npm run test:e2e` — 2 pass (header control + URL sync only; `<section>` count stays 27)

https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk)_