### PR TITLE
Add plugin settings persistence + settings drawer

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -338,12 +338,19 @@ sein.
      Hints überall; alle `/api/*`-Routen antworten; Demo-Modus zeigt alle
      Widgets. Abschluss-Sammlung aller Screenshots.
 
-## Phase Ω — Release (Run 120)
+## Phase Ω — Beta-Release (Run 120, **letzter Schritt**)
 
-120. ⚙️ **v1.0-Release** (erst nach grüner Phase Z). Signierte Installer +
-     Auto-Update, Version-Bump, Changelog, Release-Workflow finalisieren,
-     Pages-Demo mit allen Widgets.
-     *Ergebnis:* das beste Claude-Code-Observability-Tool — ausgeliefert.
+120. 🚀 **v1.0.0-beta — unsignierte Beta für alle Betriebssysteme** (erst nach
+     grüner Phase Z). Kein Code-Signing, ausdrücklich als **Beta** gekennzeichnet:
+     - Builds + Downloads für **alle OS**: **Windows** (`.exe`/portable),
+       **macOS** (`.dmg`, Intel + Apple Silicon) und **Linux**
+       (`AppImage`/`.deb`) — alle **unsigniert** (Installations-Hinweis je OS
+       in der README, z. B. Gatekeeper/SmartScreen-Umgehung für Beta-Builds).
+     - GitHub-Release `v1.0.0-beta` (Pre-Release-Flag gesetzt) mit allen
+       Artefakten als Download, Changelog, Version-Bump auf `1.0.0-beta`.
+     - Pages-Demo mit allen Widgets verlinkt.
+     *Ergebnis:* öffentliche Beta zum Ausprobieren auf jedem System — als Beta,
+     unsigniert, alle OS als Download.
 
 ## Lizenzmodell (dual / source-available)
 
@@ -383,7 +390,7 @@ hinzufügen, Lizenz-Header/`package.json`-`license`-Feld setzen, README-Abschnit
 | H | 89–95 | Integrationen | OTLP/Prometheus/Git — offener Hub |
 | I | 96–99 | Politur & Performance | a11y, Performance, Onboarding, Docs |
 | Z | 100–119 | Visuelle & funktionale Gesamtabnahme | 20 Einzel-Checks **vor** Release |
-| Ω | 120 | Release | v1.0 erst nach grüner Phase Z |
+| Ω | 120 | Beta-Release | v1.0.0-beta, **unsigniert**, alle OS als Download — nach grüner Phase Z |
 
 **Leitstern:** Nach 120 Runs — inklusive einer 20-teiligen visuellen &
 funktionalen Gesamtabnahme **vor** dem Release — ist Claude Mission Control das

--- a/src/app/api/plugins/config/route.ts
+++ b/src/app/api/plugins/config/route.ts
@@ -1,0 +1,43 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { db } from "@/lib/db";
+import { getAllPluginConfig, setPluginConfig } from "@/lib/plugin-config";
+import { log } from "@/lib/log";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+// Per-plugin settings. GET returns every plugin's config; POST upserts one. This
+// is a deliberately small, local write path (settings only) — distinct from the
+// hook ingest path, validated and size-bounded.
+export async function GET() {
+  try {
+    return NextResponse.json({ config: getAllPluginConfig(db) });
+  } catch (err) {
+    log.error("/api/plugins/config GET failed", err);
+    return NextResponse.json({ config: {} });
+  }
+}
+
+const Body = z.object({
+  pluginId: z.string().min(1).max(64),
+  config: z.record(z.string(), z.unknown()),
+});
+
+export async function POST(req: Request) {
+  try {
+    const json = await req.json();
+    const parsed = Body.safeParse(json);
+    if (!parsed.success) {
+      return NextResponse.json({ error: "invalid body" }, { status: 400 });
+    }
+    if (JSON.stringify(parsed.data.config).length > 8000) {
+      return NextResponse.json({ error: "config too large" }, { status: 413 });
+    }
+    setPluginConfig(db, parsed.data.pluginId, parsed.data.config);
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    log.error("/api/plugins/config POST failed", err);
+    return NextResponse.json({ error: "write failed" }, { status: 500 });
+  }
+}

--- a/src/components/dashboard.tsx
+++ b/src/components/dashboard.tsx
@@ -17,6 +17,7 @@ import {
   MoveVertical,
   RotateCcw,
   Search,
+  Settings,
   Trash2,
   X,
 } from "lucide-react";
@@ -30,6 +31,8 @@ import { SearchProvider, useSearch } from "@/components/search";
 import { TimeRangeProvider, useTimeRange } from "@/components/time-range";
 import { FacetProvider, useFacets } from "@/components/facets";
 import { CommandPalette } from "@/components/command-palette";
+import { PluginConfigProvider } from "@/components/plugin-config";
+import { SettingsDrawer } from "@/components/settings-drawer";
 import { useT } from "@/lib/i18n";
 import { TIME_RANGES } from "@/lib/time-range";
 import type { SearchHit } from "@/lib/search-index";
@@ -98,6 +101,7 @@ export function Dashboard() {
   const [sizes, setSizes] = useState<SizeMap>({});
   const [hidden, setHidden] = useState<string[]>([]);
   const [galleryOpen, setGalleryOpen] = useState(false);
+  const [settingsFor, setSettingsFor] = useState<string | null>(null);
   const [dragId, setDragId] = useState<string | null>(null);
 
   useEffect(() => {
@@ -220,6 +224,7 @@ export function Dashboard() {
       <SearchProvider>
         <TimeRangeProvider>
         <FacetProvider>
+        <PluginConfigProvider>
         {DEMO && <Landing />}
         <div className="mx-auto flex min-h-screen max-w-[1600px] flex-col gap-4 p-4 sm:p-6 min-[2560px]:max-w-none min-[2560px]:gap-6 min-[2560px]:p-8 min-[3840px]:gap-8 min-[3840px]:p-12">
           <Header
@@ -260,10 +265,13 @@ export function Dashboard() {
                   dragLabel={t("layout.drag")}
                   widthLabel={t("layout.width")}
                   heightLabel={t("layout.height")}
+                  settingsLabel={t("settings.title")}
+                  hasSettings={Boolean(w.settings?.length)}
                   onStart={() => setDragId(w.id)}
                   onEnd={() => setDragId(null)}
                   onWidth={() => setSize(w.id, nextPreset(SPAN_PRESETS, span), height)}
                   onHeight={() => setSize(w.id, span, nextPreset(HEIGHT_PRESETS, height))}
+                  onSettings={() => setSettingsFor(w.id)}
                 />
                 <WidgetErrorBoundary
                   label={w.title}
@@ -292,6 +300,8 @@ export function Dashboard() {
           />
         )}
         <CommandPalette onResetLayout={resetLayout} onOpenGallery={() => setGalleryOpen(true)} />
+        {settingsFor && <SettingsDrawer widgetId={settingsFor} onClose={() => setSettingsFor(null)} />}
+        </PluginConfigProvider>
         </FacetProvider>
         </TimeRangeProvider>
       </SearchProvider>
@@ -303,18 +313,24 @@ function WidgetToolbar({
   dragLabel,
   widthLabel,
   heightLabel,
+  settingsLabel,
+  hasSettings,
   onStart,
   onEnd,
   onWidth,
   onHeight,
+  onSettings,
 }: {
   dragLabel: string;
   widthLabel: string;
   heightLabel: string;
+  settingsLabel: string;
+  hasSettings: boolean;
   onStart: () => void;
   onEnd: () => void;
   onWidth: () => void;
   onHeight: () => void;
+  onSettings: () => void;
 }) {
   const btn =
     "rounded p-0.5 text-muted transition-colors hover:text-foreground focus-visible:text-foreground";
@@ -342,6 +358,11 @@ function WidgetToolbar({
       <button type="button" aria-label={heightLabel} title={heightLabel} onClick={onHeight} className={btn}>
         <MoveVertical className="h-3.5 w-3.5" />
       </button>
+      {hasSettings && (
+        <button type="button" aria-label={settingsLabel} title={settingsLabel} onClick={onSettings} className={btn}>
+          <Settings className="h-3.5 w-3.5" />
+        </button>
+      )}
     </div>
   );
 }

--- a/src/components/plugin-config.tsx
+++ b/src/components/plugin-config.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react";
+import type { PluginConfig, PluginConfigMap } from "@/lib/plugin-config";
+
+interface PluginConfigValue {
+  all: PluginConfigMap;
+  setConfig: (pluginId: string, config: PluginConfig) => void;
+}
+
+const Ctx = createContext<PluginConfigValue>({ all: {}, setConfig: () => {} });
+
+// Loads every plugin's settings once and exposes an optimistic setter that POSTs
+// to /api/plugins/config. A small local write path, settings-only.
+export function PluginConfigProvider({ children }: { children: React.ReactNode }) {
+  const [all, setAll] = useState<PluginConfigMap>({});
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch("/api/plugins/config")
+      .then((r) => r.json())
+      .then((d: { config: PluginConfigMap }) => {
+        if (!cancelled) setAll(d.config ?? {});
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const setConfig = useCallback((pluginId: string, config: PluginConfig) => {
+    setAll((prev) => ({ ...prev, [pluginId]: config }));
+    fetch("/api/plugins/config", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ pluginId, config }),
+    }).catch(() => {});
+  }, []);
+
+  const value = useMemo(() => ({ all, setConfig }), [all, setConfig]);
+  return <Ctx.Provider value={value}>{children}</Ctx.Provider>;
+}
+
+// Per-widget config accessor: current values + a single-key setter.
+export function usePluginConfig(pluginId: string): {
+  values: PluginConfig;
+  set: (key: string, value: unknown) => void;
+} {
+  const { all, setConfig } = useContext(Ctx);
+  const values = all[pluginId] ?? {};
+  const set = useCallback(
+    (key: string, value: unknown) => setConfig(pluginId, { ...(all[pluginId] ?? {}), [key]: value }),
+    [all, pluginId, setConfig],
+  );
+  return { values, set };
+}

--- a/src/components/settings-drawer.tsx
+++ b/src/components/settings-drawer.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import { useEffect } from "react";
+import { X } from "lucide-react";
+import { useT } from "@/lib/i18n";
+import { usePluginConfig } from "@/components/plugin-config";
+import { widgets, type PluginSetting } from "@/plugins/registry";
+
+export function SettingsDrawer({ widgetId, onClose }: { widgetId: string; onClose: () => void }) {
+  const { t } = useT();
+  const widget = widgets.find((w) => w.id === widgetId);
+  const { values, set } = usePluginConfig(widgetId);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  const settings = widget?.settings ?? [];
+
+  return (
+    <div className="fixed inset-0 z-[75] flex justify-end" role="dialog" aria-modal="true" aria-label={t("settings.title")}>
+      <div className="absolute inset-0 bg-black/50 backdrop-blur-sm" onClick={onClose} aria-hidden />
+      <div className="relative z-10 flex h-full w-full max-w-sm flex-col border-l border-panel-border bg-panel shadow-2xl shadow-black/50">
+        <header className="flex items-center justify-between border-b border-panel-border px-4 py-3">
+          <div className="min-w-0">
+            <p className="text-[11px] uppercase tracking-wide text-muted">{t("settings.title")}</p>
+            <h2 className="truncate text-sm font-semibold text-foreground">{widget?.title ?? widgetId}</h2>
+          </div>
+          <button type="button" onClick={onClose} aria-label={t("common.close")} title={t("common.close")} className="text-muted hover:text-foreground">
+            <X className="h-4 w-4" />
+          </button>
+        </header>
+        <div className="min-h-0 flex-1 space-y-4 overflow-auto p-4">
+          {settings.length === 0 ? (
+            <p className="text-xs text-muted">{t("settings.none")}</p>
+          ) : (
+            settings.map((s) => <SettingRow key={s.key} setting={s} value={values[s.key]} onChange={(v) => set(s.key, v)} t={t} />)
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function SettingRow({
+  setting,
+  value,
+  onChange,
+  t,
+}: {
+  setting: PluginSetting;
+  value: unknown;
+  onChange: (v: unknown) => void;
+  t: (k: string) => string;
+}) {
+  if (setting.type === "boolean") {
+    const on = typeof value === "boolean" ? value : setting.default;
+    return (
+      <label className="flex items-center justify-between gap-3 text-sm text-foreground">
+        <span>{t(setting.label)}</span>
+        <input type="checkbox" checked={on} onChange={(e) => onChange(e.target.checked)} className="h-4 w-4 accent-[var(--color-accent)]" />
+      </label>
+    );
+  }
+  if (setting.type === "number") {
+    const n = typeof value === "number" ? value : setting.default;
+    return (
+      <label className="block text-sm text-foreground">
+        <span className="mb-1 block">{t(setting.label)}</span>
+        <input
+          type="number"
+          value={n}
+          min={setting.min}
+          max={setting.max}
+          onChange={(e) => onChange(Number(e.target.value))}
+          className="w-full rounded-md border border-panel-border bg-background/40 px-2 py-1 text-xs text-foreground outline-none focus:border-accent"
+        />
+      </label>
+    );
+  }
+  const sel = typeof value === "string" ? value : setting.default;
+  return (
+    <label className="block text-sm text-foreground">
+      <span className="mb-1 block">{t(setting.label)}</span>
+      <select
+        value={sel}
+        onChange={(e) => onChange(e.target.value)}
+        className="w-full rounded-md border border-panel-border bg-background/40 px-2 py-1 text-xs text-foreground outline-none focus:border-accent"
+      >
+        {setting.options.map((o) => (
+          <option key={o.value} value={o.value}>
+            {t(o.label)}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}

--- a/src/lib/demo.ts
+++ b/src/lib/demo.ts
@@ -918,6 +918,7 @@ export function installDemoBackend() {
     if (path.endsWith("/api/calendar")) return json(demoCalendar());
     if (path.endsWith("/api/velocity")) return json(demoVelocity());
     if (path.endsWith("/api/session-duration")) return json(demoSessionDuration());
+    if (path.endsWith("/api/plugins/config")) return json({ config: {} });
     if (path.endsWith("/api/reliability")) return json(demoReliability());
     if (path.endsWith("/api/search")) {
       const u = new URL(raw, window.location.href);

--- a/src/lib/i18n.tsx
+++ b/src/lib/i18n.tsx
@@ -293,6 +293,10 @@ const DE: Record<string, string> = {
   "views.empty": "Noch keine Ansichten gespeichert.",
   "views.delete": "Ansicht löschen",
 
+  "settings.title": "Einstellungen",
+  "settings.none": "Dieses Widget hat keine Einstellungen.",
+  "stream.setLimit": "Max. Einträge",
+
   "status.active": "Aktiv",
   "status.waiting": "Wartet",
   "status.ended": "Beendet",
@@ -665,6 +669,10 @@ const EN: Record<string, string> = {
   "views.namePlaceholder": "View name…",
   "views.empty": "No saved views yet.",
   "views.delete": "Delete view",
+
+  "settings.title": "Settings",
+  "settings.none": "This widget has no settings.",
+  "stream.setLimit": "Max items",
 
   "status.active": "Active",
   "status.waiting": "Waiting",

--- a/src/lib/migrations-sql.mjs
+++ b/src/lib/migrations-sql.mjs
@@ -166,4 +166,14 @@ export const MIGRATIONS = [
   INSERT INTO search_fts (text, kind, ref_id, session_id)
     SELECT text, 'prompt', id, session_id FROM prompts WHERE text IS NOT NULL AND text <> '';
   `,
+
+  // v14 — per-plugin settings (a small JSON blob per widget id) for the settings
+  // drawer. Separate from the hook-ingest write path; only the config route writes.
+  `
+  CREATE TABLE IF NOT EXISTS plugin_config (
+    plugin_id   TEXT PRIMARY KEY,
+    config_json TEXT NOT NULL DEFAULT '{}',
+    updated_at  DATETIME DEFAULT CURRENT_TIMESTAMP
+  );
+  `,
 ];

--- a/src/lib/plugin-config.test.ts
+++ b/src/lib/plugin-config.test.ts
@@ -1,0 +1,42 @@
+import Database from "better-sqlite3";
+import { afterEach, describe, expect, it } from "vitest";
+import { migrate } from "@/lib/migrations";
+import { getAllPluginConfig, getPluginConfig, setPluginConfig } from "@/lib/plugin-config";
+
+let open: Database.Database | null = null;
+afterEach(() => {
+  open?.close();
+  open = null;
+});
+
+function fresh(): Database.Database {
+  const db = (open = new Database(":memory:"));
+  migrate(db);
+  return db;
+}
+
+describe("plugin-config", () => {
+  it("round-trips a config object", () => {
+    const db = fresh();
+    setPluginConfig(db, "live-stream", { limit: 50, dense: true });
+    expect(getPluginConfig(db, "live-stream")).toEqual({ limit: 50, dense: true });
+  });
+
+  it("upserts (replaces) on the same plugin id", () => {
+    const db = fresh();
+    setPluginConfig(db, "x", { a: 1 });
+    setPluginConfig(db, "x", { a: 2, b: 3 });
+    expect(getPluginConfig(db, "x")).toEqual({ a: 2, b: 3 });
+  });
+
+  it("returns {} for unknown ids", () => {
+    expect(getPluginConfig(fresh(), "nope")).toEqual({});
+  });
+
+  it("collects all configs as a map", () => {
+    const db = fresh();
+    setPluginConfig(db, "a", { x: 1 });
+    setPluginConfig(db, "b", { y: 2 });
+    expect(getAllPluginConfig(db)).toEqual({ a: { x: 1 }, b: { y: 2 } });
+  });
+});

--- a/src/lib/plugin-config.ts
+++ b/src/lib/plugin-config.ts
@@ -1,0 +1,41 @@
+import type Database from "better-sqlite3";
+
+// Per-plugin settings: a small JSON object keyed by widget id. Persisted in the
+// plugin_config table and read by the settings drawer + the widgets themselves.
+
+export type PluginConfig = Record<string, unknown>;
+export type PluginConfigMap = Record<string, PluginConfig>;
+
+function parse(json: string): PluginConfig {
+  try {
+    const v = JSON.parse(json);
+    return v && typeof v === "object" && !Array.isArray(v) ? (v as PluginConfig) : {};
+  } catch {
+    return {};
+  }
+}
+
+export function getAllPluginConfig(db: Database.Database): PluginConfigMap {
+  const rows = db.prepare(`SELECT plugin_id, config_json FROM plugin_config`).all() as {
+    plugin_id: string;
+    config_json: string;
+  }[];
+  const out: PluginConfigMap = {};
+  for (const r of rows) out[r.plugin_id] = parse(r.config_json);
+  return out;
+}
+
+export function getPluginConfig(db: Database.Database, pluginId: string): PluginConfig {
+  const row = db.prepare(`SELECT config_json FROM plugin_config WHERE plugin_id = ?`).get(pluginId) as
+    | { config_json: string }
+    | undefined;
+  return row ? parse(row.config_json) : {};
+}
+
+export function setPluginConfig(db: Database.Database, pluginId: string, config: PluginConfig): void {
+  db.prepare(
+    `INSERT INTO plugin_config (plugin_id, config_json, updated_at)
+     VALUES (?, ?, CURRENT_TIMESTAMP)
+     ON CONFLICT(plugin_id) DO UPDATE SET config_json = excluded.config_json, updated_at = CURRENT_TIMESTAMP`,
+  ).run(pluginId, JSON.stringify(config ?? {}));
+}

--- a/src/plugins/live-stream/widget.tsx
+++ b/src/plugins/live-stream/widget.tsx
@@ -18,6 +18,7 @@ import { Panel } from "@/components/panel";
 import { WidgetState } from "@/components/widget-state";
 import { useLive } from "@/components/live-provider";
 import { useSearch, matchesQuery } from "@/components/search";
+import { usePluginConfig } from "@/components/plugin-config";
 import { useT } from "@/lib/i18n";
 import { eventKind, KIND_COLOR, relativeTime, type EventKind } from "@/lib/format";
 
@@ -38,6 +39,7 @@ export function LiveStream() {
   const { events, connected } = useLive();
   const { query } = useSearch();
   const { t, lang } = useT();
+  const { values } = usePluginConfig("live-stream");
   const [, setNow] = useState(0);
 
   // Re-render periodically so relative timestamps stay fresh.
@@ -46,9 +48,11 @@ export function LiveStream() {
     return () => clearInterval(t);
   }, []);
 
-  const filtered = events.filter((e) =>
-    matchesQuery(query, e.summary, e.event_type, e.tool_name, e.session_id),
-  );
+  const limit = typeof values.limit === "number" ? values.limit : 100;
+
+  const filtered = events
+    .filter((e) => matchesQuery(query, e.summary, e.event_type, e.tool_name, e.session_id))
+    .slice(0, limit);
 
   return (
     <Panel

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -77,6 +77,13 @@ export type WidgetCategory =
   | "tools"
   | "quality";
 
+// Declarative per-widget settings, rendered by the settings drawer and persisted
+// via /api/plugins/config. `label` is an i18n key.
+export type PluginSetting =
+  | { key: string; type: "boolean"; label: string; default: boolean }
+  | { key: string; type: "number"; label: string; default: number; min?: number; max?: number }
+  | { key: string; type: "select"; label: string; default: string; options: { value: string; label: string }[] };
+
 export interface Widget {
   id: string;
   title: string;
@@ -89,6 +96,8 @@ export interface Widget {
   category: WidgetCategory;
   /** i18n key for a short description (reuses each widget's existing info copy). */
   description: string;
+  /** Optional declarative settings for the per-widget settings drawer. */
+  settings?: PluginSetting[];
   component: ComponentType;
 }
 
@@ -99,7 +108,7 @@ const H_TALL = "h-[420px] min-[2560px]:h-[560px] min-[3840px]:h-[760px]";
 export const widgets: Widget[] = [
   { id: "kpi-bar", title: "Übersicht", span: "lg:col-span-6", height: "h-auto", icon: LayoutDashboard, category: "overview", description: "kpi.info", component: KpiBar },
   { id: "kanban", title: "Sessions", span: "lg:col-span-4", height: H_TALL, icon: KanbanSquare, category: "sessions", description: "kanban.info", component: Kanban },
-  { id: "live-stream", title: "Live Stream", span: "lg:col-span-2", height: H_TALL, icon: Activity, category: "sessions", description: "stream.info", component: LiveStream },
+  { id: "live-stream", title: "Live Stream", span: "lg:col-span-2", height: H_TALL, icon: Activity, category: "sessions", description: "stream.info", settings: [{ key: "limit", type: "number", label: "stream.setLimit", default: 100, min: 10, max: 300 }], component: LiveStream },
   { id: "token-chart", title: "Tokens & Kosten", span: "lg:col-span-3", height: H, icon: Coins, category: "economy", description: "tokens.info", component: TokenChart },
   { id: "tool-graph", title: "Tool-Graph (3D)", span: "lg:col-span-3", height: H, icon: Boxes, category: "tools", description: "graph.info", component: ToolGraph },
   { id: "budget-gauge", title: "Budget", span: "lg:col-span-2", height: H, icon: Gauge, category: "economy", description: "budget.info", component: BudgetGauge },


### PR DESCRIPTION
## Summary
- **Plugin-Settings-Persistenz** (Run 74): a `plugin_config` table (migration **v14**), a `/api/plugins/config` route (GET all + Zod-validated, size-bounded POST), a `plugin-config` lib (+ tests), and a `PluginConfigProvider` / `usePluginConfig` hook. Widgets can declare a **settings schema** in the manifest (`boolean` / `number` / `select`); a **gear** in the widget toolbar opens a per-widget **settings drawer** that reads/writes the persisted config.
- First consumer: **live-stream** gains a persisted **"max items"** setting. Demo fetch patch + de/en i18n included. This config write path is small and settings-only — distinct from the hook ingest path.
- **Roadmap:** the final step is now an **unsigned `v1.0.0-beta`** with downloads for **all OS** (Windows `.exe`/portable, macOS `.dmg` Intel+ARM, Linux AppImage/.deb), published as a GitHub **pre-release** with per-OS install notes for unsigned builds.

## Test plan
- [x] `npm run lint` — clean
- [x] `npx vitest run` — 318 tests pass (new plugin-config round-trip cases)
- [x] `npm run build` — succeeds (`/api/plugins/config` route present)
- [x] `npm run test:e2e` — 2 pass (`<section>` count stays 27)

https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk)_