### PR TITLE
Add plugin isolation telemetry + disable-broken-plugin path

### DIFF
--- a/src/components/dashboard.tsx
+++ b/src/components/dashboard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { Profiler, useCallback, useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import {
   Activity,
@@ -106,7 +106,15 @@ export function Dashboard() {
   const [hidden, setHidden] = useState<string[]>([]);
   const [galleryOpen, setGalleryOpen] = useState(false);
   const [settingsFor, setSettingsFor] = useState<string | null>(null);
+  const [timings, setTimings] = useState<Record<string, number>>({});
   const [dragId, setDragId] = useState<string | null>(null);
+
+  // Per-plugin render telemetry via React's Profiler. Record only the first
+  // (mount) duration per widget so onRender never loops.
+  const onWidgetRender = useCallback((id: string, phase: string, actualDuration: number) => {
+    if (phase !== "mount") return;
+    setTimings((prev) => (prev[id] !== undefined ? prev : { ...prev, [id]: actualDuration }));
+  }, []);
 
   useEffect(() => {
     // Defer to a frame so the saved layout is adopted after hydration (avoids a
@@ -282,8 +290,12 @@ export function Dashboard() {
                   couldNotLoad={t("error.couldNotLoad")}
                   genericText={t("error.generic")}
                   retryLabel={t("common.retry")}
+                  disableLabel={t("error.disable")}
+                  onDisable={() => toggleHidden(w.id)}
                 >
-                  <w.component />
+                  <Profiler id={w.id} onRender={onWidgetRender}>
+                    <w.component />
+                  </Profiler>
                 </WidgetErrorBoundary>
               </div>
               );
@@ -298,6 +310,7 @@ export function Dashboard() {
             order={order}
             byId={byId}
             hidden={hidden}
+            timings={timings}
             onToggle={toggleHidden}
             onShowAll={() => persistHidden([])}
             onClose={() => setGalleryOpen(false)}
@@ -824,6 +837,7 @@ function WidgetGallery({
   order,
   byId,
   hidden,
+  timings,
   onToggle,
   onShowAll,
   onClose,
@@ -831,6 +845,7 @@ function WidgetGallery({
   order: string[];
   byId: Map<string, (typeof widgets)[number]>;
   hidden: string[];
+  timings: Record<string, number>;
   onToggle: (id: string) => void;
   onShowAll: () => void;
   onClose: () => void;
@@ -900,6 +915,14 @@ function WidgetGallery({
                             </span>
                             <span className="mt-0.5 line-clamp-2 block text-[11px] text-muted">{t(w.description)}</span>
                           </span>
+                          {timings[w.id] !== undefined && (
+                            <span
+                              className="shrink-0 font-mono text-[10px] tabular-nums text-muted/70"
+                              title={t("telemetry.renderTime")}
+                            >
+                              {Math.round(timings[w.id])}ms
+                            </span>
+                          )}
                         </button>
                       </li>
                     );

--- a/src/components/error-boundary.tsx
+++ b/src/components/error-boundary.tsx
@@ -11,6 +11,9 @@ interface Props {
   couldNotLoad?: string;
   genericText?: string;
   retryLabel?: string;
+  /** "Disable this widget" — hides a repeatedly-crashing plugin from the grid. */
+  disableLabel?: string;
+  onDisable?: () => void;
 }
 interface State {
   error: Error | null;
@@ -43,12 +46,22 @@ export class WidgetErrorBoundary extends Component<Props, State> {
               : (this.props.genericText ?? "Widget-Fehler.")}
           </p>
           <p className="max-w-[90%] break-words text-[11px] text-muted/70">{this.state.error.message}</p>
-          <button
-            onClick={this.reset}
-            className="mt-1 rounded-md border border-panel-border px-3 py-1 text-xs text-foreground transition-colors hover:border-accent/50"
-          >
-            {this.props.retryLabel ?? "Erneut versuchen"}
-          </button>
+          <div className="mt-1 flex items-center gap-2">
+            <button
+              onClick={this.reset}
+              className="rounded-md border border-panel-border px-3 py-1 text-xs text-foreground transition-colors hover:border-accent/50"
+            >
+              {this.props.retryLabel ?? "Erneut versuchen"}
+            </button>
+            {this.props.onDisable && (
+              <button
+                onClick={this.props.onDisable}
+                className="rounded-md border border-panel-border px-3 py-1 text-xs text-muted transition-colors hover:border-red-400/50 hover:text-red-400"
+              >
+                {this.props.disableLabel ?? "Deaktivieren"}
+              </button>
+            )}
+          </div>
         </div>
       );
     }

--- a/src/lib/i18n.tsx
+++ b/src/lib/i18n.tsx
@@ -416,6 +416,8 @@ const DE: Record<string, string> = {
 
   "error.couldNotLoad": "konnte nicht geladen werden.",
   "error.generic": "Widget-Fehler.",
+  "error.disable": "Deaktivieren",
+  "telemetry.renderTime": "Render-Zeit beim Laden",
 };
 
 const EN: Record<string, string> = {
@@ -799,6 +801,8 @@ const EN: Record<string, string> = {
 
   "error.couldNotLoad": "couldn’t load.",
   "error.generic": "Widget error.",
+  "error.disable": "Disable",
+  "telemetry.renderTime": "Render time on load",
 };
 
 const T: Record<Lang, Record<string, string>> = { de: DE, en: EN };


### PR DESCRIPTION
## Summary
- **Plugin-Isolierung & Telemetrie** (Run 79): each widget is wrapped in a React `Profiler` that records its **mount render time**; the **widget gallery** now shows the per-widget render time (e.g. `12ms`). Telemetry records only the first (mount) duration so the profiler callback never loops.
- The existing per-widget error boundary gains a **"Disable"** action: a repeatedly-crashing plugin can be hidden from the grid in one click (reuses the hidden-widgets persistence). Retry stays alongside it.
- Adds de/en i18n (`error.disable`, `telemetry.renderTime`).

Together with the existing error boundary (isolation) and the gallery/hidden mechanism, this gives a real "a bad plugin can't break the dashboard, and you can see + disable it" story.

## Test plan
- [x] `npm run lint` — clean
- [x] `npx vitest run` — 322 tests pass
- [x] `npm run build` — succeeds
- [x] `npm run test:e2e` — 2 pass (`<section>` count stays 28)

https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk)_