### PR TITLE
Add plugin manifest metadata to the widget registry

### DIFF
--- a/src/components/dashboard.tsx
+++ b/src/components/dashboard.tsx
@@ -43,13 +43,14 @@ import {
   SPAN_PRESETS,
   type SizeMap,
 } from "@/lib/layout";
-import { widgets } from "@/plugins/registry";
+import { widgets, type WidgetCategory } from "@/plugins/registry";
 
 // In the static demo build, start the in-browser engine + patch fetch before any
 // widget mounts. No-op in the real (server-backed) app.
 if (DEMO) installDemoBackend();
 
 const DEFAULT_ORDER = widgets.map((w) => w.id);
+const CATEGORY_ORDER: WidgetCategory[] = ["overview", "sessions", "economy", "activity", "tools", "quality"];
 const ORDER_KEY = "mc-widget-order";
 const SIZE_KEY = "mc-widget-sizes";
 const HIDDEN_KEY = "mc-widget-hidden";
@@ -782,30 +783,48 @@ function WidgetGallery({
           </button>
         </header>
         <p className="px-4 pt-3 text-xs text-muted">{t("gallery.info")}</p>
-        <ul className="min-h-0 flex-1 overflow-auto p-2">
-          {items.map((w) => {
-            const isHidden = hidden.includes(w.id);
+        <div className="min-h-0 flex-1 overflow-auto p-2">
+          {CATEGORY_ORDER.map((cat) => {
+            const group = items.filter((w) => w.category === cat);
+            if (group.length === 0) return null;
             return (
-              <li key={w.id}>
-                <button
-                  type="button"
-                  onClick={() => onToggle(w.id)}
-                  aria-pressed={!isHidden}
-                  className="flex w-full items-center gap-3 rounded-lg px-3 py-2 text-left text-sm transition-colors hover:bg-white/[0.04]"
-                >
-                  {isHidden ? (
-                    <EyeOff className="h-4 w-4 shrink-0 text-muted" />
-                  ) : (
-                    <Eye className="h-4 w-4 shrink-0 text-accent" />
-                  )}
-                  <span className={`flex-1 truncate ${isHidden ? "text-muted line-through" : "text-foreground"}`}>
-                    {w.title}
-                  </span>
-                </button>
-              </li>
+              <div key={cat} className="mb-1">
+                <p className="px-2 pb-0.5 pt-2 text-[10px] font-semibold uppercase tracking-wide text-muted">
+                  {t(`cat.${cat}`)}
+                </p>
+                <ul>
+                  {group.map((w) => {
+                    const isHidden = hidden.includes(w.id);
+                    const Icon = w.icon;
+                    return (
+                      <li key={w.id}>
+                        <button
+                          type="button"
+                          onClick={() => onToggle(w.id)}
+                          aria-pressed={!isHidden}
+                          className="flex w-full items-start gap-3 rounded-lg px-3 py-2 text-left transition-colors hover:bg-white/[0.04]"
+                        >
+                          {isHidden ? (
+                            <EyeOff className="mt-0.5 h-4 w-4 shrink-0 text-muted" />
+                          ) : (
+                            <Eye className="mt-0.5 h-4 w-4 shrink-0 text-accent" />
+                          )}
+                          <span className="min-w-0 flex-1">
+                            <span className={`flex items-center gap-1.5 text-sm ${isHidden ? "text-muted line-through" : "text-foreground"}`}>
+                              <Icon className="h-3.5 w-3.5 shrink-0 text-muted" />
+                              <span className="truncate">{w.title}</span>
+                            </span>
+                            <span className="mt-0.5 line-clamp-2 block text-[11px] text-muted">{t(w.description)}</span>
+                          </span>
+                        </button>
+                      </li>
+                    );
+                  })}
+                </ul>
+              </div>
             );
           })}
-        </ul>
+        </div>
         <footer className="flex justify-end gap-2 border-t border-panel-border px-4 py-3">
           <button type="button" onClick={onShowAll} className="rounded-md border border-panel-border px-3 py-1.5 text-xs text-muted transition-colors hover:text-foreground">
             {t("gallery.showAll")}

--- a/src/lib/i18n.tsx
+++ b/src/lib/i18n.tsx
@@ -86,6 +86,7 @@ const DE: Record<string, string> = {
   "kpi.tools": "Tool-Aufrufe heute",
   "kpi.errors": "Fehlerquote heute",
   "kpi.cost": "Kosten heute",
+  "kpi.info": "Kennzahlen von heute: aktive Sessions, Events, Tool-Aufrufe, Fehlerquote und Kosten.",
   "heatmap.title": "Aktivität",
   "heatmap.info": "Aktivität nach Wochentag und Stunde (lokale Zeit), aus dem Event-Verlauf.",
   "heatmap.empty": "Noch keine Aktivität.",
@@ -279,6 +280,13 @@ const DE: Record<string, string> = {
   "gallery.done": "Fertig",
   "gallery.allHidden": "Alle Widgets ausgeblendet. Öffne die Galerie, um welche einzublenden.",
 
+  "cat.overview": "Übersicht",
+  "cat.sessions": "Sessions",
+  "cat.economy": "Ökonomie",
+  "cat.activity": "Aktivität",
+  "cat.tools": "Tools",
+  "cat.quality": "Qualität",
+
   "views.title": "Gespeicherte Ansichten",
   "views.save": "Ansicht speichern",
   "views.namePlaceholder": "Name der Ansicht…",
@@ -451,6 +459,7 @@ const EN: Record<string, string> = {
   "kpi.tools": "Tool calls today",
   "kpi.errors": "Error rate today",
   "kpi.cost": "Cost today",
+  "kpi.info": "Today's headline metrics: active sessions, events, tool calls, error rate and cost.",
   "heatmap.title": "Activity",
   "heatmap.info": "Activity by weekday and hour (local time), from the event history.",
   "heatmap.empty": "No activity yet.",
@@ -643,6 +652,13 @@ const EN: Record<string, string> = {
   "gallery.showAll": "Show all",
   "gallery.done": "Done",
   "gallery.allHidden": "All widgets hidden. Open the gallery to show some.",
+
+  "cat.overview": "Overview",
+  "cat.sessions": "Sessions",
+  "cat.economy": "Economy",
+  "cat.activity": "Activity",
+  "cat.tools": "Tools",
+  "cat.quality": "Quality",
 
   "views.title": "Saved views",
   "views.save": "Save view",

--- a/src/plugins/registry.test.ts
+++ b/src/plugins/registry.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { widgets } from "@/plugins/registry";
+
+const CATEGORIES = ["overview", "sessions", "economy", "activity", "tools", "quality"];
+
+describe("widget registry manifest", () => {
+  it("has unique widget ids", () => {
+    const ids = widgets.map((w) => w.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("gives every widget complete manifest metadata", () => {
+    for (const w of widgets) {
+      expect(w.id, "id").toBeTruthy();
+      expect(w.title, `${w.id} title`).toBeTruthy();
+      expect(w.span, `${w.id} span`).toMatch(/col-span/);
+      expect(w.height, `${w.id} height`).toBeTruthy();
+      expect(w.icon, `${w.id} icon`).toBeTruthy();
+      expect(CATEGORIES, `${w.id} category`).toContain(w.category);
+      expect(w.description, `${w.id} description`).toMatch(/\./); // i18n key
+      expect(typeof w.component, `${w.id} component`).toBe("function");
+    }
+  });
+});

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -1,4 +1,35 @@
 import type { ComponentType } from "react";
+import {
+  Activity,
+  AlertTriangle,
+  BarChart3,
+  Boxes,
+  CalendarClock,
+  CalendarRange,
+  Clock,
+  Coins,
+  FileText,
+  Flame,
+  Fuel,
+  Gauge,
+  GitBranch,
+  Hash,
+  Hourglass,
+  KanbanSquare,
+  Layers,
+  LayoutDashboard,
+  MessageSquare,
+  PieChart,
+  Plug,
+  Radio,
+  ShieldAlert,
+  ShieldCheck,
+  Timer,
+  TrendingUp,
+  Trophy,
+  Waypoints,
+  type LucideIcon,
+} from "lucide-react";
 import { LiveStream } from "./live-stream/widget";
 import { Kanban } from "./kanban/widget";
 import { TokenChart } from "./token-chart/widget";
@@ -33,216 +64,65 @@ import { Incidents } from "./incidents/widget";
 // Add a feature in three steps:
 //   1. create  src/plugins/<your-plugin>/widget.tsx  exporting a React component
 //   2. (optional) add a read-only route under  src/app/api/<your-plugin>/route.ts
-//   3. register it below — the dashboard grid renders it automatically.
-// Nothing else needs to change. This is the seam for the future Obsidian
-// knowledge-graph / semantic-search plugins.
+//   3. register it below with its manifest — the dashboard grid renders it
+//      automatically and the gallery groups it by category.
+// Nothing else needs to change. This is the seam for future third-party plugins.
 // ─────────────────────────────────────────────────────────────────────────────
+
+export type WidgetCategory =
+  | "overview"
+  | "sessions"
+  | "economy"
+  | "activity"
+  | "tools"
+  | "quality";
 
 export interface Widget {
   id: string;
   title: string;
-  /** Tailwind grid-column span on the 6-col desktop grid. */
+  /** Tailwind grid-column span on the 6-col desktop grid (also the default size). */
   span: string;
-  /** Tailwind row-height utility for the panel. */
+  /** Tailwind row-height utility for the panel (also the default size). */
   height: string;
+  /** Manifest metadata — icon, grouping category and an i18n description key. */
+  icon: LucideIcon;
+  category: WidgetCategory;
+  /** i18n key for a short description (reuses each widget's existing info copy). */
+  description: string;
   component: ComponentType;
 }
 
+// Standard panel height (most widgets). KPI bar + calendar use h-auto.
+const H = "h-[360px] min-[2560px]:h-[480px] min-[3840px]:h-[660px]";
+const H_TALL = "h-[420px] min-[2560px]:h-[560px] min-[3840px]:h-[760px]";
+
 export const widgets: Widget[] = [
-  {
-    id: "kpi-bar",
-    title: "Übersicht",
-    span: "lg:col-span-6",
-    height: "h-auto",
-    component: KpiBar,
-  },
-  {
-    id: "kanban",
-    title: "Sessions",
-    span: "lg:col-span-4",
-    height: "h-[420px] min-[2560px]:h-[560px] min-[3840px]:h-[760px]",
-    component: Kanban,
-  },
-  {
-    id: "live-stream",
-    title: "Live Stream",
-    span: "lg:col-span-2",
-    height: "h-[420px] min-[2560px]:h-[560px] min-[3840px]:h-[760px]",
-    component: LiveStream,
-  },
-  {
-    id: "token-chart",
-    title: "Tokens & Kosten",
-    span: "lg:col-span-3",
-    height: "h-[360px] min-[2560px]:h-[480px] min-[3840px]:h-[660px]",
-    component: TokenChart,
-  },
-  {
-    id: "tool-graph",
-    title: "Tool-Graph (3D)",
-    span: "lg:col-span-3",
-    height: "h-[360px] min-[2560px]:h-[480px] min-[3840px]:h-[660px]",
-    component: ToolGraph,
-  },
-  {
-    id: "budget-gauge",
-    title: "Budget",
-    span: "lg:col-span-2",
-    height: "h-[360px] min-[2560px]:h-[480px] min-[3840px]:h-[660px]",
-    component: BudgetGauge,
-  },
-  {
-    id: "heatmap",
-    title: "Aktivität",
-    span: "lg:col-span-4",
-    height: "h-[360px] min-[2560px]:h-[480px] min-[3840px]:h-[660px]",
-    component: Heatmap,
-  },
-  {
-    id: "tool-frequency",
-    title: "Top-Tools",
-    span: "lg:col-span-2",
-    height: "h-[360px] min-[2560px]:h-[480px] min-[3840px]:h-[660px]",
-    component: ToolFrequency,
-  },
-  {
-    id: "file-hotspots",
-    title: "Datei-Hotspots",
-    span: "lg:col-span-3",
-    height: "h-[360px] min-[2560px]:h-[480px] min-[3840px]:h-[660px]",
-    component: FileHotspots,
-  },
-  {
-    id: "session-timeline",
-    title: "Session-Timeline",
-    span: "lg:col-span-3",
-    height: "h-[360px] min-[2560px]:h-[480px] min-[3840px]:h-[660px]",
-    component: SessionTimeline,
-  },
-  {
-    id: "latency",
-    title: "Tool-Latenz",
-    span: "lg:col-span-3",
-    height: "h-[360px] min-[2560px]:h-[480px] min-[3840px]:h-[660px]",
-    component: Latency,
-  },
-  {
-    id: "error-rate",
-    title: "Fehlerrate",
-    span: "lg:col-span-3",
-    height: "h-[360px] min-[2560px]:h-[480px] min-[3840px]:h-[660px]",
-    component: ErrorRate,
-  },
-  {
-    id: "model-donut",
-    title: "Modelle",
-    span: "lg:col-span-3",
-    height: "h-[360px] min-[2560px]:h-[480px] min-[3840px]:h-[660px]",
-    component: ModelDonut,
-  },
-  {
-    id: "sankey-flow",
-    title: "Fluss",
-    span: "lg:col-span-3",
-    height: "h-[360px] min-[2560px]:h-[480px] min-[3840px]:h-[660px]",
-    component: SankeyFlow,
-  },
-  {
-    id: "project-leaderboard",
-    title: "Projekt-Rangliste",
-    span: "lg:col-span-3",
-    height: "h-[360px] min-[2560px]:h-[480px] min-[3840px]:h-[660px]",
-    component: ProjectLeaderboard,
-  },
-  {
-    id: "live-now",
-    title: "Jetzt live",
-    span: "lg:col-span-3",
-    height: "h-[360px] min-[2560px]:h-[480px] min-[3840px]:h-[660px]",
-    component: LiveNow,
-  },
-  {
-    id: "prompt-history",
-    title: "Prompt-Verlauf",
-    span: "lg:col-span-3",
-    height: "h-[360px] min-[2560px]:h-[480px] min-[3840px]:h-[660px]",
-    component: PromptHistory,
-  },
-  {
-    id: "streak",
-    title: "Streak & Produktivität",
-    span: "lg:col-span-3",
-    height: "h-[360px] min-[2560px]:h-[480px] min-[3840px]:h-[660px]",
-    component: Streak,
-  },
-  {
-    id: "subagent-tree",
-    title: "Subagent-Baum",
-    span: "lg:col-span-3",
-    height: "h-[360px] min-[2560px]:h-[480px] min-[3840px]:h-[660px]",
-    component: SubagentTree,
-  },
-  {
-    id: "mcp-servers",
-    title: "MCP-Server",
-    span: "lg:col-span-3",
-    height: "h-[360px] min-[2560px]:h-[480px] min-[3840px]:h-[660px]",
-    component: McpServers,
-  },
-  {
-    id: "compaction-timeline",
-    title: "Kompaktierungen",
-    span: "lg:col-span-3",
-    height: "h-[360px] min-[2560px]:h-[480px] min-[3840px]:h-[660px]",
-    component: CompactionTimeline,
-  },
-  {
-    id: "tag-cloud",
-    title: "Themen-Cloud",
-    span: "lg:col-span-3",
-    height: "h-[360px] min-[2560px]:h-[480px] min-[3840px]:h-[660px]",
-    component: TagCloud,
-  },
-  {
-    id: "token-burn",
-    title: "Token-Verbrauch je Tool",
-    span: "lg:col-span-3",
-    height: "h-[360px] min-[2560px]:h-[480px] min-[3840px]:h-[660px]",
-    component: TokenBurn,
-  },
-  {
-    id: "calendar-heatmap",
-    title: "Jahres-Kalender",
-    span: "lg:col-span-6",
-    height: "h-auto",
-    component: CalendarHeatmap,
-  },
-  {
-    id: "velocity",
-    title: "Geschwindigkeits-Trend",
-    span: "lg:col-span-3",
-    height: "h-[360px] min-[2560px]:h-[480px] min-[3840px]:h-[660px]",
-    component: Velocity,
-  },
-  {
-    id: "session-duration",
-    title: "Session-Dauer",
-    span: "lg:col-span-3",
-    height: "h-[360px] min-[2560px]:h-[480px] min-[3840px]:h-[660px]",
-    component: SessionDuration,
-  },
-  {
-    id: "reliability",
-    title: "Zuverlässigkeit je Projekt",
-    span: "lg:col-span-3",
-    height: "h-[360px] min-[2560px]:h-[480px] min-[3840px]:h-[660px]",
-    component: Reliability,
-  },
-  {
-    id: "incidents",
-    title: "Was lief schief",
-    span: "lg:col-span-3",
-    height: "h-[360px] min-[2560px]:h-[480px] min-[3840px]:h-[660px]",
-    component: Incidents,
-  },
+  { id: "kpi-bar", title: "Übersicht", span: "lg:col-span-6", height: "h-auto", icon: LayoutDashboard, category: "overview", description: "kpi.info", component: KpiBar },
+  { id: "kanban", title: "Sessions", span: "lg:col-span-4", height: H_TALL, icon: KanbanSquare, category: "sessions", description: "kanban.info", component: Kanban },
+  { id: "live-stream", title: "Live Stream", span: "lg:col-span-2", height: H_TALL, icon: Activity, category: "sessions", description: "stream.info", component: LiveStream },
+  { id: "token-chart", title: "Tokens & Kosten", span: "lg:col-span-3", height: H, icon: Coins, category: "economy", description: "tokens.info", component: TokenChart },
+  { id: "tool-graph", title: "Tool-Graph (3D)", span: "lg:col-span-3", height: H, icon: Boxes, category: "tools", description: "graph.info", component: ToolGraph },
+  { id: "budget-gauge", title: "Budget", span: "lg:col-span-2", height: H, icon: Gauge, category: "economy", description: "budget.info", component: BudgetGauge },
+  { id: "heatmap", title: "Aktivität", span: "lg:col-span-4", height: H, icon: CalendarClock, category: "activity", description: "heatmap.info", component: Heatmap },
+  { id: "tool-frequency", title: "Top-Tools", span: "lg:col-span-2", height: H, icon: BarChart3, category: "tools", description: "tools.info", component: ToolFrequency },
+  { id: "file-hotspots", title: "Datei-Hotspots", span: "lg:col-span-3", height: H, icon: FileText, category: "tools", description: "files.info", component: FileHotspots },
+  { id: "session-timeline", title: "Session-Timeline", span: "lg:col-span-3", height: H, icon: Clock, category: "sessions", description: "timeline.info", component: SessionTimeline },
+  { id: "latency", title: "Tool-Latenz", span: "lg:col-span-3", height: H, icon: Timer, category: "quality", description: "latency.info", component: Latency },
+  { id: "error-rate", title: "Fehlerrate", span: "lg:col-span-3", height: H, icon: ShieldAlert, category: "quality", description: "errors.info", component: ErrorRate },
+  { id: "model-donut", title: "Modelle", span: "lg:col-span-3", height: H, icon: PieChart, category: "economy", description: "donut.info", component: ModelDonut },
+  { id: "sankey-flow", title: "Fluss", span: "lg:col-span-3", height: H, icon: Waypoints, category: "tools", description: "sankey.info", component: SankeyFlow },
+  { id: "project-leaderboard", title: "Projekt-Rangliste", span: "lg:col-span-3", height: H, icon: Trophy, category: "economy", description: "leaderboard.info", component: ProjectLeaderboard },
+  { id: "live-now", title: "Jetzt live", span: "lg:col-span-3", height: H, icon: Radio, category: "sessions", description: "now.info", component: LiveNow },
+  { id: "prompt-history", title: "Prompt-Verlauf", span: "lg:col-span-3", height: H, icon: MessageSquare, category: "sessions", description: "prompts.info", component: PromptHistory },
+  { id: "streak", title: "Streak & Produktivität", span: "lg:col-span-3", height: H, icon: Flame, category: "activity", description: "streak.info", component: Streak },
+  { id: "subagent-tree", title: "Subagent-Baum", span: "lg:col-span-3", height: H, icon: GitBranch, category: "sessions", description: "subagents.info", component: SubagentTree },
+  { id: "mcp-servers", title: "MCP-Server", span: "lg:col-span-3", height: H, icon: Plug, category: "tools", description: "mcp.info", component: McpServers },
+  { id: "compaction-timeline", title: "Kompaktierungen", span: "lg:col-span-3", height: H, icon: Layers, category: "quality", description: "compaction.info", component: CompactionTimeline },
+  { id: "tag-cloud", title: "Themen-Cloud", span: "lg:col-span-3", height: H, icon: Hash, category: "tools", description: "tags.info", component: TagCloud },
+  { id: "token-burn", title: "Token-Verbrauch je Tool", span: "lg:col-span-3", height: H, icon: Fuel, category: "economy", description: "burn.info", component: TokenBurn },
+  { id: "calendar-heatmap", title: "Jahres-Kalender", span: "lg:col-span-6", height: "h-auto", icon: CalendarRange, category: "activity", description: "calendar.info", component: CalendarHeatmap },
+  { id: "velocity", title: "Geschwindigkeits-Trend", span: "lg:col-span-3", height: H, icon: TrendingUp, category: "activity", description: "velocity.info", component: Velocity },
+  { id: "session-duration", title: "Session-Dauer", span: "lg:col-span-3", height: H, icon: Hourglass, category: "sessions", description: "sessionDur.info", component: SessionDuration },
+  { id: "reliability", title: "Zuverlässigkeit je Projekt", span: "lg:col-span-3", height: H, icon: ShieldCheck, category: "quality", description: "reliability.info", component: Reliability },
+  { id: "incidents", title: "Was lief schief", span: "lg:col-span-3", height: H, icon: AlertTriangle, category: "quality", description: "incidents.info", component: Incidents },
 ];


### PR DESCRIPTION
## Summary
- **Plugin-Manifest** (Run 73, starts Phase F): extends the registry `Widget` type with manifest metadata — **icon**, **category** (`overview`/`sessions`/`economy`/`activity`/`tools`/`quality`), and an i18n **description** key (the existing span/height remain the default size). All 27 widgets now carry a complete manifest.
- The **widget gallery** uses it: widgets are grouped under category headers, each row showing its icon + short description. Adds a registry invariant test (unique ids + complete metadata), de/en category labels, and a `kpi.info` description.

Descriptions reuse each widget's existing `*.info` copy, so no duplicate translations were needed (except the new `kpi.info`).

## Test plan
- [x] `npm run lint` — clean
- [x] `npx vitest run` — 314 tests pass (new registry-manifest invariants)
- [x] `npm run build` — succeeds
- [x] `npm run test:e2e` — 2 pass (`<section>` count stays 27)

https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk)_