### PR TITLE
Add cost alarm (burn-rate projection over budget)

### DIFF
--- a/src/app/api/budget/route.ts
+++ b/src/app/api/budget/route.ts
@@ -1,24 +1,49 @@
 import { NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { getUsage } from "@/lib/ccusage";
-import { computeBudget, getBudgets } from "@/lib/budget";
+import { budgetProjections, computeBudget, getBudgets, type BudgetProjection } from "@/lib/budget";
+import { recordAlert } from "@/lib/alerts";
 import { log } from "@/lib/log";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-// Daily/monthly budget limits and how much of each is used so far.
+// Raise a cost alarm into the inbox when a period's burn projects over budget.
+// Deduped per period/day so it fires at most once a day.
+function raiseAlarm(period: "daily" | "monthly", proj: BudgetProjection): void {
+  if (!proj.overBudget || proj.budgetUsd == null) return;
+  const day = new Date().toISOString().slice(0, 10);
+  recordAlert(db, {
+    ruleId: 0,
+    type: "cost_projection",
+    sessionId: "",
+    dedupKey: `cost:${period}:${day}`,
+    message: `Projected ${period} spend $${proj.projectedUsd.toFixed(2)} over $${proj.budgetUsd.toFixed(0)} budget`,
+  });
+}
+
+// Daily/monthly budget limits, how much of each is used, and a burn-rate projection.
 export async function GET() {
   try {
     const report = await getUsage();
     const budgets = getBudgets(db);
-    return NextResponse.json({ budgets, status: computeBudget(report, budgets) });
+    const status = computeBudget(report, budgets);
+    const projection = budgetProjections(status);
+    try {
+      raiseAlarm("daily", projection.daily);
+      raiseAlarm("monthly", projection.monthly);
+    } catch (err) {
+      log.error("cost alarm failed", err);
+    }
+    return NextResponse.json({ budgets, status, projection });
   } catch (err) {
     log.error("/api/budget failed", err);
     const empty = { budgetUsd: null, spentUsd: 0, pct: null };
+    const emptyProj = { projectedUsd: 0, budgetUsd: null, projectedPct: null, overBudget: false };
     return NextResponse.json({
       budgets: { dailyUsd: null, monthlyUsd: null },
       status: { daily: empty, monthly: empty },
+      projection: { daily: emptyProj, monthly: emptyProj },
     });
   }
 }

--- a/src/lib/budget.test.ts
+++ b/src/lib/budget.test.ts
@@ -1,6 +1,6 @@
 import Database from "better-sqlite3";
 import { afterEach, describe, expect, it } from "vitest";
-import { computeBudget, getBudgets } from "@/lib/budget";
+import { computeBudget, dayElapsedFraction, getBudgets, monthElapsedFraction, projectSpend } from "@/lib/budget";
 import { setConfig } from "@/lib/config";
 import { migrate } from "@/lib/migrations";
 import type { UsageReport } from "@/lib/ccusage";
@@ -71,5 +71,36 @@ describe("computeBudget", () => {
     const status = computeBudget(report(), { dailyUsd: null, monthlyUsd: null }, now);
     expect(status.daily).toEqual({ budgetUsd: null, spentUsd: 0, pct: null });
     expect(status.monthly).toEqual({ budgetUsd: null, spentUsd: 0, pct: null });
+  });
+});
+
+describe("projectSpend", () => {
+  it("projects end-of-period spend from elapsed fraction and flags over-budget", () => {
+    // half the period gone, $60 spent → projected $120 > $100 budget.
+    const p = projectSpend(60, 100, 0.5);
+    expect(p.projectedUsd).toBe(120);
+    expect(p.projectedPct).toBe(1.2);
+    expect(p.overBudget).toBe(true);
+  });
+
+  it("does not flag when under budget or no budget", () => {
+    expect(projectSpend(30, 100, 0.5).overBudget).toBe(false);
+    expect(projectSpend(60, null, 0.5).overBudget).toBe(false);
+  });
+
+  it("suppresses noisy early projections below minFraction", () => {
+    // $5 in the first 2% of the period would project huge, but it's too early.
+    expect(projectSpend(5, 100, 0.02).overBudget).toBe(false);
+  });
+});
+
+describe("elapsed fractions", () => {
+  it("computes day fraction from local time", () => {
+    expect(dayElapsedFraction(new Date(2026, 4, 24, 12, 0, 0))).toBeCloseTo(0.5);
+  });
+
+  it("computes month fraction from day of month", () => {
+    // 2026-05 has 31 days; on the 16th ~ (15 + 0.5)/31.
+    expect(monthElapsedFraction(new Date(2026, 4, 16, 12, 0, 0))).toBeCloseTo((15 + 0.5) / 31, 3);
   });
 });

--- a/src/lib/budget.ts
+++ b/src/lib/budget.ts
@@ -55,3 +55,52 @@ export function computeBudget(
     monthly: usage(monthSpent, budgets.monthlyUsd),
   };
 }
+
+// ── Burn-rate projection / cost alarm ───────────────────────────────────────
+export interface BudgetProjection {
+  projectedUsd: number; // linear projection of end-of-period spend
+  budgetUsd: number | null;
+  projectedPct: number | null;
+  overBudget: boolean;
+}
+
+export function dayElapsedFraction(now: Date): number {
+  return (now.getHours() * 3600 + now.getMinutes() * 60 + now.getSeconds()) / 86_400;
+}
+
+export function monthElapsedFraction(now: Date): number {
+  const daysInMonth = new Date(now.getFullYear(), now.getMonth() + 1, 0).getDate();
+  return (now.getDate() - 1 + now.getHours() / 24) / daysInMonth;
+}
+
+// Project end-of-period spend from how much of the period has elapsed. Only flags
+// over-budget once enough of the period has passed (minFraction) to avoid noisy
+// early projections.
+export function projectSpend(
+  spentUsd: number,
+  budgetUsd: number | null,
+  elapsedFraction: number,
+  minFraction = 0.1,
+): BudgetProjection {
+  const f = Math.min(1, Math.max(0, elapsedFraction));
+  const projectedUsd = f > 0 ? spentUsd / f : 0;
+  const hasBudget = budgetUsd != null && budgetUsd > 0;
+  return {
+    projectedUsd,
+    budgetUsd,
+    projectedPct: hasBudget ? projectedUsd / budgetUsd! : null,
+    overBudget: hasBudget && f >= minFraction && projectedUsd > budgetUsd!,
+  };
+}
+
+export interface BudgetProjections {
+  daily: BudgetProjection;
+  monthly: BudgetProjection;
+}
+
+export function budgetProjections(status: BudgetStatus, now: Date = new Date()): BudgetProjections {
+  return {
+    daily: projectSpend(status.daily.spentUsd, status.daily.budgetUsd, dayElapsedFraction(now)),
+    monthly: projectSpend(status.monthly.spentUsd, status.monthly.budgetUsd, monthElapsedFraction(now)),
+  };
+}

--- a/src/lib/demo.ts
+++ b/src/lib/demo.ts
@@ -444,9 +444,16 @@ export function demoBudget() {
   const dailyUsd = 15;
   const monthlyUsd = 300;
   const gauge = (spentUsd: number, budgetUsd: number) => ({ budgetUsd, spentUsd, pct: spentUsd / budgetUsd });
+  const proj = (spentUsd: number, budgetUsd: number, fraction: number) => {
+    const projectedUsd = spentUsd / fraction;
+    return { projectedUsd, budgetUsd, projectedPct: projectedUsd / budgetUsd, overBudget: projectedUsd > budgetUsd };
+  };
+  const now = new Date();
+  const dayFrac = Math.max(0.05, (now.getHours() * 60 + now.getMinutes()) / 1440);
   return {
     budgets: { dailyUsd, monthlyUsd },
     status: { daily: gauge(dSpent, dailyUsd), monthly: gauge(mSpent, monthlyUsd) },
+    projection: { daily: proj(dSpent, dailyUsd, dayFrac), monthly: proj(mSpent, monthlyUsd, 0.5) },
   };
 }
 

--- a/src/lib/i18n.tsx
+++ b/src/lib/i18n.tsx
@@ -400,6 +400,7 @@ const DE: Record<string, string> = {
   "budget.daily": "Heute",
   "budget.monthly": "Dieser Monat",
   "budget.projected": "Hochrechnung",
+  "budget.alarm": "Burn-Rate projiziert über Budget!",
   "budget.none": "Kein Budget gesetzt.",
   "graph.title": "Tool-Graph (3D)",
   "graph.info":
@@ -808,6 +809,7 @@ const EN: Record<string, string> = {
   "budget.daily": "Today",
   "budget.monthly": "This month",
   "budget.projected": "Projected",
+  "budget.alarm": "Burn rate projected over budget!",
   "budget.none": "No budget set.",
   "graph.title": "Tool Graph (3D)",
   "graph.info":

--- a/src/plugins/budget-gauge/widget.tsx
+++ b/src/plugins/budget-gauge/widget.tsx
@@ -1,11 +1,12 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { Wallet } from "lucide-react";
+import { TriangleAlert, Wallet } from "lucide-react";
 import { Panel } from "@/components/panel";
 import { WidgetState } from "@/components/widget-state";
 import { useT } from "@/lib/i18n";
 import { formatMoney } from "@/lib/format";
+import type { BudgetProjection } from "@/lib/budget";
 
 interface BudgetUsage {
   budgetUsd: number | null;
@@ -15,20 +16,7 @@ interface BudgetUsage {
 interface BudgetResponse {
   budgets: { dailyUsd: number | null; monthlyUsd: number | null };
   status: { daily: BudgetUsage; monthly: BudgetUsage };
-}
-
-// Linear projection of the period's spend from how much of it has elapsed.
-function project(usage: BudgetUsage, period: "day" | "month"): number | null {
-  if (usage.budgetUsd == null || usage.spentUsd <= 0) return null;
-  const now = new Date();
-  let fraction: number;
-  if (period === "day") {
-    fraction = (now.getHours() + now.getMinutes() / 60) / 24;
-  } else {
-    const daysInMonth = new Date(now.getFullYear(), now.getMonth() + 1, 0).getDate();
-    fraction = (now.getDate() - 1 + now.getHours() / 24) / daysInMonth;
-  }
-  return fraction > 0 ? usage.spentUsd / fraction : null;
+  projection?: { daily: BudgetProjection; monthly: BudgetProjection };
 }
 
 export function BudgetGauge() {
@@ -65,13 +53,15 @@ export function BudgetGauge() {
           description={<code className="text-accent">MC_BUDGET_DAILY</code>}
         />
       ) : (
-        <div className="flex h-full flex-col justify-center gap-6 p-5">
-          <Gauge label={t("budget.daily")} usage={data.status.daily} projected={project(data.status.daily, "day")} />
-          <Gauge
-            label={t("budget.monthly")}
-            usage={data.status.monthly}
-            projected={project(data.status.monthly, "month")}
-          />
+        <div className="flex h-full flex-col justify-center gap-5 p-5">
+          {(data.projection?.daily.overBudget || data.projection?.monthly.overBudget) && (
+            <div className="flex items-center gap-2 rounded-lg border border-red-400/40 bg-red-500/10 px-3 py-2 text-xs text-red-400">
+              <TriangleAlert className="h-4 w-4 shrink-0" />
+              <span>{t("budget.alarm")}</span>
+            </div>
+          )}
+          <Gauge label={t("budget.daily")} usage={data.status.daily} proj={data.projection?.daily ?? null} />
+          <Gauge label={t("budget.monthly")} usage={data.status.monthly} proj={data.projection?.monthly ?? null} />
         </div>
       )}
     </Panel>
@@ -81,17 +71,17 @@ export function BudgetGauge() {
 function Gauge({
   label,
   usage,
-  projected,
+  proj,
 }: {
   label: string;
   usage: BudgetUsage;
-  projected: number | null;
+  proj: BudgetProjection | null;
 }) {
   const { t } = useT();
   if (usage.budgetUsd == null) return null;
   const pct = usage.pct ?? 0;
   const color = pct >= 1 ? "bg-red-500" : pct >= 0.75 ? "bg-amber-500" : "bg-emerald-500";
-  const projectedOver = projected != null && projected > usage.budgetUsd;
+  const showProjected = proj != null && usage.spentUsd > 0;
 
   return (
     <div>
@@ -108,9 +98,9 @@ function Gauge({
           style={{ width: `${Math.min(pct, 1) * 100}%` }}
         />
       </div>
-      {projected != null && (
-        <p className={`mt-1 text-[11px] ${projectedOver ? "text-red-400" : "text-muted"}`}>
-          {t("budget.projected")}: {formatMoney(projected, "USD")}
+      {showProjected && (
+        <p className={`mt-1 text-[11px] ${proj!.overBudget ? "text-red-400" : "text-muted"}`}>
+          {t("budget.projected")}: {formatMoney(proj!.projectedUsd, "USD")}
         </p>
       )}
     </div>


### PR DESCRIPTION
## Summary
- **Kosten-Alarm / Cost alarm** (Run 87): a server-side **burn-rate projection** (daily + monthly) — linear extrapolation of period spend from how much of the period has elapsed — compared to the configured budget. When the burn projects **over budget** it shows a prominent **alarm banner** in the budget gauge and is **raised into the notification inbox** (deduped once/day, also flows to the optional webhook).
- Hardens the previously client-only projection into a tested pure lib (`projectSpend`, `dayElapsedFraction`, `monthElapsedFraction`) with a `minFraction` guard against noisy early-period projections. `/api/budget` now returns `projection`; demo + de/en i18n updated.

## Test plan
- [x] `npm run lint` — clean
- [x] `npx vitest run` — 343 tests pass (new `projectSpend` + fraction cases)
- [x] `npm run build` — succeeds
- [x] `npm run test:e2e` — 2 pass (`<section>` count stays 29)

https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk)_