### PR TITLE
Add daily/weekly digest (email-ready HTML)

### DIFF
--- a/src/app/api/digest/route.ts
+++ b/src/app/api/digest/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from "next/server";
+import { db } from "@/lib/db";
+import { buildDigest, renderDigestHtml, type DigestPeriod } from "@/lib/digest";
+import { log } from "@/lib/log";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+// Daily/weekly digest. HTML by default (open in a tab / save / email); JSON with
+// ?format=json.
+export async function GET(req: Request) {
+  const url = new URL(req.url);
+  const period: DigestPeriod = url.searchParams.get("period") === "week" ? "week" : "day";
+  const format = url.searchParams.get("format") === "json" ? "json" : "html";
+  try {
+    const data = buildDigest(db, period);
+    if (format === "json") return NextResponse.json(data);
+    return new NextResponse(renderDigestHtml(data), {
+      headers: { "Content-Type": "text/html; charset=utf-8" },
+    });
+  } catch (err) {
+    log.error("/api/digest failed", err);
+    return NextResponse.json({ error: "digest failed" }, { status: 500 });
+  }
+}

--- a/src/components/command-palette.tsx
+++ b/src/components/command-palette.tsx
@@ -98,6 +98,12 @@ export function CommandPalette({
       });
     }
     list.push({ id: "facet-clear", group: t("cmd.status"), label: t("facets.clear"), run: () => { clear(); close(); } });
+    const openDigest = (period: "day" | "week") => {
+      window.open(`/api/digest?period=${period}`, "_blank", "noopener");
+      close();
+    };
+    list.push({ id: "digest-day", group: t("cmd.actions"), label: t("cmd.digestDay"), keywords: "report summary", run: () => openDigest("day") });
+    list.push({ id: "digest-week", group: t("cmd.actions"), label: t("cmd.digestWeek"), keywords: "report summary", run: () => openDigest("week") });
     list.push({ id: "reset", group: t("cmd.actions"), label: t("layout.reset"), run: () => { onResetLayout(); close(); } });
     list.push({ id: "gallery", group: t("cmd.actions"), label: t("gallery.title"), run: () => { onOpenGallery(); close(); } });
     list.push({

--- a/src/lib/digest.test.ts
+++ b/src/lib/digest.test.ts
@@ -1,0 +1,65 @@
+import Database from "better-sqlite3";
+import { afterEach, describe, expect, it } from "vitest";
+import { migrate } from "@/lib/migrations";
+import { buildDigest, renderDigestHtml, type DigestData } from "@/lib/digest";
+
+let open: Database.Database | null = null;
+afterEach(() => {
+  open?.close();
+  open = null;
+});
+
+describe("buildDigest", () => {
+  it("summarizes the window from the DB", () => {
+    const db = (open = new Database(":memory:"));
+    migrate(db);
+    const now = new Date("2026-05-24T12:00:00Z");
+    const within = "2026-05-24 09:00:00";
+    db.prepare(`INSERT INTO sessions (id, first_seen, cost_usd) VALUES (?, ?, ?)`).run("s1", within, 3.5);
+    db.prepare(`INSERT INTO events (session_id, event_type, payload_json, created_at) VALUES (?, ?, '{}', ?)`).run("s1", "PostToolUse", within);
+    const tc = db.prepare(`INSERT INTO tool_calls (session_id, tool_name, success, created_at) VALUES (?, ?, ?, ?)`);
+    tc.run("s1", "Read", 1, within);
+    tc.run("s1", "Bash", 0, within);
+
+    const d = buildDigest(db, "day", now);
+    expect(d.period).toBe("day");
+    expect(d.events).toBe(1);
+    expect(d.sessions).toBe(1);
+    expect(d.toolCalls).toBe(2);
+    expect(d.failures).toBe(1);
+    expect(d.costUsd).toBe(3.5);
+    expect(d.topTools.map((t) => t.tool)).toContain("Read");
+    expect(d.topErrors.map((t) => t.tool)).toContain("Bash");
+  });
+});
+
+describe("renderDigestHtml", () => {
+  const data: DigestData = {
+    period: "week",
+    since: "2026-05-17 12:00:00",
+    generatedAt: "2026-05-24 12:00:00",
+    events: 120,
+    toolCalls: 80,
+    failures: 4,
+    sessions: 12,
+    costUsd: 9.42,
+    errorRate: 0.05,
+    topTools: [{ tool: "Read", count: 40 }],
+    topErrors: [{ tool: "Bash", failures: 4, total: 20, rate: 0.2 }],
+  };
+
+  it("renders an HTML doc with the headline numbers", () => {
+    const html = renderDigestHtml(data);
+    expect(html).toContain("<!doctype html>");
+    expect(html).toContain("Weekly digest");
+    expect(html).toContain("$9.42");
+    expect(html).toContain("Read");
+    expect(html).toContain("Bash");
+  });
+
+  it("escapes HTML in tool names", () => {
+    const html = renderDigestHtml({ ...data, topTools: [{ tool: "<script>", count: 1 }] });
+    expect(html).not.toContain("<script>");
+    expect(html).toContain("&lt;script&gt;");
+  });
+});

--- a/src/lib/digest.ts
+++ b/src/lib/digest.ts
@@ -1,0 +1,94 @@
+import type Database from "better-sqlite3";
+import { errorStats, topFailingTools, type FailingTool } from "./errors";
+
+// Daily / weekly digest: a windowed summary (events, cost, sessions, top tools,
+// top failing tools) plus an email-ready HTML renderer. buildDigest reads the DB;
+// renderDigestHtml is pure (inline styles so it survives email clients).
+
+export type DigestPeriod = "day" | "week";
+
+export interface DigestData {
+  period: DigestPeriod;
+  since: string;
+  generatedAt: string;
+  events: number;
+  toolCalls: number;
+  failures: number;
+  sessions: number;
+  costUsd: number;
+  errorRate: number;
+  topTools: { tool: string; count: number }[];
+  topErrors: FailingTool[];
+}
+
+function sinceIso(period: DigestPeriod, now: Date): string {
+  const days = period === "week" ? 7 : 1;
+  return new Date(now.getTime() - days * 86_400_000).toISOString().replace("T", " ").slice(0, 19);
+}
+
+export function buildDigest(db: Database.Database, period: DigestPeriod, now: Date = new Date()): DigestData {
+  const since = sinceIso(period, now);
+  const count = (sql: string) => (db.prepare(sql).get(since) as { n: number }).n;
+  const events = count(`SELECT COUNT(*) AS n FROM events WHERE created_at >= ?`);
+  const sessions = count(`SELECT COUNT(*) AS n FROM sessions WHERE first_seen >= ?`);
+  const cost = (
+    db.prepare(`SELECT COALESCE(SUM(cost_usd), 0) AS n FROM sessions WHERE first_seen >= ?`).get(since) as {
+      n: number;
+    }
+  ).n;
+  const stats = errorStats(db, since);
+  const topTools = db
+    .prepare(
+      `SELECT tool_name AS tool, COUNT(*) AS count FROM tool_calls
+       WHERE created_at >= ? GROUP BY tool_name ORDER BY count DESC, tool ASC LIMIT 5`,
+    )
+    .all(since) as { tool: string; count: number }[];
+
+  return {
+    period,
+    since,
+    generatedAt: now.toISOString().replace("T", " ").slice(0, 19),
+    events,
+    toolCalls: stats.toolCalls,
+    failures: stats.failures,
+    sessions,
+    costUsd: Number(cost.toFixed(2)),
+    errorRate: stats.errorRate,
+    topTools,
+    topErrors: topFailingTools(db, 5, since),
+  };
+}
+
+function esc(s: string): string {
+  return s.replace(/[&<>"]/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" })[c] ?? c);
+}
+
+export function renderDigestHtml(d: DigestData): string {
+  const title = d.period === "week" ? "Weekly digest" : "Daily digest";
+  const stat = (label: string, value: string) =>
+    `<td style="padding:10px 14px;border:1px solid #e2e6ee;border-radius:8px"><div style="font-size:20px;font-weight:600;color:#1a2230">${value}</div><div style="font-size:11px;color:#586074;text-transform:uppercase;letter-spacing:.04em">${label}</div></td>`;
+  const list = (rows: string[]) =>
+    rows.length ? `<ul style="margin:6px 0 0;padding-left:18px;color:#1a2230">${rows.join("")}</ul>` : `<p style="color:#586074;font-size:13px">—</p>`;
+
+  return `<!doctype html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width"><title>${title}</title></head>
+<body style="margin:0;background:#f5f7fa;font-family:ui-sans-serif,system-ui,sans-serif">
+  <div style="max-width:640px;margin:0 auto;padding:24px">
+    <h1 style="font-size:18px;color:#1a2230;margin:0 0 4px">Claude Mission Control — ${title}</h1>
+    <p style="font-size:12px;color:#586074;margin:0 0 16px">Since ${esc(d.since)} · generated ${esc(d.generatedAt)}</p>
+    <table style="border-collapse:separate;border-spacing:6px;width:100%"><tr>
+      ${stat("Events", String(d.events))}
+      ${stat("Tool calls", String(d.toolCalls))}
+      ${stat("Sessions", String(d.sessions))}
+    </tr><tr>
+      ${stat("Failures", String(d.failures))}
+      ${stat("Error rate", `${Math.round(d.errorRate * 100)}%`)}
+      ${stat("Cost", `$${d.costUsd.toFixed(2)}`)}
+    </tr></table>
+    <h2 style="font-size:14px;color:#1a2230;margin:18px 0 0">Top tools</h2>
+    ${list(d.topTools.map((t) => `<li>${esc(t.tool)} — ${t.count}</li>`))}
+    <h2 style="font-size:14px;color:#1a2230;margin:18px 0 0">Most failure-prone tools</h2>
+    ${list(d.topErrors.map((t) => `<li>${esc(t.tool)} — ${t.failures} fails (${Math.round(t.rate * 100)}%)</li>`))}
+    <p style="font-size:11px;color:#9aa3b5;margin-top:24px">Generated locally by Claude Mission Control · read-only.</p>
+  </div>
+</body></html>`;
+}

--- a/src/lib/i18n.tsx
+++ b/src/lib/i18n.tsx
@@ -254,6 +254,8 @@ const DE: Record<string, string> = {
   "cmd.setRange": "Zeitraum",
   "cmd.setStatus": "Status",
   "cmd.goto": "Gehe zu",
+  "cmd.digestDay": "Tages-Digest öffnen",
+  "cmd.digestWeek": "Wochen-Digest öffnen",
 
   "layout.drag": "Zum Umordnen ziehen",
   "layout.reset": "Layout zurücksetzen",
@@ -651,6 +653,8 @@ const EN: Record<string, string> = {
   "cmd.setRange": "Range",
   "cmd.setStatus": "Status",
   "cmd.goto": "Go to",
+  "cmd.digestDay": "Open daily digest",
+  "cmd.digestWeek": "Open weekly digest",
 
   "layout.drag": "Drag to reorder",
   "layout.reset": "Reset layout",


### PR DESCRIPTION
## Summary
- **Täglicher/wöchentlicher Digest** (Run 85): a new `/api/digest` renders a windowed summary — events, tool calls, sessions, failures, error rate, cost, top tools, and most failure-prone tools — as **email-ready, inline-styled HTML** (open in a tab, save, or paste into an email), or JSON via `?format=json`. Period is `day` (24h) or `week` (7d).
- Adds a `digest` lib (`buildDigest` from the DB + a pure, HTML-escaped `renderDigestHtml`) with unit tests, and **command-palette** actions ("Open daily/weekly digest").

## Test plan
- [x] `npm run lint` — clean
- [x] `npx vitest run` — 334 tests pass (new digest build + render/escape cases)
- [x] `npm run build` — succeeds (`/api/digest` route present)
- [x] `npm run test:e2e` — 2 pass (`<section>` count stays 28)

https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk)_