### PR TITLE
Add in-app notifications (bell, inbox, toast)

### DIFF
--- a/src/app/api/alerts/route.ts
+++ b/src/app/api/alerts/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
+import { z } from "zod";
 import { db } from "@/lib/db";
-import { recentAlerts, unreadAlertCount } from "@/lib/alerts";
+import { markAlertsRead, markAllAlertsRead, recentAlerts, unreadAlertCount } from "@/lib/alerts";
 import { log } from "@/lib/log";
 
 export const runtime = "nodejs";
@@ -15,5 +16,23 @@ export async function GET(req: Request) {
   } catch (err) {
     log.error("/api/alerts failed", err);
     return NextResponse.json({ alerts: [], unread: 0 });
+  }
+}
+
+const Body = z.object({
+  all: z.boolean().optional(),
+  ids: z.array(z.number().int().positive()).max(500).optional(),
+});
+
+// Mark alerts read (the only mutation — local UI read-state, not Claude data).
+export async function POST(req: Request) {
+  try {
+    const parsed = Body.safeParse(await req.json());
+    if (!parsed.success) return NextResponse.json({ error: "invalid body" }, { status: 400 });
+    const updated = parsed.data.all ? markAllAlertsRead(db) : markAlertsRead(db, parsed.data.ids ?? []);
+    return NextResponse.json({ ok: true, updated });
+  } catch (err) {
+    log.error("/api/alerts POST failed", err);
+    return NextResponse.json({ error: "write failed" }, { status: 500 });
   }
 }

--- a/src/components/dashboard.tsx
+++ b/src/components/dashboard.tsx
@@ -35,6 +35,7 @@ import { FacetProvider, useFacets } from "@/components/facets";
 import { CommandPalette } from "@/components/command-palette";
 import { PluginConfigProvider } from "@/components/plugin-config";
 import { SettingsDrawer } from "@/components/settings-drawer";
+import { Notifications } from "@/components/notifications";
 import { useTheme } from "@/components/theme";
 import { ACCENT_PRESETS } from "@/lib/theme";
 import { useT } from "@/lib/i18n";
@@ -530,6 +531,7 @@ function Header({
             <RotateCcw className="h-3.5 w-3.5" />
           </button>
         )}
+        <Notifications />
         <ThemePicker />
         <LangToggle />
         <span className="hidden font-mono tabular-nums sm:inline">{clock}</span>

--- a/src/components/notifications.tsx
+++ b/src/components/notifications.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import Link from "next/link";
+import { AlertTriangle, Bell, Clock, Coins, Plug } from "lucide-react";
+import { useLive } from "@/components/live-provider";
+import { useT } from "@/lib/i18n";
+import { relativeTime } from "@/lib/format";
+import type { AlertItem } from "@/lib/alerts";
+
+const TYPE_ICON: Record<string, typeof AlertTriangle> = {
+  mcp_error: Plug,
+  error_spike: AlertTriangle,
+  session_long: Clock,
+  cost_session: Coins,
+};
+
+export function Notifications() {
+  const { t, lang } = useT();
+  const { tick } = useLive();
+  const [alerts, setAlerts] = useState<AlertItem[]>([]);
+  const [unread, setUnread] = useState(0);
+  const [open, setOpen] = useState(false);
+  const [toast, setToast] = useState<string | null>(null);
+  const seenMaxId = useRef<number | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = () =>
+      fetch("/api/alerts?limit=30")
+        .then((r) => r.json())
+        .then((d: { alerts: AlertItem[]; unread: number }) => {
+          if (cancelled) return;
+          setAlerts(d.alerts ?? []);
+          setUnread(d.unread ?? 0);
+          const maxId = d.alerts?.[0]?.id ?? 0;
+          if (seenMaxId.current === null) {
+            seenMaxId.current = maxId; // first load: don't toast historical alerts
+          } else if (maxId > seenMaxId.current) {
+            const newest = d.alerts[0];
+            if (newest && !newest.read) {
+              setToast(newest.message);
+              setTimeout(() => setToast(null), 5000);
+            }
+            seenMaxId.current = maxId;
+          }
+        })
+        .catch(() => {});
+    load();
+    const poll = setInterval(load, 20_000);
+    return () => {
+      cancelled = true;
+      clearInterval(poll);
+    };
+  }, [tick]);
+
+  const markAllRead = () => {
+    setUnread(0);
+    setAlerts((a) => a.map((x) => ({ ...x, read: 1 })));
+    fetch("/api/alerts", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ all: true }),
+    }).catch(() => {});
+  };
+
+  const toggle = () => {
+    setOpen((o) => {
+      if (!o && unread > 0) markAllRead();
+      return !o;
+    });
+  };
+
+  return (
+    <>
+      <div className="relative hidden sm:block">
+        <button
+          type="button"
+          onClick={toggle}
+          aria-label={t("notif.title")}
+          title={t("notif.title")}
+          className="relative flex items-center rounded-full border border-panel-border bg-background/40 p-1.5 text-muted transition-colors hover:border-accent/50 hover:text-foreground"
+        >
+          <Bell className="h-3.5 w-3.5" />
+          {unread > 0 && (
+            <span className="absolute -right-1 -top-1 flex h-4 min-w-4 items-center justify-center rounded-full bg-red-500 px-1 text-[9px] font-semibold text-white">
+              {unread > 9 ? "9+" : unread}
+            </span>
+          )}
+        </button>
+        {open && (
+          <div className="absolute right-0 top-9 z-50 w-80 overflow-hidden rounded-lg border border-panel-border bg-panel shadow-2xl shadow-black/50">
+            <header className="flex items-center justify-between border-b border-panel-border px-3 py-2 text-sm font-semibold text-foreground">
+              <span className="flex items-center gap-1.5">
+                <Bell className="h-3.5 w-3.5 text-accent" />
+                {t("notif.title")}
+              </span>
+              <button type="button" onClick={markAllRead} className="text-[11px] font-normal text-muted hover:text-foreground">
+                {t("notif.markRead")}
+              </button>
+            </header>
+            {alerts.length === 0 ? (
+              <p className="px-3 py-6 text-center text-xs text-muted">{t("notif.empty")}</p>
+            ) : (
+              <ul className="max-h-80 overflow-auto">
+                {alerts.map((a) => {
+                  const Icon = TYPE_ICON[a.type] ?? AlertTriangle;
+                  const row = (
+                    <span className="flex items-start gap-2 px-3 py-2">
+                      <Icon className="mt-0.5 h-3.5 w-3.5 shrink-0 text-amber-400" />
+                      <span className="min-w-0 flex-1">
+                        <span className="block text-xs text-foreground">{a.message}</span>
+                        <span className="text-[10px] text-muted">{relativeTime(a.created_at, lang)}</span>
+                      </span>
+                    </span>
+                  );
+                  return (
+                    <li key={a.id} className={a.read ? "" : "bg-accent/[0.06]"}>
+                      {a.session_id ? (
+                        <Link
+                          href={`/session?id=${encodeURIComponent(a.session_id)}`}
+                          onClick={() => setOpen(false)}
+                          className="block transition-colors hover:bg-white/[0.04]"
+                        >
+                          {row}
+                        </Link>
+                      ) : (
+                        row
+                      )}
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+          </div>
+        )}
+      </div>
+      {toast && (
+        <div className="mc-fade-up fixed bottom-4 right-4 z-[90] flex max-w-sm items-start gap-2 rounded-lg border border-amber-400/40 bg-panel px-4 py-3 shadow-2xl shadow-black/50">
+          <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-400" />
+          <div>
+            <p className="text-xs font-semibold text-foreground">{t("notif.new")}</p>
+            <p className="text-xs text-muted">{toast}</p>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/lib/alerts.ts
+++ b/src/lib/alerts.ts
@@ -146,3 +146,13 @@ export function recentAlerts(db: Database.Database, limit: number): AlertItem[] 
 export function unreadAlertCount(db: Database.Database): number {
   return (db.prepare(`SELECT COUNT(*) AS n FROM alerts WHERE read = 0`).get() as { n: number }).n;
 }
+
+export function markAllAlertsRead(db: Database.Database): number {
+  return db.prepare(`UPDATE alerts SET read = 1 WHERE read = 0`).run().changes;
+}
+
+export function markAlertsRead(db: Database.Database, ids: number[]): number {
+  if (ids.length === 0) return 0;
+  const placeholders = ids.map(() => "?").join(",");
+  return db.prepare(`UPDATE alerts SET read = 1 WHERE id IN (${placeholders})`).run(...ids).changes;
+}

--- a/src/lib/i18n.tsx
+++ b/src/lib/i18n.tsx
@@ -273,6 +273,11 @@ const DE: Record<string, string> = {
   "theme.accent": "Akzentfarbe",
   "theme.custom": "Eigene Farbe",
 
+  "notif.title": "Benachrichtigungen",
+  "notif.empty": "Keine Benachrichtigungen.",
+  "notif.markRead": "Alle gelesen",
+  "notif.new": "Neue Benachrichtigung",
+
   "facets.project": "Projekt-Filter",
   "facets.allProjects": "Alle Projekte",
   "facets.status": "Status-Filter",
@@ -657,6 +662,11 @@ const EN: Record<string, string> = {
   "theme.light": "Light",
   "theme.accent": "Accent color",
   "theme.custom": "Custom color",
+
+  "notif.title": "Notifications",
+  "notif.empty": "No notifications.",
+  "notif.markRead": "Mark all read",
+  "notif.new": "New notification",
 
   "facets.project": "Project filter",
   "facets.allProjects": "All projects",


### PR DESCRIPTION
## Summary
- **In-App-Benachrichtigungen** (Run 82): a header **bell** with an unread **badge** and an **inbox dropdown** listing recent rule-engine alerts (type icon, message, link to the relevant session, relative time; unread rows highlighted). Opening the inbox or clicking "mark all read" clears the badge via a new **`/api/alerts` POST** (mark read — the only mutation, local UI read-state). A **toast** pops bottom-right when a new alert arrives (detected by polling; historical alerts don't toast on first load).
- Adds `markAllAlertsRead` / `markAlertsRead` helpers and de/en i18n.

## Test plan
- [x] `npm run lint` — clean
- [x] `npx vitest run` — 327 tests pass
- [x] `npm run build` — succeeds (`/api/alerts` GET+POST)
- [x] `npm run test:e2e` — 2 pass (`<section>` count stays 28)

https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk)_