### PR TITLE
Add reference third-party plugin

### DIFF
--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -43,8 +43,8 @@ test("dashboard renders all four widgets and connects", async ({ page }) => {
 
   await expect(page.getByRole("heading", { name: "Claude Mission Control" })).toBeVisible();
 
-  // Twenty-seven widget panels (+ incidents).
-  await expect(page.locator("section")).toHaveCount(27);
+  // Twenty-eight widget panels (27 core + the reference plugin from plugins.local/).
+  await expect(page.locator("section")).toHaveCount(28);
   // Two titles are identical in both locales — safe to assert regardless of language.
   await expect(page.getByText("Sessions", { exact: true })).toBeVisible();
   await expect(page.getByText("Live Stream", { exact: true })).toBeVisible();

--- a/plugins.local/README.md
+++ b/plugins.local/README.md
@@ -12,6 +12,13 @@ widget registry.
    merges into `widgets`. The dashboard renders, the gallery groups, and the
    command palette finds your widget automatically — nothing else to wire.
 
+## Reference example
+
+A complete, working example ships in [`reference/plugin.tsx`](./reference/plugin.tsx).
+It renders in the dashboard out of the box and shows the manifest, the read-only
+`usePluginQuery` data API, and the shared `Panel` chrome. Copy that folder as a
+starting point.
+
 ## Authoring a widget
 
 Create `plugins.local/<your-widget>/plugin.tsx`:

--- a/plugins.local/reference/plugin.tsx
+++ b/plugins.local/reference/plugin.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+// Reference third-party plugin. Lives entirely outside src/ in plugins.local/ and
+// is merged into the dashboard by the build-time scan (scripts/scan-plugins.mjs) —
+// no core files touched. Copy this folder as a starting point for your own widget.
+//
+// It demonstrates the seam: the manifest (`export const plugin: Widget`), the
+// typed read-only data API (usePluginQuery), and the shared Panel chrome. Strings
+// are literal here so a plugin needs no access to the core i18n catalogue.
+
+import { Sparkles } from "lucide-react";
+import { Panel } from "@/components/panel";
+import { WidgetState } from "@/components/widget-state";
+import { usePluginQuery } from "@/components/plugin-data";
+import { formatCompact } from "@/lib/format";
+import type { Widget } from "@/plugins/registry";
+
+interface Stats {
+  eventsToday: number;
+  toolCallsToday: number;
+}
+
+function ReferencePlugin() {
+  const { data } = usePluginQuery<Stats>("/api/stats", { pollMs: 15_000 });
+  return (
+    <Panel
+      title="Reference Plugin"
+      icon={<Sparkles className="h-4 w-4 text-accent" />}
+      info="Example third-party widget loaded from plugins.local/ — read-only, via usePluginQuery."
+    >
+      {!data ? (
+        <WidgetState icon={Sparkles} title="Loading…" loading />
+      ) : (
+        <div className="flex h-full flex-col items-center justify-center gap-2 p-4 text-center">
+          <Sparkles className="h-7 w-7 text-accent" />
+          <p className="text-sm text-foreground">Hello from a third-party plugin</p>
+          <p className="text-xs text-muted">
+            {formatCompact(data.eventsToday)} events · {formatCompact(data.toolCallsToday)} tool calls today
+          </p>
+          <p className="max-w-xs text-[11px] text-muted">
+            Defined in <code className="text-accent">plugins.local/reference/plugin.tsx</code>.
+          </p>
+        </div>
+      )}
+    </Panel>
+  );
+}
+
+export const plugin: Widget = {
+  id: "reference-plugin",
+  title: "Reference Plugin",
+  span: "lg:col-span-3",
+  height: "h-[360px] min-[2560px]:h-[480px] min-[3840px]:h-[660px]",
+  icon: Sparkles,
+  category: "tools",
+  description: "Example third-party widget — see plugins.local/README.md.",
+  component: ReferencePlugin,
+};

--- a/src/plugins/external.generated.ts
+++ b/src/plugins/external.generated.ts
@@ -2,4 +2,6 @@
 // Refresh with `npm run plugins:scan` (also runs automatically before build).
 import type { Widget } from "./registry";
 
-export const externalWidgets: Widget[] = [];
+import { plugin as ext_reference } from "../../plugins.local/reference/plugin";
+
+export const externalWidgets: Widget[] = [ext_reference];


### PR DESCRIPTION
## Summary
- **Referenz-Plugin** (Run 78): a complete, working example third-party widget at `plugins.local/reference/plugin.tsx` that the build scan (Run 76) merges into the dashboard — proving the external-plugin seam **end to end**, with no core files touched. It exercises the manifest (`export const plugin: Widget`), the read-only `usePluginQuery` data API (reads `/api/stats`), and the shared `Panel` chrome. Strings are literal so a plugin needs no access to the core i18n catalogue.
- `plugins.local/README.md` now points to the example; the generated `external.generated.ts` includes it; E2E widget count bumped 27 → 28.

## Test plan
- [x] `npm run lint` — clean
- [x] `npx vitest run` — 322 tests pass (registry uniqueness/metadata covers the merged plugin)
- [x] `npm run build` — succeeds (prebuild scan: "1 external plugin(s)")
- [x] `npm run test:e2e` — 2 pass, the reference plugin renders → `<section>` count now 28

https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk)_