### PR TITLE
Add desktop notifications + demo-polish roadmap items

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -338,6 +338,25 @@ sein.
      Hints überall; alle `/api/*`-Routen antworten; Demo-Modus zeigt alle
      Widgets. Abschluss-Sammlung aller Screenshots.
 
+### Z-Demo. 🌐 Demo-Website-Politur (nur die Pages-Demo, `src/lib/demo.ts`)
+
+Die öffentliche Demo (läuft idealerweise **nur** auf der Website) wirkt aktuell
+**zu hektisch und inkonsistent**. Ruhiger, glaubwürdiger und stabil machen:
+
+- **Sessions bleiben bestehen.** Mehrere offene Sessions sind ok, aber eine
+  **beendete Session verschwindet nie wieder** — sie bleibt in der „Beendet"-
+  Spalte (kein Wegrotieren/Abschneiden der Historie wie heute).
+- **Geld steigt realistisch & monoton.** Kosten/Tokens nur **aufwärts**, in
+  kleinen, plausiblen Schritten — **kein Hoch-/Runter-Springen**.
+- **Weniger Hektik.** Ereignis-Takt entschleunigen, keine sprunghaften
+  Zahlensprünge; Werte sanft fortschreiben statt neu zu würfeln.
+- **3D-Graph: episch statt zappelig.** Optik ist gut, aber er soll **nicht
+  springen** — eine **langsame, gleichmäßige (epische) Auto-Rotation**. Bei
+  **manueller** Bewegung nicht sofort weiterdrehen, sondern **15 s warten**,
+  dann sanft wieder die Auto-Rotation aufnehmen.
+- **Konsistenz.** Über Reloads hinweg ein stimmiges, kuratiertes Bild (seedbare
+  Demo-Daten), damit Screenshots/GIFs reproduzierbar sind.
+
 ## Phase Ω — Beta-Release (Run 120, **letzter Schritt**)
 
 120. 🚀 **v1.0.0-beta — unsignierte Beta für alle Betriebssysteme** (erst nach

--- a/src/components/notifications.tsx
+++ b/src/components/notifications.tsx
@@ -2,11 +2,13 @@
 
 import { useEffect, useRef, useState } from "react";
 import Link from "next/link";
-import { AlertTriangle, Bell, Clock, Coins, Plug } from "lucide-react";
+import { AlertTriangle, Bell, BellRing, Clock, Coins, Plug } from "lucide-react";
 import { useLive } from "@/components/live-provider";
 import { useT } from "@/lib/i18n";
 import { relativeTime } from "@/lib/format";
 import type { AlertItem } from "@/lib/alerts";
+
+const DESKTOP_KEY = "mc-desktop-notif";
 
 const TYPE_ICON: Record<string, typeof AlertTriangle> = {
   mcp_error: Plug,
@@ -22,7 +24,30 @@ export function Notifications() {
   const [unread, setUnread] = useState(0);
   const [open, setOpen] = useState(false);
   const [toast, setToast] = useState<string | null>(null);
+  const [desktop, setDesktop] = useState(false);
   const seenMaxId = useRef<number | null>(null);
+  const desktopRef = useRef(false);
+
+  useEffect(() => {
+    desktopRef.current = desktop;
+  }, [desktop]);
+
+  useEffect(() => {
+    const id = requestAnimationFrame(() => {
+      try {
+        if (
+          localStorage.getItem(DESKTOP_KEY) === "1" &&
+          typeof Notification !== "undefined" &&
+          Notification.permission === "granted"
+        ) {
+          setDesktop(true);
+        }
+      } catch {
+        /* ignore */
+      }
+    });
+    return () => cancelAnimationFrame(id);
+  }, []);
 
   useEffect(() => {
     let cancelled = false;
@@ -41,6 +66,14 @@ export function Notifications() {
             if (newest && !newest.read) {
               setToast(newest.message);
               setTimeout(() => setToast(null), 5000);
+              // Bridge to a native (Electron/OS) notification when enabled.
+              if (desktopRef.current && typeof Notification !== "undefined" && Notification.permission === "granted") {
+                try {
+                  new Notification("Claude Mission Control", { body: newest.message });
+                } catch {
+                  /* notifications unavailable */
+                }
+              }
             }
             seenMaxId.current = maxId;
           }
@@ -53,6 +86,29 @@ export function Notifications() {
       clearInterval(poll);
     };
   }, [tick]);
+
+  const toggleDesktop = () => {
+    if (desktop) {
+      setDesktop(false);
+      try {
+        localStorage.removeItem(DESKTOP_KEY);
+      } catch {
+        /* ignore */
+      }
+      return;
+    }
+    if (typeof Notification === "undefined") return;
+    void Notification.requestPermission().then((p) => {
+      if (p === "granted") {
+        setDesktop(true);
+        try {
+          localStorage.setItem(DESKTOP_KEY, "1");
+        } catch {
+          /* ignore */
+        }
+      }
+    });
+  };
 
   const markAllRead = () => {
     setUnread(0);
@@ -95,9 +151,20 @@ export function Notifications() {
                 <Bell className="h-3.5 w-3.5 text-accent" />
                 {t("notif.title")}
               </span>
-              <button type="button" onClick={markAllRead} className="text-[11px] font-normal text-muted hover:text-foreground">
-                {t("notif.markRead")}
-              </button>
+              <span className="flex items-center gap-2">
+                <button
+                  type="button"
+                  onClick={toggleDesktop}
+                  aria-pressed={desktop}
+                  title={t("notif.desktop")}
+                  className={`transition-colors ${desktop ? "text-accent" : "text-muted hover:text-foreground"}`}
+                >
+                  <BellRing className="h-3.5 w-3.5" />
+                </button>
+                <button type="button" onClick={markAllRead} className="text-[11px] font-normal text-muted hover:text-foreground">
+                  {t("notif.markRead")}
+                </button>
+              </span>
             </header>
             {alerts.length === 0 ? (
               <p className="px-3 py-6 text-center text-xs text-muted">{t("notif.empty")}</p>

--- a/src/lib/i18n.tsx
+++ b/src/lib/i18n.tsx
@@ -277,6 +277,7 @@ const DE: Record<string, string> = {
   "notif.empty": "Keine Benachrichtigungen.",
   "notif.markRead": "Alle gelesen",
   "notif.new": "Neue Benachrichtigung",
+  "notif.desktop": "Desktop-Benachrichtigungen umschalten",
 
   "facets.project": "Projekt-Filter",
   "facets.allProjects": "Alle Projekte",
@@ -667,6 +668,7 @@ const EN: Record<string, string> = {
   "notif.empty": "No notifications.",
   "notif.markRead": "Mark all read",
   "notif.new": "New notification",
+  "notif.desktop": "Toggle desktop notifications",
 
   "facets.project": "Project filter",
   "facets.allProjects": "All projects",


### PR DESCRIPTION
## Summary
- **Desktop-Notifications** (Run 83): bridges new rule-engine alerts to **native (Electron/OS) notifications** via the Web Notification API — which Electron maps to native and browsers show as OS notifications. Behind an **opt-in toggle** (bell-ring icon) in the notifications inbox that requests permission and persists the choice (`localStorage`); fires only for genuinely new, unread alerts. Adds de/en i18n.
- **Roadmap:** adds a **"Demo-Website-Politur"** item to Phase Z (per your notes): make the public Pages demo calmer & consistent — **ended sessions persist** (never disappear), **cost rises monotonically** (no up/down jumps), less hectic event cadence, and the **3D graph gently/epically auto-rotates** without jitter, **waiting 15s after manual interaction** before resuming.

## Test plan
- [x] `npm run lint` — clean
- [x] `npx vitest run` — 327 tests pass
- [x] `npm run build` — succeeds
- [x] `npm run test:e2e` — 2 pass (`<section>` count stays 28)

https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk)_