### PR TITLE
Add read-only alerting rule engine

### DIFF
--- a/src/app/api/alerts/route.ts
+++ b/src/app/api/alerts/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from "next/server";
+import { db } from "@/lib/db";
+import { recentAlerts, unreadAlertCount } from "@/lib/alerts";
+import { log } from "@/lib/log";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+// Recent alerts raised by the rule engine (newest first) + unread count.
+export async function GET(req: Request) {
+  const url = new URL(req.url);
+  const limit = Math.min(Math.max(Math.trunc(Number(url.searchParams.get("limit")) || 50), 1), 200);
+  try {
+    return NextResponse.json({ alerts: recentAlerts(db, limit), unread: unreadAlertCount(db) });
+  } catch (err) {
+    log.error("/api/alerts failed", err);
+    return NextResponse.json({ alerts: [], unread: 0 });
+  }
+}

--- a/src/lib/alerts.test.ts
+++ b/src/lib/alerts.test.ts
@@ -1,0 +1,62 @@
+import Database from "better-sqlite3";
+import { afterEach, describe, expect, it } from "vitest";
+import { migrate } from "@/lib/migrations";
+import { evaluateRules, processAlerts, recentAlerts, type Rule, type RuleCtx } from "@/lib/alerts";
+
+const rule = (over: Partial<Rule> = {}): Rule => ({ id: 1, type: "mcp_error", threshold: 0, enabled: 1, label: null, ...over });
+
+const ctx = (over: Partial<RuleCtx> = {}): RuleCtx => ({
+  eventType: "PostToolUse",
+  toolName: "mcp__github__x",
+  toolSource: "mcp",
+  toolSuccess: 1,
+  sessionId: "s1",
+  sessionCostUsd: 0,
+  sessionDurationMin: 0,
+  recentErrorRate: 0,
+  hourBucket: "2026-05-24 10",
+  ...over,
+});
+
+describe("evaluateRules", () => {
+  it("fires mcp_error only on a failed MCP PostToolUse", () => {
+    const rules = [rule({ type: "mcp_error" })];
+    expect(evaluateRules(ctx({ toolSuccess: 0 }), rules)).toHaveLength(1);
+    expect(evaluateRules(ctx({ toolSuccess: 1 }), rules)).toHaveLength(0);
+    expect(evaluateRules(ctx({ toolSuccess: 0, toolSource: "builtin" }), rules)).toHaveLength(0);
+  });
+
+  it("fires error_spike at/above the threshold", () => {
+    const rules = [rule({ type: "error_spike", threshold: 0.25 })];
+    expect(evaluateRules(ctx({ recentErrorRate: 0.3 }), rules)).toHaveLength(1);
+    expect(evaluateRules(ctx({ recentErrorRate: 0.1 }), rules)).toHaveLength(0);
+  });
+
+  it("fires session_long and cost_session by threshold", () => {
+    expect(evaluateRules(ctx({ sessionDurationMin: 130 }), [rule({ type: "session_long", threshold: 120 })])).toHaveLength(1);
+    expect(evaluateRules(ctx({ sessionCostUsd: 6 }), [rule({ type: "cost_session", threshold: 5 })])).toHaveLength(1);
+    expect(evaluateRules(ctx({ sessionCostUsd: 2 }), [rule({ type: "cost_session", threshold: 5 })])).toHaveLength(0);
+  });
+
+  it("skips disabled rules", () => {
+    expect(evaluateRules(ctx({ toolSuccess: 0 }), [rule({ enabled: 0 })])).toHaveLength(0);
+  });
+});
+
+describe("processAlerts (dedup)", () => {
+  let open: Database.Database | null = null;
+  afterEach(() => {
+    open?.close();
+    open = null;
+  });
+
+  it("records an alert once per dedup key", () => {
+    const db = (open = new Database(":memory:"));
+    migrate(db); // seeds default rules incl. cost_session @ 5
+    const c = ctx({ eventType: "Stop", sessionCostUsd: 9 });
+    expect(processAlerts(db, c)).toBeGreaterThan(0);
+    expect(processAlerts(db, c)).toBe(0); // same session → deduped
+    const alerts = recentAlerts(db, 10);
+    expect(alerts.some((a) => a.type === "cost_session")).toBe(true);
+  });
+});

--- a/src/lib/alerts.ts
+++ b/src/lib/alerts.ts
@@ -1,0 +1,148 @@
+import type Database from "better-sqlite3";
+
+// Read-only alerting rule engine. Rules live in the DB and are evaluated at ingest
+// against a small per-event context. Pure evaluateRules so the conditions are
+// unit-testable; the DB helpers add caching + dedup (one alert per rule + key).
+// This NEVER writes back to Claude — it only records alerts for the dashboard.
+
+export type RuleType = "mcp_error" | "error_spike" | "session_long" | "cost_session";
+
+export interface Rule {
+  id: number;
+  type: string;
+  threshold: number;
+  enabled: number;
+  label: string | null;
+}
+
+export interface RuleCtx {
+  eventType: string;
+  toolName: string | null;
+  toolSource: string | null; // "mcp" | "builtin" | null
+  toolSuccess: number | null; // 0 | 1 | null
+  sessionId: string;
+  sessionCostUsd: number;
+  sessionDurationMin: number;
+  recentErrorRate: number; // 0..1 over recent tool calls
+  hourBucket: string; // for spike dedup
+}
+
+export interface AlertFire {
+  ruleId: number;
+  type: string;
+  message: string;
+  sessionId: string;
+  dedupKey: string; // (ruleId, dedupKey) is unique → no flapping/spam
+}
+
+export function evaluateRules(ctx: RuleCtx, rules: Rule[]): AlertFire[] {
+  const fires: AlertFire[] = [];
+  const isPost = ctx.eventType === "PostToolUse";
+  for (const r of rules) {
+    if (!r.enabled) continue;
+    switch (r.type) {
+      case "mcp_error":
+        if (isPost && ctx.toolSource === "mcp" && ctx.toolSuccess === 0) {
+          fires.push({
+            ruleId: r.id,
+            type: r.type,
+            sessionId: ctx.sessionId,
+            dedupKey: `${ctx.sessionId}:${ctx.toolName}:${ctx.hourBucket}`,
+            message: `MCP tool failed: ${ctx.toolName ?? "?"}`,
+          });
+        }
+        break;
+      case "error_spike":
+        if (isPost && ctx.recentErrorRate >= r.threshold && r.threshold > 0) {
+          fires.push({
+            ruleId: r.id,
+            type: r.type,
+            sessionId: ctx.sessionId,
+            dedupKey: ctx.hourBucket,
+            message: `Error rate ${Math.round(ctx.recentErrorRate * 100)}% (≥ ${Math.round(r.threshold * 100)}%)`,
+          });
+        }
+        break;
+      case "session_long":
+        if (ctx.sessionDurationMin >= r.threshold && r.threshold > 0) {
+          fires.push({
+            ruleId: r.id,
+            type: r.type,
+            sessionId: ctx.sessionId,
+            dedupKey: ctx.sessionId,
+            message: `Session running ${Math.round(ctx.sessionDurationMin)} min (≥ ${r.threshold})`,
+          });
+        }
+        break;
+      case "cost_session":
+        if (ctx.sessionCostUsd >= r.threshold && r.threshold > 0) {
+          fires.push({
+            ruleId: r.id,
+            type: r.type,
+            sessionId: ctx.sessionId,
+            dedupKey: ctx.sessionId,
+            message: `Session cost $${ctx.sessionCostUsd.toFixed(2)} (≥ $${r.threshold})`,
+          });
+        }
+        break;
+    }
+  }
+  return fires;
+}
+
+export interface AlertItem {
+  id: number;
+  rule_id: number | null;
+  type: string;
+  message: string;
+  session_id: string | null;
+  read: number;
+  created_at: string;
+}
+
+// Enabled rules, cached briefly so the hot ingest path doesn't re-query per event.
+let rulesCache: Rule[] | null = null;
+let rulesCacheAt = 0;
+
+export function getEnabledRules(db: Database.Database): Rule[] {
+  const now = Date.now();
+  if (rulesCache && now - rulesCacheAt < 60_000) return rulesCache;
+  rulesCache = db
+    .prepare(`SELECT id, type, threshold, enabled, label FROM alert_rules WHERE enabled = 1`)
+    .all() as Rule[];
+  rulesCacheAt = now;
+  return rulesCache;
+}
+
+// Insert an alert, ignoring duplicates (same rule + dedup key). Returns true when
+// a new alert was actually recorded.
+export function recordAlert(db: Database.Database, fire: AlertFire): boolean {
+  const info = db
+    .prepare(
+      `INSERT OR IGNORE INTO alerts (rule_id, type, message, session_id, dedup_key)
+       VALUES (?, ?, ?, ?, ?)`,
+    )
+    .run(fire.ruleId, fire.type, fire.message, fire.sessionId, fire.dedupKey);
+  return info.changes > 0;
+}
+
+export function processAlerts(db: Database.Database, ctx: RuleCtx): number {
+  let recorded = 0;
+  for (const fire of evaluateRules(ctx, getEnabledRules(db))) {
+    if (recordAlert(db, fire)) recorded += 1;
+  }
+  return recorded;
+}
+
+export function recentAlerts(db: Database.Database, limit: number): AlertItem[] {
+  return db
+    .prepare(
+      `SELECT id, rule_id, type, message, session_id, read, created_at
+       FROM alerts ORDER BY id DESC LIMIT ?`,
+    )
+    .all(limit) as AlertItem[];
+}
+
+export function unreadAlertCount(db: Database.Database): number {
+  return (db.prepare(`SELECT COUNT(*) AS n FROM alerts WHERE read = 0`).get() as { n: number }).n;
+}

--- a/src/lib/demo.ts
+++ b/src/lib/demo.ts
@@ -13,6 +13,7 @@ import { streakStats, peakHour, type DayCount } from "./streak";
 import { topTerms } from "./tags";
 import type { ToolTokenBurn } from "./token-burn";
 import type { ToolCallDetail } from "./errors";
+import type { AlertItem } from "./alerts";
 import type { ProjectReliability } from "./reliability";
 import type { SearchHit } from "./search-index";
 import type { SessionDetail } from "./session-detail";
@@ -871,6 +872,17 @@ export function demoSearch(q: string): { hits: SearchHit[] } {
   return { hits: hits.slice(0, 20) };
 }
 
+export function demoAlerts() {
+  const now = Date.now();
+  const at = (ms: number) => new Date(now - ms).toISOString().slice(0, 19).replace("T", " ");
+  const alerts: AlertItem[] = [
+    { id: 3, rule_id: 2, type: "error_spike", message: "Error rate 33% (≥ 25%)", session_id: "demo-incident", read: 0, created_at: at(120_000) },
+    { id: 2, rule_id: 1, type: "mcp_error", message: "MCP tool failed: mcp__github__create_pr", session_id: "demo-incident", read: 0, created_at: at(3_600_000) },
+    { id: 1, rule_id: 4, type: "cost_session", message: "Session cost $6.20 (≥ $5)", session_id: "demo-bot", read: 1, created_at: at(7_200_000) },
+  ];
+  return { alerts, unread: alerts.filter((a) => !a.read).length };
+}
+
 export function demoSubscribe(fn: (m: StreamMessage) => void) {
   listeners.add(fn);
   return () => listeners.delete(fn);
@@ -919,6 +931,7 @@ export function installDemoBackend() {
     if (path.endsWith("/api/velocity")) return json(demoVelocity());
     if (path.endsWith("/api/session-duration")) return json(demoSessionDuration());
     if (path.endsWith("/api/plugins/config")) return json({ config: {} });
+    if (path.endsWith("/api/alerts")) return json(demoAlerts());
     if (path.endsWith("/api/reliability")) return json(demoReliability());
     if (path.endsWith("/api/search")) {
       const u = new URL(raw, window.location.href);

--- a/src/lib/ingest.ts
+++ b/src/lib/ingest.ts
@@ -1,8 +1,10 @@
 import path from "node:path";
 import { db } from "./db";
 import { hourBucket } from "./activity";
+import { processAlerts } from "./alerts";
 import { publish } from "./bus";
 import { describeFileEdit } from "./file-edit";
+import { parseDbTime } from "./format";
 import { scheduleGitUpdate } from "./git-sync";
 import { log } from "./log";
 import { parseMcpTool } from "./mcp";
@@ -185,6 +187,12 @@ const bumpActivity = db.prepare<[string, string]>(`
 
 const getSession = db.prepare<[string]>(`SELECT * FROM sessions WHERE id = ?`);
 
+// Error rate over the most recent tool calls — feeds the error-spike alert rule.
+const recentErrorRateStmt = db.prepare(
+  `SELECT AVG(CASE WHEN success = 0 THEN 1.0 ELSE 0 END) AS r
+   FROM (SELECT success FROM tool_calls ORDER BY id DESC LIMIT 50)`,
+);
+
 const lastPreToolTime = db.prepare<[string, string]>(`
   SELECT created_at FROM events
   WHERE session_id = ? AND event_type = 'PreToolUse' AND tool_name = ?
@@ -252,6 +260,10 @@ export function ingest(headerEvent: string, payload: HookPayload): IngestResult 
   const toolName = typeof payload.tool_name === "string" ? payload.tool_name : null;
   const model = extractModel(payload);
 
+  // Captured in the PostToolUse branch for the alert engine (after the tx).
+  let alertToolSource: string | null = null;
+  let alertToolSuccess: number | null = null;
+
   // Redact secrets in the prompt before it's persisted anywhere (payload_json,
   // title, summary, prompts table all use the redacted text).
   let prepared: PreparedPrompt | null = null;
@@ -305,6 +317,8 @@ export function ingest(headerEvent: string, payload: HookPayload): IngestResult 
       }
       const { isError, errorText } = describeToolResult(payload.tool_response);
       const mcp = parseMcpTool(toolName);
+      alertToolSource = mcp.isMcp ? "mcp" : "builtin";
+      alertToolSuccess = isError ? 0 : 1;
       const info = insertToolCall.run(
         sessionId,
         toolName,
@@ -367,6 +381,30 @@ export function ingest(headerEvent: string, payload: HookPayload): IngestResult 
   const result = tx();
   maybePrune();
   publish(result);
+
+  // Read-only alerting: evaluate the rule engine against this event. Never blocks
+  // or fails ingest.
+  try {
+    const startMs = parseDbTime(result.session.first_seen)?.getTime();
+    const durationMin = startMs ? Math.max(0, (Date.now() - startMs) / 60_000) : 0;
+    const recentErrorRate =
+      eventType === "PostToolUse"
+        ? ((recentErrorRateStmt.get() as { r: number | null }).r ?? 0)
+        : 0;
+    processAlerts(db, {
+      eventType,
+      toolName,
+      toolSource: alertToolSource,
+      toolSuccess: alertToolSuccess,
+      sessionId,
+      sessionCostUsd: result.session.cost_usd ?? 0,
+      sessionDurationMin: durationMin,
+      recentErrorRate,
+      hourBucket: hourBucket(result.event.created_at),
+    });
+  } catch (err) {
+    log.error("alert processing failed", err);
+  }
 
   // Capture the git branch/commit of the project once, at session start.
   if (eventType === "SessionStart" && cwd) {

--- a/src/lib/migrations-sql.mjs
+++ b/src/lib/migrations-sql.mjs
@@ -176,4 +176,34 @@ export const MIGRATIONS = [
     updated_at  DATETIME DEFAULT CURRENT_TIMESTAMP
   );
   `,
+
+  // v15 — read-only alerting: rules (conditions over the event stream) evaluated at
+  // ingest, and the alerts they raise. The unique (rule_id, dedup_key) index keeps
+  // a firing condition from spamming. Seeded with sensible default rules.
+  `
+  CREATE TABLE IF NOT EXISTS alert_rules (
+    id        INTEGER PRIMARY KEY AUTOINCREMENT,
+    type      TEXT NOT NULL,
+    threshold REAL NOT NULL DEFAULT 0,
+    enabled   INTEGER NOT NULL DEFAULT 1,
+    label     TEXT
+  );
+  CREATE TABLE IF NOT EXISTS alerts (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    rule_id    INTEGER,
+    type       TEXT NOT NULL,
+    message    TEXT NOT NULL,
+    session_id TEXT,
+    dedup_key  TEXT,
+    read       INTEGER NOT NULL DEFAULT 0,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+  );
+  CREATE UNIQUE INDEX IF NOT EXISTS idx_alerts_dedup ON alerts(rule_id, dedup_key);
+  CREATE INDEX IF NOT EXISTS idx_alerts_read ON alerts(read);
+  INSERT INTO alert_rules (type, threshold, enabled, label) VALUES
+    ('mcp_error', 0, 1, 'MCP tool failed'),
+    ('error_spike', 0.25, 1, 'Error-rate spike'),
+    ('session_long', 120, 1, 'Long-running session'),
+    ('cost_session', 5, 1, 'Session cost over budget');
+  `,
 ];


### PR DESCRIPTION
## Summary
- **Read-only Regel-Engine** (Run 81, starts Phase G): DB-stored alert rules evaluated at ingest against a small per-event context. Four rule types — `mcp_error`, `error_spike` (recent error rate over a threshold), `session_long`, `cost_session` — raise alerts, **deduplicated** via a unique `(rule_id, dedup_key)` index so a firing condition can't spam (one per session / per hour, etc.).
- Migration **v15** adds `alert_rules` + `alerts` and seeds sensible default rules. Adds a pure `evaluateRules` (+ DB helpers `processAlerts`/`recordAlert`/`recentAlerts`) with unit tests, an `/api/alerts` GET (recent + unread count), and demo alerts. The engine runs after the ingest transaction inside a try/catch — it never blocks or fails ingest, and **never writes back to Claude** (observe-only).
- The UI (toast/inbox) lands in Run 82; this PR is the engine + storage + read route.

## Test plan
- [x] `npm run lint` — clean
- [x] `npx vitest run` — 327 tests pass (new `evaluateRules` + dedup cases)
- [x] `npm run build` — succeeds (`/api/alerts` route present)
- [x] `npm run test:e2e` — 2 pass (`<section>` count stays 28)

https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk)_