### PR TITLE
Add optional OTLP receiver (second read-only ingress, off by default)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,15 @@ MC_HOOK_TOKEN=
 # Where Claude Code stores its data (transcripts + usage). Defaults to ~/.claude.
 # CLAUDE_DIR=/home/youruser/.claude
 
+# Optional SECOND read-only ingress: accept Claude Code's OpenTelemetry export
+# (OTLP/HTTP, JSON encoding) at /api/otlp/v1/{metrics,logs}. Off by default; set to 1
+# to enable, then point the exporter at the dashboard (local-only, like /api/ingest):
+#   CLAUDE_CODE_ENABLE_TELEMETRY=1
+#   OTEL_METRICS_EXPORTER=otlp  OTEL_LOGS_EXPORTER=otlp
+#   OTEL_EXPORTER_OTLP_PROTOCOL=http/json
+#   OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:3000/api/otlp
+# MC_OTLP_ENABLED=1
+
 # --- Optional operational knobs (sensible defaults; uncomment to override) ---
 # Where the dashboard DB lives (Electron sets this per-user). Default: ./data
 # MC_DATA_DIR=./data

--- a/src/app/api/otlp/v1/logs/route.ts
+++ b/src/app/api/otlp/v1/logs/route.ts
@@ -1,0 +1,41 @@
+import { NextResponse } from "next/server";
+import { insertLogs, otlpEnabled, parseLogs } from "@/lib/otlp";
+import { log } from "@/lib/log";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const MAX_BODY = 8 * 1024 * 1024;
+
+// Optional SECOND read-only ingress (OTLP/HTTP, JSON). Off unless MC_OTLP_ENABLED=1.
+// Point Claude Code's exporter at it with:
+//   export OTEL_EXPORTER_OTLP_PROTOCOL=http/json
+//   export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:3000/api/otlp
+// Same trust model as /api/ingest: the server binds 127.0.0.1, so this is local-only.
+export async function POST(req: Request) {
+  if (!otlpEnabled()) {
+    return NextResponse.json({ error: "otlp disabled" }, { status: 404 });
+  }
+  const declared = Number(req.headers.get("content-length"));
+  if (Number.isFinite(declared) && declared > MAX_BODY) {
+    return NextResponse.json({ error: "payload too large" }, { status: 413 });
+  }
+  let body: unknown;
+  try {
+    const text = await req.text();
+    if (text.length > MAX_BODY) {
+      return NextResponse.json({ error: "payload too large" }, { status: 413 });
+    }
+    body = text ? JSON.parse(text) : {};
+  } catch {
+    return NextResponse.json({ error: "invalid json" }, { status: 400 });
+  }
+  try {
+    insertLogs(parseLogs(body));
+    // OTLP/HTTP success: an (empty) ExportLogsServiceResponse.
+    return NextResponse.json({ partialSuccess: {} });
+  } catch (err) {
+    log.error("/api/otlp/v1/logs failed", err);
+    return NextResponse.json({ error: "store failed" }, { status: 500 });
+  }
+}

--- a/src/app/api/otlp/v1/metrics/route.ts
+++ b/src/app/api/otlp/v1/metrics/route.ts
@@ -1,0 +1,41 @@
+import { NextResponse } from "next/server";
+import { insertMetrics, otlpEnabled, parseMetrics } from "@/lib/otlp";
+import { log } from "@/lib/log";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const MAX_BODY = 8 * 1024 * 1024;
+
+// Optional SECOND read-only ingress (OTLP/HTTP, JSON). Off unless MC_OTLP_ENABLED=1.
+// Point Claude Code's exporter at it with:
+//   export OTEL_EXPORTER_OTLP_PROTOCOL=http/json
+//   export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:3000/api/otlp
+// Same trust model as /api/ingest: the server binds 127.0.0.1, so this is local-only.
+export async function POST(req: Request) {
+  if (!otlpEnabled()) {
+    return NextResponse.json({ error: "otlp disabled" }, { status: 404 });
+  }
+  const declared = Number(req.headers.get("content-length"));
+  if (Number.isFinite(declared) && declared > MAX_BODY) {
+    return NextResponse.json({ error: "payload too large" }, { status: 413 });
+  }
+  let body: unknown;
+  try {
+    const text = await req.text();
+    if (text.length > MAX_BODY) {
+      return NextResponse.json({ error: "payload too large" }, { status: 413 });
+    }
+    body = text ? JSON.parse(text) : {};
+  } catch {
+    return NextResponse.json({ error: "invalid json" }, { status: 400 });
+  }
+  try {
+    insertMetrics(parseMetrics(body));
+    // OTLP/HTTP success: an (empty) ExportMetricsServiceResponse.
+    return NextResponse.json({ partialSuccess: {} });
+  } catch (err) {
+    log.error("/api/otlp/v1/metrics failed", err);
+    return NextResponse.json({ error: "store failed" }, { status: 500 });
+  }
+}

--- a/src/lib/migrations-sql.mjs
+++ b/src/lib/migrations-sql.mjs
@@ -206,4 +206,36 @@ export const MIGRATIONS = [
     ('session_long', 120, 1, 'Long-running session'),
     ('cost_session', 5, 1, 'Session cost over budget');
   `,
+
+  // v16 — optional OTLP receiver (a SECOND read-only ingress, off by default).
+  // Claude Code's OpenTelemetry exporter can post metrics/logs here when MC_OTLP_ENABLED=1.
+  // Kept deliberately isolated from the hook-driven model: raw-ish rows land in their own
+  // tables so the OTLP path can never corrupt sessions/events. Mapping + reconcile with the
+  // core model happens in a later run; this run only receives and stores.
+  `
+  CREATE TABLE IF NOT EXISTS otlp_metric (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    received_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    ts          TEXT,
+    name        TEXT NOT NULL,
+    session_id  TEXT,
+    model       TEXT,
+    value       REAL NOT NULL DEFAULT 0,
+    attrs       TEXT
+  );
+  CREATE INDEX IF NOT EXISTS idx_otlp_metric_name ON otlp_metric(name);
+  CREATE INDEX IF NOT EXISTS idx_otlp_metric_session ON otlp_metric(session_id);
+  CREATE TABLE IF NOT EXISTS otlp_log (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    received_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    ts          TEXT,
+    name        TEXT NOT NULL,
+    session_id  TEXT,
+    model       TEXT,
+    body        TEXT,
+    attrs       TEXT
+  );
+  CREATE INDEX IF NOT EXISTS idx_otlp_log_name ON otlp_log(name);
+  CREATE INDEX IF NOT EXISTS idx_otlp_log_session ON otlp_log(session_id);
+  `,
 ];

--- a/src/lib/otlp.test.ts
+++ b/src/lib/otlp.test.ts
@@ -1,0 +1,172 @@
+import Database from "better-sqlite3";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  attrValue,
+  flattenAttributes,
+  insertLogs,
+  insertMetrics,
+  parseLogs,
+  parseMetrics,
+} from "@/lib/otlp";
+import { migrate } from "@/lib/migrations";
+
+let open: Database.Database | null = null;
+afterEach(() => {
+  open?.close();
+  open = null;
+});
+
+describe("attrValue", () => {
+  it("extracts each OTLP scalar shape and coerces stringly numbers", () => {
+    expect(attrValue({ stringValue: "input" })).toBe("input");
+    expect(attrValue({ intValue: "5000" })).toBe(5000);
+    expect(attrValue({ doubleValue: "0.0342" })).toBe(0.0342);
+    expect(attrValue({ boolValue: true })).toBe(true);
+    expect(attrValue({})).toBeNull();
+    expect(attrValue("nope")).toBeNull();
+  });
+});
+
+describe("flattenAttributes", () => {
+  it("builds a plain object and skips keyless/empty entries", () => {
+    const out = flattenAttributes([
+      { key: "model", value: { stringValue: "claude-sonnet-4-6" } },
+      { key: "input_tokens", value: { intValue: "1250" } },
+      { value: { stringValue: "orphan" } },
+      { key: "blank", value: {} },
+    ]);
+    expect(out).toEqual({ model: "claude-sonnet-4-6", input_tokens: 1250 });
+  });
+});
+
+const metricsBody = {
+  resourceMetrics: [
+    {
+      resource: { attributes: [{ key: "service.name", value: { stringValue: "claude-code" } }] },
+      scopeMetrics: [
+        {
+          scope: { name: "com.anthropic.claude_code" },
+          metrics: [
+            {
+              name: "claude_code.token.usage",
+              sum: {
+                dataPoints: [
+                  {
+                    attributes: [
+                      { key: "type", value: { stringValue: "input" } },
+                      { key: "model", value: { stringValue: "claude-sonnet-4-6" } },
+                      { key: "session.id", value: { stringValue: "sess-1" } },
+                    ],
+                    asInt: "5000",
+                    timeUnixNano: "1700000000000000000",
+                  },
+                ],
+              },
+            },
+            {
+              name: "claude_code.cost.usage",
+              sum: {
+                dataPoints: [{ attributes: [{ key: "session.id", value: { stringValue: "sess-1" } }], asDouble: "0.0342" }],
+              },
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+describe("parseMetrics", () => {
+  it("flattens sum/gauge data points and promotes session + model", () => {
+    const rows = parseMetrics(metricsBody);
+    expect(rows).toHaveLength(2);
+    const token = rows[0];
+    expect(token.name).toBe("claude_code.token.usage");
+    expect(token.sessionId).toBe("sess-1");
+    expect(token.model).toBe("claude-sonnet-4-6");
+    expect(token.value).toBe(5000);
+    expect(token.ts).toBe(new Date(1700000000000).toISOString());
+    expect(token.attrs["service.name"]).toBe("claude-code"); // resource attrs merged in
+
+    const cost = rows[1];
+    expect(cost.value).toBeCloseTo(0.0342);
+    expect(cost.model).toBeNull();
+    expect(cost.ts).toBeNull();
+  });
+
+  it("returns [] for empty or malformed bodies", () => {
+    expect(parseMetrics({})).toEqual([]);
+    expect(parseMetrics(null)).toEqual([]);
+    expect(parseMetrics({ resourceMetrics: "x" })).toEqual([]);
+  });
+});
+
+const logsBody = {
+  resourceLogs: [
+    {
+      resource: { attributes: [{ key: "service.name", value: { stringValue: "claude-code" } }] },
+      scopeLogs: [
+        {
+          logRecords: [
+            {
+              timeUnixNano: "1700000000000000000",
+              body: { stringValue: "api_request" },
+              attributes: [
+                { key: "event.name", value: { stringValue: "api_request" } },
+                { key: "model", value: { stringValue: "claude-sonnet-4-6" } },
+                { key: "session.id", value: { stringValue: "sess-1" } },
+                { key: "output_tokens", value: { intValue: "340" } },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+describe("parseLogs", () => {
+  it("uses event.name, promotes session/model, and keeps the body", () => {
+    const rows = parseLogs(logsBody);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].name).toBe("api_request");
+    expect(rows[0].sessionId).toBe("sess-1");
+    expect(rows[0].model).toBe("claude-sonnet-4-6");
+    expect(rows[0].body).toBe("api_request");
+    expect(rows[0].attrs.output_tokens).toBe(340);
+  });
+
+  it("falls back to the body when event.name is absent, and skips nameless records", () => {
+    const fallback = parseLogs({
+      resourceLogs: [{ scopeLogs: [{ logRecords: [{ body: { stringValue: "user_prompt" } }, {}] }] }],
+    });
+    expect(fallback).toHaveLength(1);
+    expect(fallback[0].name).toBe("user_prompt");
+  });
+});
+
+describe("insert", () => {
+  it("writes parsed rows into the isolated otlp tables", () => {
+    const db = (open = new Database(":memory:"));
+    migrate(db);
+    expect(insertMetrics(parseMetrics(metricsBody), db)).toBe(2);
+    expect(insertLogs(parseLogs(logsBody), db)).toBe(1);
+
+    const m = db.prepare("SELECT name, session_id, value FROM otlp_metric ORDER BY id").all() as {
+      name: string;
+      session_id: string;
+      value: number;
+    }[];
+    expect(m[0]).toMatchObject({ name: "claude_code.token.usage", session_id: "sess-1", value: 5000 });
+
+    const l = db.prepare("SELECT name, model FROM otlp_log").get() as { name: string; model: string };
+    expect(l).toMatchObject({ name: "api_request", model: "claude-sonnet-4-6" });
+  });
+
+  it("no-ops on empty input", () => {
+    const db = (open = new Database(":memory:"));
+    migrate(db);
+    expect(insertMetrics([], db)).toBe(0);
+    expect(insertLogs([], db)).toBe(0);
+  });
+});

--- a/src/lib/otlp.ts
+++ b/src/lib/otlp.ts
@@ -1,0 +1,164 @@
+import type Database from "better-sqlite3";
+import { db as defaultDb } from "./db";
+
+// Optional SECOND read-only ingress: parse Claude Code's OpenTelemetry export
+// (OTLP/HTTP, JSON encoding) into flat rows for the isolated otlp_* tables. These
+// functions are pure (no DB) except the insert helpers, so they're easy to test and
+// can never reach into the hook-driven model. Mapping/reconcile is a later run.
+
+export interface OtlpMetricRow {
+  ts: string | null;
+  name: string;
+  sessionId: string | null;
+  model: string | null;
+  value: number;
+  attrs: Record<string, string | number | boolean>;
+}
+
+export interface OtlpLogRow {
+  ts: string | null;
+  name: string;
+  sessionId: string | null;
+  model: string | null;
+  body: string | null;
+  attrs: Record<string, string | number | boolean>;
+}
+
+export function otlpEnabled(): boolean {
+  return process.env.MC_OTLP_ENABLED === "1";
+}
+
+function asRecord(v: unknown): Record<string, unknown> | null {
+  return v && typeof v === "object" && !Array.isArray(v) ? (v as Record<string, unknown>) : null;
+}
+
+function asArray(v: unknown): unknown[] {
+  return Array.isArray(v) ? v : [];
+}
+
+// Extract a scalar from an OTLP AnyValue ({ stringValue | intValue | doubleValue | boolValue }).
+// intValue/asInt arrive as strings on the wire, so coerce numerics defensively.
+export function attrValue(v: unknown): string | number | boolean | null {
+  const o = asRecord(v);
+  if (!o) return null;
+  if (typeof o.stringValue === "string") return o.stringValue;
+  if (o.intValue !== undefined) {
+    const n = Number(o.intValue);
+    return Number.isFinite(n) ? n : null;
+  }
+  if (o.doubleValue !== undefined) {
+    const n = Number(o.doubleValue);
+    return Number.isFinite(n) ? n : null;
+  }
+  if (typeof o.boolValue === "boolean") return o.boolValue;
+  return null;
+}
+
+// Flatten an OTLP attributes array ([{ key, value }]) into a plain object.
+export function flattenAttributes(attrs: unknown): Record<string, string | number | boolean> {
+  const out: Record<string, string | number | boolean> = {};
+  for (const a of asArray(attrs)) {
+    const kv = asRecord(a);
+    if (!kv || typeof kv.key !== "string") continue;
+    const val = attrValue(kv.value);
+    if (val !== null) out[kv.key] = val;
+  }
+  return out;
+}
+
+function nanoToIso(ts: unknown): string | null {
+  if (ts === undefined || ts === null) return null;
+  const n = Number(ts);
+  if (!Number.isFinite(n) || n <= 0) return null;
+  return new Date(n / 1e6).toISOString();
+}
+
+function promote(attrs: Record<string, string | number | boolean>, key: string): string | null {
+  const v = attrs[key];
+  return v === undefined ? null : String(v);
+}
+
+// resourceMetrics[].scopeMetrics[].metrics[].(sum|gauge).dataPoints[] -> rows.
+export function parseMetrics(body: unknown): OtlpMetricRow[] {
+  const rows: OtlpMetricRow[] = [];
+  for (const rm of asArray(asRecord(body)?.resourceMetrics)) {
+    const rmo = asRecord(rm);
+    const resourceAttrs = flattenAttributes(asRecord(rmo?.resource)?.attributes);
+    for (const sm of asArray(rmo?.scopeMetrics)) {
+      for (const m of asArray(asRecord(sm)?.metrics)) {
+        const mo = asRecord(m);
+        if (!mo || typeof mo.name !== "string") continue;
+        const points = [
+          ...asArray(asRecord(mo.sum)?.dataPoints),
+          ...asArray(asRecord(mo.gauge)?.dataPoints),
+        ];
+        for (const dp of points) {
+          const dpo = asRecord(dp);
+          if (!dpo) continue;
+          const attrs = { ...resourceAttrs, ...flattenAttributes(dpo.attributes) };
+          const raw = dpo.asInt !== undefined ? Number(dpo.asInt) : dpo.asDouble !== undefined ? Number(dpo.asDouble) : 0;
+          rows.push({
+            ts: nanoToIso(dpo.timeUnixNano),
+            name: mo.name,
+            sessionId: promote(attrs, "session.id"),
+            model: promote(attrs, "model"),
+            value: Number.isFinite(raw) ? raw : 0,
+            attrs,
+          });
+        }
+      }
+    }
+  }
+  return rows;
+}
+
+// resourceLogs[].scopeLogs[].logRecords[] -> rows. The event name is the
+// event.name attribute (Claude Code's convention), falling back to the log body.
+export function parseLogs(body: unknown): OtlpLogRow[] {
+  const rows: OtlpLogRow[] = [];
+  for (const rl of asArray(asRecord(body)?.resourceLogs)) {
+    const rlo = asRecord(rl);
+    const resourceAttrs = flattenAttributes(asRecord(rlo?.resource)?.attributes);
+    for (const sl of asArray(rlo?.scopeLogs)) {
+      for (const lr of asArray(asRecord(sl)?.logRecords)) {
+        const lro = asRecord(lr);
+        if (!lro) continue;
+        const attrs = { ...resourceAttrs, ...flattenAttributes(lro.attributes) };
+        const bodyVal = attrValue(lro.body);
+        const name = promote(attrs, "event.name") ?? (typeof bodyVal === "string" ? bodyVal : null);
+        if (!name) continue;
+        rows.push({
+          ts: nanoToIso(lro.timeUnixNano),
+          name,
+          sessionId: promote(attrs, "session.id"),
+          model: promote(attrs, "model"),
+          body: bodyVal !== null ? String(bodyVal) : null,
+          attrs,
+        });
+      }
+    }
+  }
+  return rows;
+}
+
+export function insertMetrics(rows: OtlpMetricRow[], database: Database.Database = defaultDb): number {
+  if (rows.length === 0) return 0;
+  const stmt = database.prepare(
+    "INSERT INTO otlp_metric (ts, name, session_id, model, value, attrs) VALUES (?, ?, ?, ?, ?, ?)",
+  );
+  database.transaction((rs: OtlpMetricRow[]) => {
+    for (const r of rs) stmt.run(r.ts, r.name, r.sessionId, r.model, r.value, JSON.stringify(r.attrs));
+  })(rows);
+  return rows.length;
+}
+
+export function insertLogs(rows: OtlpLogRow[], database: Database.Database = defaultDb): number {
+  if (rows.length === 0) return 0;
+  const stmt = database.prepare(
+    "INSERT INTO otlp_log (ts, name, session_id, model, body, attrs) VALUES (?, ?, ?, ?, ?, ?)",
+  );
+  database.transaction((rs: OtlpLogRow[]) => {
+    for (const r of rs) stmt.run(r.ts, r.name, r.sessionId, r.model, r.body, JSON.stringify(r.attrs));
+  })(rows);
+  return rows.length;
+}


### PR DESCRIPTION
## Summary
- Adds an **optional, opt-in, read-only OTLP receiver** — a *second* ingress alongside `/api/ingest` — that accepts Claude Code's OpenTelemetry export (OTLP/HTTP, JSON encoding) at `POST /api/otlp/v1/metrics` and `POST /api/otlp/v1/logs`.
- **Off by default**: both routes return `404` unless `MC_OTLP_ENABLED=1`. Local-only, same trust model as `/api/ingest` (server binds `127.0.0.1`).
- **Kept isolated** from the hook-driven model: parsed metrics/logs land in their own `otlp_metric` / `otlp_log` tables (migration v16), so the OTLP path can never corrupt sessions/events. Mapping onto the core data model + reconcile is the next run.
- New `src/lib/otlp.ts`: pure parsers (`parseMetrics`, `parseLogs`, `attrValue`, `flattenAttributes`) that flatten OTLP JSON and promote `session.id` / `model` / event name / value / timestamp, plus `insertMetrics` / `insertLogs` transactional writers. Dependency-free (JSON encoding — no protobuf).
- `.env.example` documents `MC_OTLP_ENABLED` and the exporter env to point Claude Code at the dashboard.

### How to use
```bash
export CLAUDE_CODE_ENABLE_TELEMETRY=1
export OTEL_METRICS_EXPORTER=otlp OTEL_LOGS_EXPORTER=otlp
export OTEL_EXPORTER_OTLP_PROTOCOL=http/json
export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:3000/api/otlp
# and run the dashboard with MC_OTLP_ENABLED=1
```

## Test plan
- [x] `npm run lint`
- [x] `npx vitest run` (356 passing, incl. new `otlp.test.ts` — 8 tests)
- [x] `npm run build` (both `/api/otlp/v1/*` routes registered)
- [x] `npm run test:e2e` (2 passing, 29 sections unchanged)

First run of **Phase H** (Integrationen & weitere Datenquellen).

https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk)_