### PR TITLE
Add typed plugin data API (usePluginQuery/useLiveTick)

### DIFF
--- a/src/components/plugin-data.tsx
+++ b/src/components/plugin-data.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useLive } from "@/components/live-provider";
+
+// Typed data API for plugins. `usePluginQuery` removes the fetch + poll + tick +
+// cancellation boilerplate every widget repeats; `useLiveTick` exposes the live
+// refresh tick without pulling in the whole live provider. Read-only by design —
+// these only GET from the dashboard's own /api/* routes.
+
+export function useLiveTick(): number {
+  return useLive().tick;
+}
+
+export interface PluginQuery<T> {
+  data: T | null;
+  loading: boolean;
+  error: boolean;
+}
+
+export function usePluginQuery<T>(path: string, opts?: { pollMs?: number }): PluginQuery<T> {
+  const pollMs = opts?.pollMs ?? 15_000;
+  const tick = useLive().tick;
+  const [state, setState] = useState<PluginQuery<T>>({ data: null, loading: true, error: false });
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = () =>
+      fetch(path)
+        .then((r) => (r.ok ? (r.json() as Promise<T>) : Promise.reject(new Error("bad status"))))
+        .then((d) => {
+          if (!cancelled) setState({ data: d, loading: false, error: false });
+        })
+        .catch(() => {
+          if (!cancelled) setState((s) => ({ data: s.data, loading: false, error: true }));
+        });
+    load();
+    const id = pollMs > 0 ? setInterval(load, pollMs) : null;
+    return () => {
+      cancelled = true;
+      if (id) clearInterval(id);
+    };
+    // Re-fetch when the path changes (e.g. a filter param) or the live tick bumps.
+  }, [path, pollMs, tick]);
+
+  return state;
+}

--- a/src/plugins/mcp-servers/widget.tsx
+++ b/src/plugins/mcp-servers/widget.tsx
@@ -1,10 +1,9 @@
 "use client";
 
-import { useEffect, useState } from "react";
 import { Plug } from "lucide-react";
 import { Panel } from "@/components/panel";
 import { WidgetState } from "@/components/widget-state";
-import { useLive } from "@/components/live-provider";
+import { usePluginQuery } from "@/components/plugin-data";
 import { useSearch, matchesQuery } from "@/components/search";
 import { useT } from "@/lib/i18n";
 import { formatCompact, relativeTime } from "@/lib/format";
@@ -18,27 +17,10 @@ function errorColor(rate: number): string {
 }
 
 export function McpServers() {
-  const { tick } = useLive();
   const { query } = useSearch();
   const { t, lang } = useT();
-  const [servers, setServers] = useState<McpServerUsage[] | null>(null);
-
-  useEffect(() => {
-    let cancelled = false;
-    const load = () =>
-      fetch("/api/mcp?limit=50")
-        .then((r) => r.json())
-        .then((d: { servers: McpServerUsage[] }) => {
-          if (!cancelled) setServers(d.servers);
-        })
-        .catch(() => {});
-    load();
-    const poll = setInterval(load, 15_000);
-    return () => {
-      cancelled = true;
-      clearInterval(poll);
-    };
-  }, [tick]);
+  const { data } = usePluginQuery<{ servers: McpServerUsage[] }>("/api/mcp?limit=50");
+  const servers = data?.servers ?? null;
 
   const filtered = (servers ?? []).filter((s) => matchesQuery(query, s.server));
   const max = filtered.reduce((m, s) => Math.max(m, s.calls), 0) || 1;

--- a/src/plugins/reliability/widget.tsx
+++ b/src/plugins/reliability/widget.tsx
@@ -1,10 +1,9 @@
 "use client";
 
-import { useEffect, useState } from "react";
 import { ShieldCheck } from "lucide-react";
 import { Panel } from "@/components/panel";
 import { WidgetState } from "@/components/widget-state";
-import { useLive } from "@/components/live-provider";
+import { usePluginQuery } from "@/components/plugin-data";
 import { useSearch, matchesQuery } from "@/components/search";
 import { useT } from "@/lib/i18n";
 import { formatCompact } from "@/lib/format";
@@ -17,27 +16,10 @@ function rateColor(rate: number): { bar: string; text: string } {
 }
 
 export function Reliability() {
-  const { tick } = useLive();
   const { query } = useSearch();
   const { t } = useT();
-  const [projects, setProjects] = useState<ProjectReliability[] | null>(null);
-
-  useEffect(() => {
-    let cancelled = false;
-    const load = () =>
-      fetch("/api/reliability?limit=100")
-        .then((r) => r.json())
-        .then((d: { projects: ProjectReliability[] }) => {
-          if (!cancelled) setProjects(d.projects);
-        })
-        .catch(() => {});
-    load();
-    const poll = setInterval(load, 15_000);
-    return () => {
-      cancelled = true;
-      clearInterval(poll);
-    };
-  }, [tick]);
+  const { data } = usePluginQuery<{ projects: ProjectReliability[] }>("/api/reliability?limit=100");
+  const projects = data?.projects ?? null;
 
   const filtered = (projects ?? []).filter((p) => matchesQuery(query, p.project));
 

--- a/src/plugins/session-duration/widget.tsx
+++ b/src/plugins/session-duration/widget.tsx
@@ -1,11 +1,10 @@
 "use client";
 
-import { useEffect, useState } from "react";
 import { BarChart, Bar, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
 import { Hourglass } from "lucide-react";
 import { Panel } from "@/components/panel";
 import { WidgetState } from "@/components/widget-state";
-import { useLive } from "@/components/live-provider";
+import { usePluginQuery } from "@/components/plugin-data";
 import { useT } from "@/lib/i18n";
 import { formatDuration } from "@/lib/format";
 import type { DurationStats } from "@/lib/session-duration";
@@ -19,25 +18,7 @@ const tooltipStyle = {
 
 export function SessionDuration() {
   const { t } = useT();
-  const { tick } = useLive();
-  const [stats, setStats] = useState<DurationStats | null>(null);
-
-  useEffect(() => {
-    let cancelled = false;
-    const load = () =>
-      fetch("/api/session-duration")
-        .then((r) => r.json())
-        .then((d: DurationStats) => {
-          if (!cancelled) setStats(d);
-        })
-        .catch(() => {});
-    load();
-    const poll = setInterval(load, 30_000);
-    return () => {
-      cancelled = true;
-      clearInterval(poll);
-    };
-  }, [tick]);
+  const { data: stats } = usePluginQuery<DurationStats>("/api/session-duration", { pollMs: 30_000 });
 
   return (
     <Panel title={t("sessionDur.title")} icon={<Hourglass className="h-4 w-4 text-accent" />} info={t("sessionDur.info")}>

--- a/src/plugins/streak/widget.tsx
+++ b/src/plugins/streak/widget.tsx
@@ -1,10 +1,9 @@
 "use client";
 
-import { useEffect, useState } from "react";
 import { Flame } from "lucide-react";
 import { Panel } from "@/components/panel";
 import { WidgetState } from "@/components/widget-state";
-import { useLive } from "@/components/live-provider";
+import { usePluginQuery } from "@/components/plugin-data";
 import { useT } from "@/lib/i18n";
 import type { DayCount, StreakStats } from "@/lib/streak";
 
@@ -16,26 +15,8 @@ interface StreakData {
 }
 
 export function Streak() {
-  const { tick } = useLive();
   const { t } = useT();
-  const [data, setData] = useState<StreakData | null>(null);
-
-  useEffect(() => {
-    let cancelled = false;
-    const load = () =>
-      fetch("/api/streak?days=30")
-        .then((r) => r.json())
-        .then((d: StreakData) => {
-          if (!cancelled) setData(d);
-        })
-        .catch(() => {});
-    load();
-    const poll = setInterval(load, 15_000);
-    return () => {
-      cancelled = true;
-      clearInterval(poll);
-    };
-  }, [tick]);
+  const { data } = usePluginQuery<StreakData>("/api/streak?days=30");
 
   const empty = data && data.streak.totalSessions === 0;
 

--- a/src/plugins/token-burn/widget.tsx
+++ b/src/plugins/token-burn/widget.tsx
@@ -1,35 +1,17 @@
 "use client";
 
-import { useEffect, useState } from "react";
 import { Flame } from "lucide-react";
 import { Panel } from "@/components/panel";
 import { WidgetState } from "@/components/widget-state";
-import { useLive } from "@/components/live-provider";
+import { usePluginQuery } from "@/components/plugin-data";
 import { useT } from "@/lib/i18n";
 import { formatCompact } from "@/lib/format";
 import type { ToolTokenBurn } from "@/lib/token-burn";
 
 export function TokenBurn() {
-  const { tick } = useLive();
   const { t } = useT();
-  const [tools, setTools] = useState<ToolTokenBurn[] | null>(null);
-
-  useEffect(() => {
-    let cancelled = false;
-    const load = () =>
-      fetch("/api/token-burn?limit=8")
-        .then((r) => r.json())
-        .then((d: { tools: ToolTokenBurn[] }) => {
-          if (!cancelled) setTools(d.tools);
-        })
-        .catch(() => {});
-    load();
-    const poll = setInterval(load, 15_000);
-    return () => {
-      cancelled = true;
-      clearInterval(poll);
-    };
-  }, [tick]);
+  const { data } = usePluginQuery<{ tools: ToolTokenBurn[] }>("/api/token-burn?limit=8");
+  const tools = data?.tools ?? null;
 
   const empty = tools && (tools.length === 0 || tools.every((t) => t.tokens === 0));
   const max = (tools ?? []).reduce((m, t) => Math.max(m, t.tokens), 0) || 1;


### PR DESCRIPTION
## Summary
- **Typed Plugin-Data-API** (Run 75): new read-only data hooks — `usePluginQuery<T>(path, { pollMs })` and `useLiveTick()` — that remove the fetch + poll + live-tick + cancellation boilerplate every widget repeats. `usePluginQuery` returns `{ data, loading, error }`, re-fetches when the path (e.g. a filter param) or the live tick changes, and polls on an interval.
- Refactors five widgets onto it as proof of the seam — **streak, reliability, token-burn, session-duration, mcp-servers** — with unchanged behaviour (net −45 lines). Remaining widgets can adopt it incrementally.

This gives third-party plugins a one-liner data layer instead of hand-rolled effects.

## Test plan
- [x] `npm run lint` — clean (removed now-unused effect/state imports)
- [x] `npx vitest run` — 318 tests pass
- [x] `npm run build` — succeeds
- [x] `npm run test:e2e` — 2 pass (`<section>` count stays 27)

https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk)_