### PR TITLE
Add quiet hours (suppress non-critical alerts on a schedule)

### DIFF
--- a/src/app/api/alerts/quiet/route.ts
+++ b/src/app/api/alerts/quiet/route.ts
@@ -1,0 +1,45 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { db } from "@/lib/db";
+import { getConfig, setConfig } from "@/lib/config";
+import { invalidateQuietCache } from "@/lib/quiet";
+import { log } from "@/lib/log";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+// Quiet-hours schedule. Suppresses non-critical alert channels during the window.
+export async function GET() {
+  try {
+    return NextResponse.json({
+      enabled: getConfig(db, "quiet.enabled") === "1",
+      start: getConfig(db, "quiet.start") ?? "22:00",
+      end: getConfig(db, "quiet.end") ?? "07:00",
+    });
+  } catch (err) {
+    log.error("/api/alerts/quiet GET failed", err);
+    return NextResponse.json({ enabled: false, start: "22:00", end: "07:00" });
+  }
+}
+
+const HHMM = z.string().regex(/^\d{1,2}:\d{2}$/);
+const Body = z.object({
+  enabled: z.boolean().optional(),
+  start: HHMM.optional(),
+  end: HHMM.optional(),
+});
+
+export async function POST(req: Request) {
+  try {
+    const parsed = Body.safeParse(await req.json());
+    if (!parsed.success) return NextResponse.json({ error: "invalid body" }, { status: 400 });
+    if (parsed.data.enabled !== undefined) setConfig(db, "quiet.enabled", parsed.data.enabled ? "1" : "0");
+    if (parsed.data.start !== undefined) setConfig(db, "quiet.start", parsed.data.start);
+    if (parsed.data.end !== undefined) setConfig(db, "quiet.end", parsed.data.end);
+    invalidateQuietCache();
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    log.error("/api/alerts/quiet POST failed", err);
+    return NextResponse.json({ error: "write failed" }, { status: 500 });
+  }
+}

--- a/src/components/notifications.tsx
+++ b/src/components/notifications.tsx
@@ -2,10 +2,11 @@
 
 import { useEffect, useRef, useState } from "react";
 import Link from "next/link";
-import { AlertTriangle, Bell, BellRing, Clock, Coins, Plug, Webhook } from "lucide-react";
+import { AlertTriangle, Bell, BellRing, Clock, Coins, MoonStar, Plug, Webhook } from "lucide-react";
 import { useLive } from "@/components/live-provider";
 import { useT } from "@/lib/i18n";
 import { relativeTime } from "@/lib/format";
+import { inQuietHours, isCritical, type QuietConfig } from "@/lib/quiet";
 import type { AlertItem } from "@/lib/alerts";
 
 const DESKTOP_KEY = "mc-desktop-notif";
@@ -27,6 +28,16 @@ export function Notifications() {
   const [desktop, setDesktop] = useState(false);
   const seenMaxId = useRef<number | null>(null);
   const desktopRef = useRef(false);
+  const quietRef = useRef<QuietConfig>({ enabled: false, start: "22:00", end: "07:00" });
+
+  useEffect(() => {
+    fetch("/api/alerts/quiet")
+      .then((r) => r.json())
+      .then((d: QuietConfig) => {
+        quietRef.current = d;
+      })
+      .catch(() => {});
+  }, [tick]);
 
   useEffect(() => {
     desktopRef.current = desktop;
@@ -63,7 +74,13 @@ export function Notifications() {
             seenMaxId.current = maxId; // first load: don't toast historical alerts
           } else if (maxId > seenMaxId.current) {
             const newest = d.alerts[0];
-            if (newest && !newest.read) {
+            const q = quietRef.current;
+            const suppressed =
+              !!newest &&
+              q.enabled &&
+              !isCritical(newest.type) &&
+              inQuietHours(q.start, q.end, new Date());
+            if (newest && !newest.read && !suppressed) {
               setToast(newest.message);
               setTimeout(() => setToast(null), 5000);
               // Bridge to a native (Electron/OS) notification when enabled.
@@ -199,6 +216,7 @@ export function Notifications() {
                 })}
               </ul>
             )}
+            <QuietConfig t={t} />
             <WebhookConfig t={t} />
           </div>
         )}
@@ -213,6 +231,92 @@ export function Notifications() {
         </div>
       )}
     </>
+  );
+}
+
+function QuietConfig({ t }: { t: (k: string) => string }) {
+  const [open, setOpen] = useState(false);
+  const [enabled, setEnabled] = useState(false);
+  const [start, setStart] = useState("22:00");
+  const [end, setEnd] = useState("07:00");
+  const [saved, setSaved] = useState(false);
+
+  const openConfig = () => {
+    setOpen((o) => !o);
+    if (!open) {
+      fetch("/api/alerts/quiet")
+        .then((r) => r.json())
+        .then((d: QuietConfig) => {
+          setEnabled(Boolean(d.enabled));
+          setStart(d.start ?? "22:00");
+          setEnd(d.end ?? "07:00");
+        })
+        .catch(() => {});
+    }
+  };
+
+  const save = () => {
+    fetch("/api/alerts/quiet", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ enabled, start, end }),
+    })
+      .then(() => {
+        setSaved(true);
+        setTimeout(() => setSaved(false), 1500);
+      })
+      .catch(() => {});
+  };
+
+  return (
+    <div className="border-t border-panel-border">
+      <button
+        type="button"
+        onClick={openConfig}
+        className="flex w-full items-center gap-1.5 px-3 py-2 text-left text-[11px] text-muted transition-colors hover:text-foreground"
+      >
+        <MoonStar className="h-3.5 w-3.5" />
+        {t("quiet.title")}
+      </button>
+      {open && (
+        <div className="space-y-2 px-3 pb-3">
+          <label className="flex items-center gap-2 text-[11px] text-foreground">
+            <input type="checkbox" checked={enabled} onChange={(e) => setEnabled(e.target.checked)} className="h-3.5 w-3.5 accent-[var(--color-accent)]" />
+            {t("quiet.enable")}
+          </label>
+          <div className="flex items-center gap-2">
+            <label className="flex flex-1 items-center gap-1.5 text-[11px] text-muted">
+              {t("quiet.start")}
+              <input
+                type="time"
+                value={start}
+                onChange={(e) => setStart(e.target.value)}
+                aria-label={t("quiet.start")}
+                className="w-full rounded-md border border-panel-border bg-background/40 px-2 py-1 text-[11px] text-foreground outline-none focus:border-accent"
+              />
+            </label>
+            <label className="flex flex-1 items-center gap-1.5 text-[11px] text-muted">
+              {t("quiet.end")}
+              <input
+                type="time"
+                value={end}
+                onChange={(e) => setEnd(e.target.value)}
+                aria-label={t("quiet.end")}
+                className="w-full rounded-md border border-panel-border bg-background/40 px-2 py-1 text-[11px] text-foreground outline-none focus:border-accent"
+              />
+            </label>
+          </div>
+          <button
+            type="button"
+            onClick={save}
+            className="w-full rounded-md border border-accent/40 bg-accent/10 py-1 text-[11px] text-accent transition-colors hover:bg-accent/20"
+          >
+            {saved ? t("quiet.saved") : t("quiet.save")}
+          </button>
+          <p className="text-[10px] text-muted/70">{t("quiet.hint")}</p>
+        </div>
+      )}
+    </div>
   );
 }
 

--- a/src/lib/demo.ts
+++ b/src/lib/demo.ts
@@ -949,6 +949,7 @@ export function installDemoBackend() {
     if (path.endsWith("/api/session-duration")) return json(demoSessionDuration());
     if (path.endsWith("/api/plugins/config")) return json({ config: {} });
     if (path.includes("/api/alerts/webhook")) return json({ url: "", enabled: false });
+    if (path.includes("/api/alerts/quiet")) return json({ enabled: false, start: "22:00", end: "07:00" });
     if (path.endsWith("/api/alerts")) return json(demoAlerts());
     if (path.endsWith("/api/anomaly")) return json(demoAnomaly());
     if (path.endsWith("/api/reliability")) return json(demoReliability());

--- a/src/lib/i18n.tsx
+++ b/src/lib/i18n.tsx
@@ -296,6 +296,14 @@ const DE: Record<string, string> = {
   "webhook.saved": "Gespeichert!",
   "webhook.hint": "Standardmäßig aus. Sendet bei Alarm nur an diese URL.",
 
+  "quiet.title": "Ruhezeiten",
+  "quiet.enable": "Ruhezeiten aktivieren",
+  "quiet.start": "Von",
+  "quiet.end": "Bis",
+  "quiet.save": "Speichern",
+  "quiet.saved": "Gespeichert!",
+  "quiet.hint": "Unterdrückt unkritische Hinweise im Zeitfenster. Fehler-Spitzen und Budget-Alarme kommen immer durch.",
+
   "facets.project": "Projekt-Filter",
   "facets.allProjects": "Alle Projekte",
   "facets.status": "Status-Filter",
@@ -704,6 +712,14 @@ const EN: Record<string, string> = {
   "webhook.save": "Save",
   "webhook.saved": "Saved!",
   "webhook.hint": "Off by default. Only ever posts to this URL on an alert.",
+
+  "quiet.title": "Quiet hours",
+  "quiet.enable": "Enable quiet hours",
+  "quiet.start": "From",
+  "quiet.end": "To",
+  "quiet.save": "Save",
+  "quiet.saved": "Saved!",
+  "quiet.hint": "Mutes non-critical alerts during the window. Error spikes and budget alarms always come through.",
 
   "facets.project": "Project filter",
   "facets.allProjects": "All projects",

--- a/src/lib/ingest.ts
+++ b/src/lib/ingest.ts
@@ -11,6 +11,7 @@ import { parseMcpTool } from "./mcp";
 import { preparePrompt, type PreparedPrompt } from "./prompt";
 import { pruneAll } from "./retention";
 import { scheduleTranscriptUpdate } from "./transcript-sync";
+import { getQuietConfig, isSuppressed } from "./quiet";
 import { getWebhookConfig, sendAlertWebhook } from "./webhook";
 import type { EventRow, HookPayload, SessionRow, SessionStatus } from "./types";
 
@@ -407,7 +408,10 @@ export function ingest(headerEvent: string, payload: HookPayload): IngestResult 
     if (fired.length > 0) {
       const wh = getWebhookConfig(db);
       if (wh.enabled && wh.url) {
+        const quiet = getQuietConfig(db);
+        const at = new Date();
         for (const f of fired) {
+          if (isSuppressed(f.type, quiet, at)) continue; // quiet hours: skip non-critical
           void sendAlertWebhook(wh.url, f.message).catch((err) => log.error("webhook failed", err));
         }
       }

--- a/src/lib/quiet.test.ts
+++ b/src/lib/quiet.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { inQuietHours, isCritical, isSuppressed } from "@/lib/quiet";
+
+const at = (h: number, m = 0) => new Date(2026, 4, 24, h, m, 0);
+
+describe("inQuietHours", () => {
+  it("handles a same-day window", () => {
+    expect(inQuietHours("09:00", "17:00", at(12))).toBe(true);
+    expect(inQuietHours("09:00", "17:00", at(18))).toBe(false);
+  });
+
+  it("handles an overnight window", () => {
+    expect(inQuietHours("22:00", "07:00", at(23))).toBe(true);
+    expect(inQuietHours("22:00", "07:00", at(3))).toBe(true);
+    expect(inQuietHours("22:00", "07:00", at(12))).toBe(false);
+  });
+
+  it("is never quiet for empty/equal/invalid windows", () => {
+    expect(inQuietHours("08:00", "08:00", at(8))).toBe(false);
+    expect(inQuietHours("", "07:00", at(3))).toBe(false);
+    expect(inQuietHours("25:00", "07:00", at(3))).toBe(false);
+  });
+});
+
+describe("isCritical", () => {
+  it("marks error spikes and cost projections critical", () => {
+    expect(isCritical("error_spike")).toBe(true);
+    expect(isCritical("cost_projection")).toBe(true);
+    expect(isCritical("mcp_error")).toBe(false);
+    expect(isCritical("session_long")).toBe(false);
+  });
+});
+
+describe("isSuppressed", () => {
+  const cfg = { enabled: true, start: "22:00", end: "07:00" };
+  it("suppresses non-critical alerts during quiet hours only", () => {
+    expect(isSuppressed("session_long", cfg, at(23))).toBe(true);
+    expect(isSuppressed("session_long", cfg, at(12))).toBe(false);
+    expect(isSuppressed("error_spike", cfg, at(23))).toBe(false); // critical → never suppressed
+    expect(isSuppressed("session_long", { ...cfg, enabled: false }, at(23))).toBe(false);
+  });
+});

--- a/src/lib/quiet.ts
+++ b/src/lib/quiet.ts
@@ -1,0 +1,60 @@
+import type Database from "better-sqlite3";
+import { getConfig } from "./config";
+
+// Quiet hours: suppress NON-critical alerts (toast / desktop / webhook) during a
+// scheduled window. Alerts are still recorded to the inbox — quiet hours only
+// silence the intrusive channels. Pure time/severity helpers are unit-tested.
+
+export interface QuietConfig {
+  enabled: boolean;
+  start: string; // "HH:MM"
+  end: string; // "HH:MM"
+}
+
+const CRITICAL = new Set(["error_spike", "cost_projection"]);
+
+export function isCritical(type: string): boolean {
+  return CRITICAL.has(type);
+}
+
+function toMinutes(hhmm: string): number | null {
+  const m = /^(\d{1,2}):(\d{2})$/.exec(hhmm);
+  if (!m) return null;
+  const h = Number(m[1]);
+  const min = Number(m[2]);
+  if (h > 23 || min > 59) return null;
+  return h * 60 + min;
+}
+
+// Handles overnight windows (e.g. 22:00–07:00). Empty/equal/invalid → not quiet.
+export function inQuietHours(start: string, end: string, now: Date): boolean {
+  const s = toMinutes(start);
+  const e = toMinutes(end);
+  if (s == null || e == null || s === e) return false;
+  const cur = now.getHours() * 60 + now.getMinutes();
+  return s < e ? cur >= s && cur < e : cur >= s || cur < e;
+}
+
+// An alert is suppressed when quiet hours are active and it isn't critical.
+export function isSuppressed(type: string, cfg: QuietConfig, now: Date): boolean {
+  return cfg.enabled && !isCritical(type) && inQuietHours(cfg.start, cfg.end, now);
+}
+
+let cache: QuietConfig | null = null;
+let cacheAt = 0;
+
+export function getQuietConfig(db: Database.Database): QuietConfig {
+  const now = Date.now();
+  if (cache && now - cacheAt < 60_000) return cache;
+  cache = {
+    enabled: getConfig(db, "quiet.enabled") === "1",
+    start: getConfig(db, "quiet.start") ?? "22:00",
+    end: getConfig(db, "quiet.end") ?? "07:00",
+  };
+  cacheAt = now;
+  return cache;
+}
+
+export function invalidateQuietCache(): void {
+  cache = null;
+}


### PR DESCRIPTION
## Summary
- Adds a configurable **quiet-hours** window that mutes non-critical alert channels (toast, desktop, webhook) during the window, while always letting **critical** alerts (error spikes, budget alarms) through.
- New `src/lib/quiet.ts` (+ tests): `QuietConfig`, `isCritical`, `inQuietHours` (handles overnight wrap), `isSuppressed`, cached `getQuietConfig`/`invalidateQuietCache`.
- New `GET`/`POST /api/alerts/quiet` route (Zod `HH:MM` validation).
- `ingest.ts` webhook send loop now skips suppressed (non-critical during quiet hours) fires.
- `notifications.tsx`: new collapsible **Quiet hours** panel in the inbox (MoonStar icon, enable toggle + start/end time inputs); the new-alert toast/desktop bridge is gated by the same suppression rule.
- Demo patch for `/api/alerts/quiet`; `quiet.*` strings added in DE + EN.

## Test plan
- [x] `npm run lint`
- [x] `npx vitest run` (348 passing, incl. `quiet.test.ts`)
- [x] `npm run build`
- [x] `npm run test:e2e` (2 passing, 29 sections unchanged)

This completes **Phase G** of the roadmap.

https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk)_