### PR TITLE
Add command palette (Cmd/Ctrl+K)

### DIFF
--- a/src/components/command-palette.tsx
+++ b/src/components/command-palette.tsx
@@ -1,0 +1,203 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import { CornerDownLeft, Search } from "lucide-react";
+import { useT } from "@/lib/i18n";
+import { useFacets } from "@/components/facets";
+import { useTimeRange } from "@/components/time-range";
+import { filterCommands, type CommandItem } from "@/lib/command-palette";
+import { TIME_RANGES } from "@/lib/time-range";
+import { widgets } from "@/plugins/registry";
+import type { SessionRow } from "@/lib/types";
+
+interface RunCommand extends CommandItem {
+  run: () => void;
+}
+
+export function CommandPalette({
+  onResetLayout,
+  onOpenGallery,
+}: {
+  onResetLayout: () => void;
+  onOpenGallery: () => void;
+}) {
+  const { t, lang, setLang } = useT();
+  const { setStatus, clear } = useFacets();
+  const { setRange } = useTimeRange();
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const [index, setIndex] = useState(0);
+  const [sessions, setSessions] = useState<SessionRow[]>([]);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    const reset = () => {
+      setQuery("");
+      setIndex(0);
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k") {
+        e.preventDefault();
+        setOpen((o) => !o);
+        reset();
+      }
+    };
+    const onOpenEvent = () => {
+      setOpen(true);
+      reset();
+    };
+    window.addEventListener("keydown", onKey);
+    window.addEventListener("mc:open-command", onOpenEvent);
+    return () => {
+      window.removeEventListener("keydown", onKey);
+      window.removeEventListener("mc:open-command", onOpenEvent);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!open) return;
+    inputRef.current?.focus();
+    let cancelled = false;
+    fetch("/api/sessions")
+      .then((r) => r.json())
+      .then((d: { sessions: SessionRow[] }) => {
+        if (!cancelled) setSessions(d.sessions ?? []);
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [open]);
+
+  const commands = useMemo<RunCommand[]>(() => {
+    const close = () => setOpen(false);
+    const list: RunCommand[] = [];
+    for (const r of TIME_RANGES) {
+      list.push({
+        id: `range-${r}`,
+        group: t("cmd.range"),
+        label: `${t("cmd.setRange")}: ${t(`range.${r}`)}`,
+        keywords: "time zeit range zeitraum",
+        run: () => {
+          setRange(r);
+          close();
+        },
+      });
+    }
+    for (const s of ["active", "waiting", "ended"]) {
+      list.push({
+        id: `status-${s}`,
+        group: t("cmd.status"),
+        label: `${t("cmd.setStatus")}: ${t(`status.${s}`)}`,
+        run: () => {
+          setStatus(s);
+          close();
+        },
+      });
+    }
+    list.push({ id: "facet-clear", group: t("cmd.status"), label: t("facets.clear"), run: () => { clear(); close(); } });
+    list.push({ id: "reset", group: t("cmd.actions"), label: t("layout.reset"), run: () => { onResetLayout(); close(); } });
+    list.push({ id: "gallery", group: t("cmd.actions"), label: t("gallery.title"), run: () => { onOpenGallery(); close(); } });
+    list.push({
+      id: "lang",
+      group: t("cmd.actions"),
+      label: lang === "de" ? "Language: English" : "Sprache: Deutsch",
+      keywords: "language sprache locale",
+      run: () => {
+        setLang(lang === "de" ? "en" : "de");
+        close();
+      },
+    });
+    for (const w of widgets) {
+      list.push({
+        id: `widget-${w.id}`,
+        group: t("cmd.widgets"),
+        label: `${t("cmd.goto")}: ${w.title}`,
+        run: () => {
+          document.getElementById(`mc-widget-${w.id}`)?.scrollIntoView({ behavior: "smooth", block: "start" });
+          close();
+        },
+      });
+    }
+    for (const s of sessions.slice(0, 30)) {
+      list.push({
+        id: `session-${s.id}`,
+        group: t("cmd.sessions"),
+        label: s.title || s.id.slice(0, 8),
+        keywords: `${s.project_name ?? ""} ${s.id}`,
+        run: () => {
+          router.push(`/session?id=${encodeURIComponent(s.id)}`);
+          close();
+        },
+      });
+    }
+    return list;
+  }, [t, lang, setLang, setRange, setStatus, clear, onResetLayout, onOpenGallery, sessions, router]);
+
+  const filtered = filterCommands(commands, query);
+  const sel = filtered.length ? Math.min(index, filtered.length - 1) : 0;
+
+  if (!open) return null;
+
+  const onInputKey = (e: React.KeyboardEvent) => {
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setIndex((i) => Math.min(i + 1, filtered.length - 1));
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setIndex((i) => Math.max(i - 1, 0));
+    } else if (e.key === "Enter") {
+      e.preventDefault();
+      filtered[sel]?.run();
+    } else if (e.key === "Escape") {
+      setOpen(false);
+    }
+  };
+
+  return (
+    <div role="dialog" aria-modal="true" aria-label={t("cmd.title")} className="fixed inset-0 z-[80] flex items-start justify-center p-4 pt-[12vh]">
+      <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" onClick={() => setOpen(false)} aria-hidden />
+      <div className="relative z-10 flex max-h-[70vh] w-full max-w-lg flex-col overflow-hidden rounded-xl border border-panel-border bg-panel shadow-2xl shadow-black/50">
+        <div className="flex items-center gap-2 border-b border-panel-border px-3">
+          <Search className="h-4 w-4 shrink-0 text-muted" />
+          <input
+            ref={inputRef}
+            value={query}
+            onChange={(e) => {
+              setQuery(e.target.value);
+              setIndex(0);
+            }}
+            onKeyDown={onInputKey}
+            placeholder={t("cmd.placeholder")}
+            aria-label={t("cmd.title")}
+            className="w-full bg-transparent py-3 text-sm text-foreground outline-none placeholder:text-muted"
+          />
+        </div>
+        <ul className="min-h-0 flex-1 overflow-auto p-1">
+          {filtered.length === 0 ? (
+            <li className="px-3 py-6 text-center text-xs text-muted">{t("cmd.empty")}</li>
+          ) : (
+            filtered.map((c, i) => (
+              <li key={c.id}>
+                <button
+                  type="button"
+                  onMouseEnter={() => setIndex(i)}
+                  onClick={() => c.run()}
+                  className={`flex w-full items-center justify-between gap-3 rounded-lg px-3 py-2 text-left text-sm ${i === sel ? "bg-accent/15 text-foreground" : "text-foreground hover:bg-white/[0.04]"}`}
+                >
+                  <span className="truncate">{c.label}</span>
+                  <span className="flex shrink-0 items-center gap-1.5">
+                    <span className="text-[10px] uppercase tracking-wide text-muted">{c.group}</span>
+                    {i === sel && <CornerDownLeft className="h-3 w-3 text-accent" />}
+                  </span>
+                </button>
+              </li>
+            ))
+          )}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/src/components/dashboard.tsx
+++ b/src/components/dashboard.tsx
@@ -29,6 +29,7 @@ import { Landing } from "@/components/landing";
 import { SearchProvider, useSearch } from "@/components/search";
 import { TimeRangeProvider, useTimeRange } from "@/components/time-range";
 import { FacetProvider, useFacets } from "@/components/facets";
+import { CommandPalette } from "@/components/command-palette";
 import { useT } from "@/lib/i18n";
 import { TIME_RANGES } from "@/lib/time-range";
 import type { SearchHit } from "@/lib/search-index";
@@ -241,6 +242,7 @@ export function Dashboard() {
               return (
               <div
                 key={w.id}
+                id={`mc-widget-${w.id}`}
                 // The 3D graph goes fullscreen via position:fixed, which breaks if an
                 // ancestor has a transform. So its cell uses an opacity-only entrance
                 // (no transform) while the others keep the subtle rise. `relative`
@@ -288,6 +290,7 @@ export function Dashboard() {
             onClose={() => setGalleryOpen(false)}
           />
         )}
+        <CommandPalette onResetLayout={resetLayout} onOpenGallery={() => setGalleryOpen(true)} />
         </FacetProvider>
         </TimeRangeProvider>
       </SearchProvider>
@@ -458,6 +461,15 @@ function Header({
         <FacetBar />
         <TimeRangePicker />
         <ViewsMenu order={order} sizes={sizes} hidden={hidden} onApplyLayout={onApplyLayout} />
+        <button
+          type="button"
+          onClick={() => window.dispatchEvent(new Event("mc:open-command"))}
+          aria-label={t("cmd.title")}
+          title={t("cmd.title")}
+          className="hidden items-center gap-1 rounded-full border border-panel-border bg-background/40 px-2 py-1 font-mono text-[11px] text-muted transition-colors hover:border-accent/50 hover:text-foreground sm:flex"
+        >
+          ⌘K
+        </button>
         <CopyLinkButton />
         <button
           type="button"

--- a/src/lib/command-palette.test.ts
+++ b/src/lib/command-palette.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { filterCommands, type CommandItem } from "@/lib/command-palette";
+
+const cmds: CommandItem[] = [
+  { id: "1", label: "Open session shopify-bot", group: "Sessions" },
+  { id: "2", label: "Filter: last 7 days", group: "Range", keywords: "time week" },
+  { id: "3", label: "Reset layout", group: "Actions" },
+];
+
+describe("filterCommands", () => {
+  it("returns all commands for an empty query", () => {
+    expect(filterCommands(cmds, "")).toHaveLength(3);
+  });
+
+  it("matches against label, group and keywords", () => {
+    expect(filterCommands(cmds, "shopify").map((c) => c.id)).toEqual(["1"]);
+    expect(filterCommands(cmds, "range").map((c) => c.id)).toEqual(["2"]);
+    expect(filterCommands(cmds, "week").map((c) => c.id)).toEqual(["2"]);
+  });
+
+  it("requires all terms to match (AND)", () => {
+    expect(filterCommands(cmds, "filter days").map((c) => c.id)).toEqual(["2"]);
+    expect(filterCommands(cmds, "filter reset")).toHaveLength(0);
+  });
+
+  it("is case-insensitive", () => {
+    expect(filterCommands(cmds, "RESET").map((c) => c.id)).toEqual(["3"]);
+  });
+});

--- a/src/lib/command-palette.ts
+++ b/src/lib/command-palette.ts
@@ -1,0 +1,19 @@
+// Pure command-list filtering for the ⌘K palette. Multi-term substring match over
+// each command's label, group and keywords — kept here so it's unit-testable.
+
+export interface CommandItem {
+  id: string;
+  label: string;
+  group: string;
+  keywords?: string;
+}
+
+export function filterCommands<T extends CommandItem>(commands: T[], query: string): T[] {
+  const q = query.trim().toLowerCase();
+  if (!q) return commands;
+  const terms = q.split(/\s+/);
+  return commands.filter((c) => {
+    const hay = `${c.label} ${c.group} ${c.keywords ?? ""}`.toLowerCase();
+    return terms.every((t) => hay.includes(t));
+  });
+}

--- a/src/lib/i18n.tsx
+++ b/src/lib/i18n.tsx
@@ -242,6 +242,18 @@ const DE: Record<string, string> = {
   "deeplink.copy": "Link zu dieser Ansicht kopieren",
   "deeplink.copied": "Link kopiert!",
 
+  "cmd.title": "Befehlspalette",
+  "cmd.placeholder": "Befehl eingeben oder Session suchen…",
+  "cmd.empty": "Keine Treffer.",
+  "cmd.range": "Zeitraum",
+  "cmd.status": "Status",
+  "cmd.actions": "Aktionen",
+  "cmd.widgets": "Widgets",
+  "cmd.sessions": "Sessions",
+  "cmd.setRange": "Zeitraum",
+  "cmd.setStatus": "Status",
+  "cmd.goto": "Gehe zu",
+
   "layout.drag": "Zum Umordnen ziehen",
   "layout.reset": "Layout zurücksetzen",
   "layout.width": "Breite ändern",
@@ -594,6 +606,18 @@ const EN: Record<string, string> = {
 
   "deeplink.copy": "Copy link to this view",
   "deeplink.copied": "Link copied!",
+
+  "cmd.title": "Command palette",
+  "cmd.placeholder": "Type a command or search a session…",
+  "cmd.empty": "No matches.",
+  "cmd.range": "Range",
+  "cmd.status": "Status",
+  "cmd.actions": "Actions",
+  "cmd.widgets": "Widgets",
+  "cmd.sessions": "Sessions",
+  "cmd.setRange": "Range",
+  "cmd.setStatus": "Status",
+  "cmd.goto": "Go to",
 
   "layout.drag": "Drag to reorder",
   "layout.reset": "Reset layout",


### PR DESCRIPTION
## Summary
- **Command-Palette (⌘K)** (Run 72, completes Phase E): a keyboard-first palette to jump to **sessions** (navigate to the session page), scroll to **widgets**, set the **time range** / **status**, **clear filters**, **reset layout**, **open the gallery**, and **toggle language**. Opens via **Cmd/Ctrl+K** or a header `⌘K` button; arrow keys move, Enter runs, Esc closes; backdrop click closes. Results show a group tag per row.
- Adds a pure `filterCommands` matcher (multi-term, label/group/keywords) with unit tests, gives widget cells DOM ids as scroll targets, and de/en i18n.

Research/UX note: follows the ⌘K convention with fuzzy/substring filtering, grouped results, and full keyboard navigation — the Linear/VS Code pattern.

## Test plan
- [x] `npm run lint` — clean
- [x] `npx vitest run` — 312 tests pass (new `filterCommands` cases)
- [x] `npm run build` — succeeds
- [x] `npm run test:e2e` — 2 pass (`<section>` count stays 27)

This wraps **Phase E (Drill-down & Detail-UX)**: session page, JSON tree, tool-call inspector, transcript viewer, global time range, facets, FTS search, saved views, deep-links, and now the command palette.

https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk)_