### PR TITLE
Add theme/design system (light/dark/custom accent)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -9,6 +9,16 @@
   --accent: #4f8cff;
 }
 
+/* Light token set — swapped in via data-theme on <html>. Charts/tooltips that
+   hard-code dark hues stay dark by design; the panel chrome adapts. */
+[data-theme="light"] {
+  --background: #f5f7fa;
+  --panel: #ffffff;
+  --panel-border: #e2e6ee;
+  --foreground: #1a2230;
+  --muted: #586074;
+}
+
 @theme inline {
   --color-background: var(--background);
   --color-panel: var(--panel);

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import { ThemeProvider } from "@/components/theme";
 
 const geistSans = Geist({ variable: "--font-geist-sans", subsets: ["latin"] });
 const geistMono = Geist_Mono({ variable: "--font-geist-mono", subsets: ["latin"] });
@@ -13,7 +14,9 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: Readonly<{ children: React.ReactNode }>) {
   return (
     <html lang="de" className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}>
-      <body className="min-h-full">{children}</body>
+      <body className="min-h-full">
+        <ThemeProvider>{children}</ThemeProvider>
+      </body>
     </html>
   );
 }

--- a/src/components/dashboard.tsx
+++ b/src/components/dashboard.tsx
@@ -13,11 +13,13 @@ import {
   LayoutGrid,
   Link2,
   MessageSquare,
+  Moon,
   MoveHorizontal,
   MoveVertical,
   RotateCcw,
   Search,
   Settings,
+  Sun,
   Trash2,
   X,
 } from "lucide-react";
@@ -33,6 +35,8 @@ import { FacetProvider, useFacets } from "@/components/facets";
 import { CommandPalette } from "@/components/command-palette";
 import { PluginConfigProvider } from "@/components/plugin-config";
 import { SettingsDrawer } from "@/components/settings-drawer";
+import { useTheme } from "@/components/theme";
+import { ACCENT_PRESETS } from "@/lib/theme";
 import { useT } from "@/lib/i18n";
 import { TIME_RANGES } from "@/lib/time-range";
 import type { SearchHit } from "@/lib/search-index";
@@ -513,6 +517,7 @@ function Header({
             <RotateCcw className="h-3.5 w-3.5" />
           </button>
         )}
+        <ThemePicker />
         <LangToggle />
         <span className="hidden font-mono tabular-nums sm:inline">{clock}</span>
         <span className="hidden items-center gap-1 rounded-full border border-panel-border bg-background/40 px-2.5 py-1 tabular-nums sm:flex">
@@ -734,6 +739,64 @@ function CopyLinkButton() {
     >
       {copied ? <Check className="h-3.5 w-3.5 text-emerald-400" /> : <Link2 className="h-3.5 w-3.5" />}
     </button>
+  );
+}
+
+function ThemePicker() {
+  const { t } = useT();
+  const { mode, accent, setMode, setAccent } = useTheme();
+  const [open, setOpen] = useState(false);
+  const tab = (active: boolean) =>
+    `flex-1 rounded-md px-2 py-1 text-xs transition-colors ${active ? "bg-accent/20 text-accent" : "text-muted hover:text-foreground"}`;
+  return (
+    <div className="relative hidden sm:block">
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        aria-label={t("theme.title")}
+        title={t("theme.title")}
+        className="flex items-center rounded-full border border-panel-border bg-background/40 p-1.5 text-muted transition-colors hover:border-accent/50 hover:text-foreground"
+      >
+        {mode === "dark" ? <Moon className="h-3.5 w-3.5" /> : <Sun className="h-3.5 w-3.5" />}
+      </button>
+      {open && (
+        <div className="absolute right-0 top-9 z-50 w-56 space-y-3 rounded-lg border border-panel-border bg-panel p-3 shadow-2xl shadow-black/50">
+          <div className="flex gap-1.5">
+            <button type="button" onClick={() => setMode("dark")} className={tab(mode === "dark")}>
+              <Moon className="mx-auto h-3.5 w-3.5" />
+              {t("theme.dark")}
+            </button>
+            <button type="button" onClick={() => setMode("light")} className={tab(mode === "light")}>
+              <Sun className="mx-auto h-3.5 w-3.5" />
+              {t("theme.light")}
+            </button>
+          </div>
+          <div>
+            <p className="mb-1.5 text-[10px] uppercase tracking-wide text-muted">{t("theme.accent")}</p>
+            <div className="flex flex-wrap items-center gap-1.5">
+              {ACCENT_PRESETS.map((c) => (
+                <button
+                  key={c}
+                  type="button"
+                  onClick={() => setAccent(c)}
+                  aria-label={c}
+                  style={{ background: c }}
+                  className={`h-6 w-6 rounded-full ring-2 ring-offset-2 ring-offset-panel transition ${accent === c ? "ring-foreground" : "ring-transparent"}`}
+                />
+              ))}
+              <input
+                type="color"
+                value={accent}
+                onChange={(e) => setAccent(e.target.value)}
+                aria-label={t("theme.custom")}
+                title={t("theme.custom")}
+                className="h-6 w-6 cursor-pointer rounded-full border border-panel-border bg-transparent"
+              />
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
   );
 }
 

--- a/src/components/theme.tsx
+++ b/src/components/theme.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react";
+import { DEFAULT_ACCENT, DEFAULT_THEME, sanitizeTheme, type Theme, type ThemeMode } from "@/lib/theme";
+
+const KEY = "mc-theme";
+
+interface ThemeValue extends Theme {
+  setMode: (mode: ThemeMode) => void;
+  setAccent: (accent: string) => void;
+}
+
+const ThemeContext = createContext<ThemeValue>({
+  ...DEFAULT_THEME,
+  setMode: () => {},
+  setAccent: () => {},
+});
+
+function applyTheme(t: Theme) {
+  const el = document.documentElement;
+  el.setAttribute("data-theme", t.mode);
+  if (t.accent && t.accent !== DEFAULT_ACCENT) el.style.setProperty("--accent", t.accent);
+  else el.style.removeProperty("--accent");
+}
+
+// Applies the saved theme to <html> after hydration and persists changes. Default
+// (dark + default accent) matches the CSS :root, so the first paint is correct.
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [theme, setTheme] = useState<Theme>(DEFAULT_THEME);
+
+  useEffect(() => {
+    const id = requestAnimationFrame(() => {
+      let t = DEFAULT_THEME;
+      try {
+        const raw = localStorage.getItem(KEY);
+        if (raw) t = sanitizeTheme(JSON.parse(raw));
+      } catch {
+        /* ignore */
+      }
+      setTheme(t);
+      applyTheme(t);
+    });
+    return () => cancelAnimationFrame(id);
+  }, []);
+
+  const update = useCallback((next: Theme) => {
+    setTheme(next);
+    applyTheme(next);
+    try {
+      localStorage.setItem(KEY, JSON.stringify(next));
+    } catch {
+      /* ignore */
+    }
+  }, []);
+
+  const value = useMemo<ThemeValue>(
+    () => ({
+      ...theme,
+      setMode: (mode) => update({ ...theme, mode }),
+      setAccent: (accent) => update({ ...theme, accent }),
+    }),
+    [theme, update],
+  );
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+}
+
+export function useTheme(): ThemeValue {
+  return useContext(ThemeContext);
+}

--- a/src/lib/i18n.tsx
+++ b/src/lib/i18n.tsx
@@ -267,6 +267,12 @@ const DE: Record<string, string> = {
   "range.90d": "90 Tage",
   "range.all": "Gesamt",
 
+  "theme.title": "Design",
+  "theme.dark": "Dunkel",
+  "theme.light": "Hell",
+  "theme.accent": "Akzentfarbe",
+  "theme.custom": "Eigene Farbe",
+
   "facets.project": "Projekt-Filter",
   "facets.allProjects": "Alle Projekte",
   "facets.status": "Status-Filter",
@@ -643,6 +649,12 @@ const EN: Record<string, string> = {
   "range.30d": "30 days",
   "range.90d": "90 days",
   "range.all": "All time",
+
+  "theme.title": "Theme",
+  "theme.dark": "Dark",
+  "theme.light": "Light",
+  "theme.accent": "Accent color",
+  "theme.custom": "Custom color",
 
   "facets.project": "Project filter",
   "facets.allProjects": "All projects",

--- a/src/lib/theme.test.ts
+++ b/src/lib/theme.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { DEFAULT_THEME, isHexColor, sanitizeTheme } from "@/lib/theme";
+
+describe("isHexColor", () => {
+  it("accepts 6-digit hex and rejects others", () => {
+    expect(isHexColor("#4f8cff")).toBe(true);
+    expect(isHexColor("#FFF")).toBe(false);
+    expect(isHexColor("blue")).toBe(false);
+    expect(isHexColor(123)).toBe(false);
+  });
+});
+
+describe("sanitizeTheme", () => {
+  it("keeps a valid theme", () => {
+    expect(sanitizeTheme({ mode: "light", accent: "#22d3ee" })).toEqual({ mode: "light", accent: "#22d3ee" });
+  });
+
+  it("falls back to defaults for bad fields", () => {
+    expect(sanitizeTheme({ mode: "weird", accent: "nope" })).toEqual(DEFAULT_THEME);
+    expect(sanitizeTheme(null)).toEqual(DEFAULT_THEME);
+    expect(sanitizeTheme("x")).toEqual(DEFAULT_THEME);
+  });
+
+  it("defaults mode to dark and accent to the default", () => {
+    expect(sanitizeTheme({})).toEqual(DEFAULT_THEME);
+  });
+});

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -1,0 +1,28 @@
+// Token-based theming. Mode swaps the CSS-variable token set (dark/light);
+// a custom accent overrides --accent inline. Pure (de)serialisation here so the
+// validation is unit-testable; the provider applies it to <html>.
+
+export type ThemeMode = "dark" | "light";
+
+export interface Theme {
+  mode: ThemeMode;
+  accent: string; // #rrggbb
+}
+
+export const DEFAULT_ACCENT = "#4f8cff";
+export const DEFAULT_THEME: Theme = { mode: "dark", accent: DEFAULT_ACCENT };
+
+export const ACCENT_PRESETS = ["#4f8cff", "#22d3ee", "#34d399", "#a78bfa", "#f472b6", "#f59e0b"];
+
+export function isHexColor(value: unknown): value is string {
+  return typeof value === "string" && /^#[0-9a-fA-F]{6}$/.test(value);
+}
+
+export function sanitizeTheme(raw: unknown): Theme {
+  if (!raw || typeof raw !== "object") return DEFAULT_THEME;
+  const o = raw as Record<string, unknown>;
+  return {
+    mode: o.mode === "light" ? "light" : "dark",
+    accent: isHexColor(o.accent) ? o.accent : DEFAULT_ACCENT,
+  };
+}


### PR DESCRIPTION
## Summary
- **Theme-/Design-System** (Run 77): token-based theming via CSS variables. A **light** token set is swapped in through `data-theme` on `<html>`, a **custom accent** overrides `--accent` inline, and a header **theme picker** offers Dark/Light plus accent presets and a custom color input. The choice persists to `localStorage` and is applied app-wide (dashboard **and** session page) by a `ThemeProvider` in the root layout.
- Adds a pure `theme` lib (`sanitizeTheme`, `isHexColor`, presets) with unit tests and de/en i18n. Default (dark + default accent) matches the CSS `:root`, so first paint is correct with no hydration mismatch.

Note: chart internals (tooltips/strokes) keep fixed dark hues by design; the panel chrome adapts to light. Full light-mode polish is part of the Phase Z visual audit.

## Test plan
- [x] `npm run lint` — clean
- [x] `npx vitest run` — 322 tests pass (new theme cases)
- [x] `npm run build` — succeeds
- [x] `npm run test:e2e` — 2 pass (`<section>` count stays 27)

https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk)_