### PR TITLE
Add anomaly detection widget (recent vs baseline)

### DIFF
--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -43,8 +43,8 @@ test("dashboard renders all four widgets and connects", async ({ page }) => {
 
   await expect(page.getByRole("heading", { name: "Claude Mission Control" })).toBeVisible();
 
-  // Twenty-eight widget panels (27 core + the reference plugin from plugins.local/).
-  await expect(page.locator("section")).toHaveCount(28);
+  // Twenty-nine widget panels (28 core sections + the reference plugin from plugins.local/).
+  await expect(page.locator("section")).toHaveCount(29);
   // Two titles are identical in both locales — safe to assert regardless of language.
   await expect(page.getByText("Sessions", { exact: true })).toBeVisible();
   await expect(page.getByText("Live Stream", { exact: true })).toBeVisible();

--- a/src/app/api/anomaly/route.ts
+++ b/src/app/api/anomaly/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from "next/server";
+import { db } from "@/lib/db";
+import { anomalyReport } from "@/lib/anomaly";
+import { log } from "@/lib/log";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+// Latency p95 + error rate, recent (24h) vs baseline (prior 7d).
+export async function GET() {
+  try {
+    return NextResponse.json(anomalyReport(db));
+  } catch (err) {
+    log.error("/api/anomaly failed", err);
+    return NextResponse.json({
+      latencyMs: { recent: 0, baseline: 0, deltaPct: 0, anomalous: false },
+      errorRate: { recent: 0, baseline: 0, deltaPct: 0, anomalous: false },
+      recentSamples: 0,
+      baselineSamples: 0,
+    });
+  }
+}

--- a/src/lib/anomaly.test.ts
+++ b/src/lib/anomaly.test.ts
@@ -1,0 +1,48 @@
+import Database from "better-sqlite3";
+import { afterEach, describe, expect, it } from "vitest";
+import { migrate } from "@/lib/migrations";
+import { anomalyReport, compareMetric } from "@/lib/anomaly";
+
+describe("compareMetric", () => {
+  it("flags a meaningful rise above baseline", () => {
+    const c = compareMetric(150, 100, 0.5);
+    expect(c.deltaPct).toBeCloseTo(0.5);
+    expect(c.anomalous).toBe(true);
+  });
+
+  it("does not flag small or downward changes", () => {
+    expect(compareMetric(110, 100, 0.5).anomalous).toBe(false);
+    expect(compareMetric(50, 100, 0.5).anomalous).toBe(false);
+  });
+
+  it("never flags when there is no baseline", () => {
+    expect(compareMetric(500, 0).anomalous).toBe(false);
+    expect(compareMetric(500, 0).deltaPct).toBe(0);
+  });
+});
+
+describe("anomalyReport", () => {
+  let open: Database.Database | null = null;
+  afterEach(() => {
+    open?.close();
+    open = null;
+  });
+
+  it("compares recent latency p95 to the baseline window", () => {
+    const db = (open = new Database(":memory:"));
+    migrate(db);
+    const now = new Date("2026-05-24T12:00:00Z");
+    const tc = db.prepare(`INSERT INTO tool_calls (session_id, tool_name, duration_ms, success, created_at) VALUES (?, ?, ?, 1, ?)`);
+    // baseline (~5 days ago): fast
+    for (let i = 0; i < 20; i++) tc.run("s1", "Read", 100, "2026-05-19 12:00:00");
+    // recent (1h ago): slow
+    for (let i = 0; i < 20; i++) tc.run("s1", "Read", 400, "2026-05-24 11:00:00");
+
+    const r = anomalyReport(db, now);
+    expect(r.recentSamples).toBe(20);
+    expect(r.baselineSamples).toBe(20);
+    expect(r.latencyMs.recent).toBe(400);
+    expect(r.latencyMs.baseline).toBe(100);
+    expect(r.latencyMs.anomalous).toBe(true);
+  });
+});

--- a/src/lib/anomaly.ts
+++ b/src/lib/anomaly.ts
@@ -1,0 +1,72 @@
+import type Database from "better-sqlite3";
+import { percentile } from "./latency";
+
+// "Is Claude getting worse?" — compares a recent window (last 24h) against a
+// baseline (the prior 7 days) for tool latency (p95) and error rate, flagging a
+// metric as anomalous when it rises meaningfully above its baseline. Pure
+// compareMetric so the threshold logic is unit-testable.
+
+export interface MetricComparison {
+  recent: number;
+  baseline: number;
+  deltaPct: number; // relative change vs baseline (0 when no baseline)
+  anomalous: boolean;
+}
+
+export function compareMetric(recent: number, baseline: number, threshold = 0.5): MetricComparison {
+  const deltaPct = baseline > 0 ? (recent - baseline) / baseline : 0;
+  return { recent, baseline, deltaPct, anomalous: baseline > 0 && recent > baseline && deltaPct >= threshold };
+}
+
+export interface AnomalyReport {
+  latencyMs: MetricComparison; // p95
+  errorRate: MetricComparison; // 0..1
+  recentSamples: number;
+  baselineSamples: number;
+}
+
+function iso(ms: number): string {
+  return new Date(ms).toISOString().replace("T", " ").slice(0, 19);
+}
+
+function durations(db: Database.Database, sql: string, args: unknown[]): number[] {
+  return (db.prepare(sql).all(...args) as { duration_ms: number }[])
+    .map((r) => r.duration_ms)
+    .sort((a, b) => a - b);
+}
+
+function windowErrorRate(db: Database.Database, since: string, until: string | null): number {
+  const cond = until ? `created_at >= ? AND created_at < ?` : `created_at >= ?`;
+  const args = until ? [since, until] : [since];
+  const row = db
+    .prepare(
+      `SELECT COUNT(*) AS total, SUM(CASE WHEN success = 0 THEN 1 ELSE 0 END) AS failures
+       FROM tool_calls WHERE ${cond}`,
+    )
+    .get(...args) as { total: number; failures: number };
+  return row.total ? row.failures / row.total : 0;
+}
+
+export function anomalyReport(db: Database.Database, now: Date = new Date()): AnomalyReport {
+  const day = 86_400_000;
+  const recentSince = iso(now.getTime() - day);
+  const baseSince = iso(now.getTime() - 8 * day);
+
+  const recentD = durations(
+    db,
+    `SELECT duration_ms FROM tool_calls WHERE duration_ms IS NOT NULL AND created_at >= ?`,
+    [recentSince],
+  );
+  const baseD = durations(
+    db,
+    `SELECT duration_ms FROM tool_calls WHERE duration_ms IS NOT NULL AND created_at >= ? AND created_at < ?`,
+    [baseSince, recentSince],
+  );
+
+  return {
+    latencyMs: compareMetric(percentile(recentD, 95), percentile(baseD, 95)),
+    errorRate: compareMetric(windowErrorRate(db, recentSince, null), windowErrorRate(db, baseSince, recentSince)),
+    recentSamples: recentD.length,
+    baselineSamples: baseD.length,
+  };
+}

--- a/src/lib/demo.ts
+++ b/src/lib/demo.ts
@@ -14,6 +14,7 @@ import { topTerms } from "./tags";
 import type { ToolTokenBurn } from "./token-burn";
 import type { ToolCallDetail } from "./errors";
 import type { AlertItem } from "./alerts";
+import type { AnomalyReport } from "./anomaly";
 import type { ProjectReliability } from "./reliability";
 import type { SearchHit } from "./search-index";
 import type { SessionDetail } from "./session-detail";
@@ -883,6 +884,15 @@ export function demoAlerts() {
   return { alerts, unread: alerts.filter((a) => !a.read).length };
 }
 
+export function demoAnomaly(): AnomalyReport {
+  return {
+    latencyMs: { recent: 640, baseline: 410, deltaPct: (640 - 410) / 410, anomalous: true },
+    errorRate: { recent: 0.06, baseline: 0.05, deltaPct: (0.06 - 0.05) / 0.05, anomalous: false },
+    recentSamples: 142,
+    baselineSamples: 980,
+  };
+}
+
 export function demoSubscribe(fn: (m: StreamMessage) => void) {
   listeners.add(fn);
   return () => listeners.delete(fn);
@@ -933,6 +943,7 @@ export function installDemoBackend() {
     if (path.endsWith("/api/plugins/config")) return json({ config: {} });
     if (path.includes("/api/alerts/webhook")) return json({ url: "", enabled: false });
     if (path.endsWith("/api/alerts")) return json(demoAlerts());
+    if (path.endsWith("/api/anomaly")) return json(demoAnomaly());
     if (path.endsWith("/api/reliability")) return json(demoReliability());
     if (path.endsWith("/api/search")) {
       const u = new URL(raw, window.location.href);

--- a/src/lib/i18n.tsx
+++ b/src/lib/i18n.tsx
@@ -221,6 +221,15 @@ const DE: Record<string, string> = {
   "reliability.empty": "Noch keine Tool-Aufrufe.",
   "reliability.fail": "Fehler",
 
+  "anomaly.title": "Anomalie-Erkennung",
+  "anomaly.info": "Letzte 24 h vs. Basislinie (7 Tage): steigt Latenz/Fehlerrate? – „Wird Claude schlechter?“",
+  "anomaly.empty": "Noch nicht genug Daten.",
+  "anomaly.latency": "Latenz p95",
+  "anomaly.errorRate": "Fehlerrate",
+  "anomaly.vs": "vs.",
+  "anomaly.flag": "Auffällig über Basislinie",
+  "anomaly.window": "24 h vs. 7-Tage-Basislinie",
+
   "incidents.title": "Was lief schief",
   "incidents.info": "Letzte fehlgeschlagene Tool-Aufrufe. Klick öffnet Eingabe und Fehlertext.",
   "incidents.empty": "Keine Fehler – alles grün. 🎉",
@@ -619,6 +628,15 @@ const EN: Record<string, string> = {
   "reliability.info": "Share of successful tool calls per project. Green ≥95%, amber ≥85%, else red.",
   "reliability.empty": "No tool calls yet.",
   "reliability.fail": "fail",
+
+  "anomaly.title": "Anomaly detection",
+  "anomaly.info": "Last 24h vs. baseline (7 days): is latency/error rate rising? — \"Is Claude getting worse?\"",
+  "anomaly.empty": "Not enough data yet.",
+  "anomaly.latency": "Latency p95",
+  "anomaly.errorRate": "Error rate",
+  "anomaly.vs": "vs.",
+  "anomaly.flag": "Notably above baseline",
+  "anomaly.window": "24h vs. 7-day baseline",
 
   "incidents.title": "What went wrong",
   "incidents.info": "Latest failed tool calls. Click to reveal the input and error text.",

--- a/src/plugins/anomaly/widget.tsx
+++ b/src/plugins/anomaly/widget.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { Activity, TrendingDown, TrendingUp } from "lucide-react";
+import { Panel } from "@/components/panel";
+import { WidgetState } from "@/components/widget-state";
+import { usePluginQuery } from "@/components/plugin-data";
+import { useT } from "@/lib/i18n";
+import { formatMs } from "@/lib/latency";
+import type { AnomalyReport, MetricComparison } from "@/lib/anomaly";
+
+function Row({
+  label,
+  cmp,
+  format,
+  t,
+}: {
+  label: string;
+  cmp: MetricComparison;
+  format: (n: number) => string;
+  t: (k: string) => string;
+}) {
+  const pct = Math.round(cmp.deltaPct * 100);
+  const up = cmp.deltaPct > 0.005;
+  const down = cmp.deltaPct < -0.005;
+  const Icon = up ? TrendingUp : down ? TrendingDown : Activity;
+  const tone = cmp.anomalous ? "text-red-400" : up ? "text-amber-400" : "text-emerald-400";
+  return (
+    <div className="rounded-lg bg-white/[0.03] p-3">
+      <div className="flex items-baseline justify-between">
+        <span className="text-xs text-muted">{label}</span>
+        <span className={`flex items-center gap-1 text-xs tabular-nums ${tone}`}>
+          <Icon className="h-3 w-3" />
+          {pct > 0 ? "+" : ""}
+          {pct}%
+        </span>
+      </div>
+      <div className="mt-1 flex items-baseline gap-2">
+        <span className="font-mono text-lg tabular-nums text-foreground">{format(cmp.recent)}</span>
+        <span className="text-[11px] text-muted">
+          {t("anomaly.vs")} {format(cmp.baseline)}
+        </span>
+      </div>
+      {cmp.anomalous && <p className="mt-1 text-[11px] text-red-400">{t("anomaly.flag")}</p>}
+    </div>
+  );
+}
+
+export function Anomaly() {
+  const { t } = useT();
+  const { data } = usePluginQuery<AnomalyReport>("/api/anomaly", { pollMs: 30_000 });
+
+  return (
+    <Panel title={t("anomaly.title")} icon={<Activity className="h-4 w-4 text-accent" />} info={t("anomaly.info")}>
+      {!data ? (
+        <WidgetState icon={Activity} title={t("common.loading")} loading />
+      ) : data.recentSamples === 0 && data.baselineSamples === 0 ? (
+        <WidgetState icon={Activity} title={t("anomaly.empty")} />
+      ) : (
+        <div className="flex h-full flex-col justify-center gap-3 p-4">
+          <Row label={t("anomaly.latency")} cmp={data.latencyMs} format={(n) => formatMs(Math.round(n))} t={t} />
+          <Row label={t("anomaly.errorRate")} cmp={data.errorRate} format={(n) => `${Math.round(n * 100)}%`} t={t} />
+          <p className="text-center text-[10px] text-muted/70">
+            {t("anomaly.window")} · n={data.recentSamples}/{data.baselineSamples}
+          </p>
+        </div>
+      )}
+    </Panel>
+  );
+}

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -58,6 +58,7 @@ import { Velocity } from "./velocity/widget";
 import { SessionDuration } from "./session-duration/widget";
 import { Reliability } from "./reliability/widget";
 import { Incidents } from "./incidents/widget";
+import { Anomaly } from "./anomaly/widget";
 import { externalWidgets } from "./external.generated";
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -135,6 +136,7 @@ export const widgets: Widget[] = [
   { id: "session-duration", title: "Session-Dauer", span: "lg:col-span-3", height: H, icon: Hourglass, category: "sessions", description: "sessionDur.info", component: SessionDuration },
   { id: "reliability", title: "Zuverlässigkeit je Projekt", span: "lg:col-span-3", height: H, icon: ShieldCheck, category: "quality", description: "reliability.info", component: Reliability },
   { id: "incidents", title: "Was lief schief", span: "lg:col-span-3", height: H, icon: AlertTriangle, category: "quality", description: "incidents.info", component: Incidents },
+  { id: "anomaly", title: "Anomalie-Erkennung", span: "lg:col-span-3", height: H, icon: Activity, category: "quality", description: "anomaly.info", component: Anomaly },
   // Third-party widgets dropped into plugins.local/ (scanned at build).
   ...externalWidgets,
 ];


### PR DESCRIPTION
## Summary
- **Anomalie-Erkennung / Anomaly detection** (Run 86): a new widget + `/api/anomaly` that compares the **last 24h** to a **7-day baseline** for tool **latency (p95)** and **error rate**, flagging a metric as anomalous when it rises meaningfully above baseline — the "is Claude getting worse?" check. Each row shows the recent value vs baseline with a delta % and an "above baseline" flag; sample counts shown for honesty.
- Adds a pure `compareMetric` + `anomalyReport` lib (+ unit tests), a `demoAnomaly()` source, and de/en i18n.

Research note (per standing instruction): anomaly UIs read best as current-vs-baseline with a clear delta indicator and a sensitivity threshold — applied here (relative-change threshold, no flag when there's no baseline to avoid false positives).

## Test plan
- [x] `npm run lint` — clean
- [x] `npx vitest run` — 338 tests pass (new `compareMetric` + `anomalyReport` cases)
- [x] `npm run build` — succeeds (`/api/anomaly` route present)
- [x] `npm run test:e2e` — 2 pass, widget `<section>` count bumped 28 → 29

https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk)_