### PR TITLE
Map OTLP token/cost/latency onto the model and reconcile cost

### DIFF
--- a/src/app/api/otlp/summary/route.ts
+++ b/src/app/api/otlp/summary/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from "next/server";
+import { db } from "@/lib/db";
+import { otlpAvailable, otlpSessionSummaries } from "@/lib/otlp-map";
+import { log } from "@/lib/log";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+// Read path for the OTLP-derived per-session mapping (cost, tokens, latency).
+// Returns an empty, available:false payload when the optional receiver was never fed.
+export async function GET() {
+  try {
+    const sessions = otlpSessionSummaries(db);
+    const totals = sessions.reduce(
+      (acc, s) => {
+        acc.costUsd += s.costUsd;
+        acc.tokens += s.tokens.total;
+        acc.requests += s.latency.count;
+        return acc;
+      },
+      { costUsd: 0, tokens: 0, requests: 0 },
+    );
+    return NextResponse.json({ available: otlpAvailable(db), sessions, totals });
+  } catch (err) {
+    log.error("/api/otlp/summary failed", err);
+    return NextResponse.json({ available: false, sessions: [], totals: { costUsd: 0, tokens: 0, requests: 0 } });
+  }
+}

--- a/src/app/api/usage/reconcile/route.ts
+++ b/src/app/api/usage/reconcile/route.ts
@@ -1,13 +1,14 @@
 import { NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { getSessionUsage } from "@/lib/ccusage";
+import { otlpAvailable, otlpCostMap } from "@/lib/otlp-map";
 import { reconcileSessions } from "@/lib/reconcile";
 import { log } from "@/lib/log";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-// Per-session cost reconciled against ccusage (preferred when available), with the
+// Per-session cost reconciled across sources (ccusage > otlp > transcript), with the
 // transcript estimate and the discrepancy alongside.
 export async function GET() {
   try {
@@ -16,11 +17,12 @@ export async function GET() {
       .all() as { id: string; cost_usd: number }[];
     const usage = await getSessionUsage();
     return NextResponse.json({
-      sessions: reconcileSessions(sessions, usage.sessions),
+      sessions: reconcileSessions(sessions, usage.sessions, otlpCostMap(db)),
       ccusageAvailable: usage.available,
+      otlpAvailable: otlpAvailable(db),
     });
   } catch (err) {
     log.error("/api/usage/reconcile failed", err);
-    return NextResponse.json({ sessions: [], ccusageAvailable: false });
+    return NextResponse.json({ sessions: [], ccusageAvailable: false, otlpAvailable: false });
   }
 }

--- a/src/lib/otlp-map.test.ts
+++ b/src/lib/otlp-map.test.ts
@@ -1,0 +1,116 @@
+import Database from "better-sqlite3";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  aggregateCost,
+  aggregateLatency,
+  aggregateTokens,
+  otlpAvailable,
+  otlpCostMap,
+  otlpSessionSummaries,
+  percentile,
+} from "@/lib/otlp-map";
+import { insertLogs, insertMetrics, type OtlpLogRow, type OtlpMetricRow } from "@/lib/otlp";
+import { migrate } from "@/lib/migrations";
+
+let open: Database.Database | null = null;
+afterEach(() => {
+  open?.close();
+  open = null;
+});
+
+const metric = (
+  sessionId: string | null,
+  name: string,
+  value: number,
+  attrs: Record<string, string | number | boolean> = {},
+): OtlpMetricRow => ({ ts: null, name, sessionId, model: null, value, attrs });
+
+const logRow = (
+  sessionId: string | null,
+  name: string,
+  attrs: Record<string, string | number | boolean> = {},
+): OtlpLogRow => ({ ts: null, name, sessionId, model: null, body: null, attrs });
+
+describe("aggregateCost", () => {
+  it("sums cost.usage per session and ignores other metrics/sessionless rows", () => {
+    const out = aggregateCost([
+      metric("s1", "claude_code.cost.usage", 0.5),
+      metric("s1", "claude_code.cost.usage", 0.25),
+      metric("s2", "claude_code.cost.usage", 1),
+      metric("s1", "claude_code.token.usage", 100),
+      metric(null, "claude_code.cost.usage", 9),
+    ]);
+    expect(out.get("s1")).toBeCloseTo(0.75);
+    expect(out.get("s2")).toBe(1);
+    expect(out.size).toBe(2);
+  });
+});
+
+describe("aggregateTokens", () => {
+  it("splits token.usage by the type attribute and tracks the total", () => {
+    const out = aggregateTokens([
+      metric("s1", "claude_code.token.usage", 1000, { type: "input" }),
+      metric("s1", "claude_code.token.usage", 200, { type: "output" }),
+      metric("s1", "claude_code.token.usage", 50, { type: "cacheRead" }),
+      metric("s1", "claude_code.token.usage", 10, { type: "cacheCreation" }),
+    ]);
+    expect(out.get("s1")).toEqual({ input: 1000, output: 200, cacheRead: 50, cacheCreation: 10, total: 1260 });
+  });
+});
+
+describe("percentile", () => {
+  it("uses nearest-rank and handles the empty case", () => {
+    expect(percentile([], 95)).toBe(0);
+    expect(percentile([10, 20, 30, 40, 50, 60, 70, 80, 90, 100], 95)).toBe(100);
+    expect(percentile([5], 50)).toBe(5);
+  });
+});
+
+describe("aggregateLatency", () => {
+  it("counts api_request events and computes avg + p95 from duration_ms", () => {
+    const rows = [
+      logRow("s1", "api_request", { duration_ms: 100 }),
+      logRow("s1", "api_request", { duration_ms: 300 }),
+      logRow("s1", "tool_result", { duration_ms: 9999 }),
+      logRow("s1", "api_request", { duration_ms: -1 }),
+    ];
+    const out = aggregateLatency(rows);
+    expect(out.get("s1")).toEqual({ count: 2, avgMs: 200, p95Ms: 300 });
+  });
+});
+
+describe("DB readers", () => {
+  it("maps stored OTLP rows into per-session summaries", () => {
+    const db = (open = new Database(":memory:"));
+    migrate(db);
+    insertMetrics(
+      [
+        metric("s1", "claude_code.cost.usage", 0.4),
+        metric("s1", "claude_code.token.usage", 1000, { type: "input" }),
+        metric("s1", "claude_code.token.usage", 250, { type: "output" }),
+      ],
+      db,
+    );
+    insertLogs([logRow("s1", "api_request", { duration_ms: 120 })], db);
+
+    const summaries = otlpSessionSummaries(db);
+    expect(summaries).toHaveLength(1);
+    expect(summaries[0]).toMatchObject({
+      sessionId: "s1",
+      costUsd: 0.4,
+      tokens: { input: 1000, output: 250, total: 1250 },
+      latency: { count: 1, avgMs: 120, p95Ms: 120 },
+    });
+
+    expect(otlpCostMap(db).get("s1")).toBeCloseTo(0.4);
+    expect(otlpAvailable(db)).toBe(true);
+  });
+
+  it("reports unavailable with no rows", () => {
+    const db = (open = new Database(":memory:"));
+    migrate(db);
+    expect(otlpAvailable(db)).toBe(false);
+    expect(otlpSessionSummaries(db)).toEqual([]);
+    expect(otlpCostMap(db).size).toBe(0);
+  });
+});

--- a/src/lib/otlp-map.ts
+++ b/src/lib/otlp-map.ts
@@ -1,0 +1,162 @@
+import type Database from "better-sqlite3";
+import { db as defaultDb } from "./db";
+import type { OtlpLogRow, OtlpMetricRow } from "./otlp";
+
+// Map the isolated OTLP rows (received in a prior run) onto the dashboard's data
+// model: per-session cost, token breakdown, and request latency. Pure aggregators
+// (testable) plus thin DB readers. The OTLP path stays read-only and isolated — this
+// only reads the otlp_* tables; the per-session cost feeds the cost reconciliation.
+
+export const OTLP_COST_METRIC = "claude_code.cost.usage";
+export const OTLP_TOKEN_METRIC = "claude_code.token.usage";
+export const OTLP_API_REQUEST = "api_request"; // log event.name
+
+export interface OtlpTokens {
+  input: number;
+  output: number;
+  cacheRead: number;
+  cacheCreation: number;
+  total: number;
+}
+
+export interface OtlpLatency {
+  count: number;
+  avgMs: number;
+  p95Ms: number;
+}
+
+export interface OtlpSessionSummary {
+  sessionId: string;
+  costUsd: number;
+  tokens: OtlpTokens;
+  latency: OtlpLatency;
+}
+
+function emptyTokens(): OtlpTokens {
+  return { input: 0, output: 0, cacheRead: 0, cacheCreation: 0, total: 0 };
+}
+
+function emptyLatency(): OtlpLatency {
+  return { count: 0, avgMs: 0, p95Ms: 0 };
+}
+
+export function aggregateCost(rows: Pick<OtlpMetricRow, "sessionId" | "name" | "value">[]): Map<string, number> {
+  const out = new Map<string, number>();
+  for (const r of rows) {
+    if (r.name !== OTLP_COST_METRIC || !r.sessionId) continue;
+    out.set(r.sessionId, (out.get(r.sessionId) ?? 0) + r.value);
+  }
+  return out;
+}
+
+export function aggregateTokens(
+  rows: Pick<OtlpMetricRow, "sessionId" | "name" | "value" | "attrs">[],
+): Map<string, OtlpTokens> {
+  const out = new Map<string, OtlpTokens>();
+  for (const r of rows) {
+    if (r.name !== OTLP_TOKEN_METRIC || !r.sessionId) continue;
+    const t = out.get(r.sessionId) ?? emptyTokens();
+    switch (String(r.attrs?.type ?? "")) {
+      case "input":
+        t.input += r.value;
+        break;
+      case "output":
+        t.output += r.value;
+        break;
+      case "cacheRead":
+        t.cacheRead += r.value;
+        break;
+      case "cacheCreation":
+        t.cacheCreation += r.value;
+        break;
+    }
+    t.total += r.value;
+    out.set(r.sessionId, t);
+  }
+  return out;
+}
+
+// Nearest-rank percentile (p in 0..100). Empty input -> 0.
+export function percentile(values: number[], p: number): number {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const idx = Math.min(sorted.length - 1, Math.max(0, Math.ceil((p / 100) * sorted.length) - 1));
+  return sorted[idx];
+}
+
+export function aggregateLatency(rows: Pick<OtlpLogRow, "sessionId" | "name" | "attrs">[]): Map<string, OtlpLatency> {
+  const samples = new Map<string, number[]>();
+  for (const r of rows) {
+    if (r.name !== OTLP_API_REQUEST || !r.sessionId) continue;
+    const d = Number(r.attrs?.duration_ms);
+    if (!Number.isFinite(d) || d < 0) continue;
+    const arr = samples.get(r.sessionId) ?? [];
+    arr.push(d);
+    samples.set(r.sessionId, arr);
+  }
+  const out = new Map<string, OtlpLatency>();
+  for (const [sid, arr] of samples) {
+    const sum = arr.reduce((a, b) => a + b, 0);
+    out.set(sid, { count: arr.length, avgMs: sum / arr.length, p95Ms: percentile(arr, 95) });
+  }
+  return out;
+}
+
+interface RawMetric {
+  session_id: string | null;
+  name: string;
+  value: number;
+  attrs: string | null;
+}
+interface RawLog {
+  session_id: string | null;
+  name: string;
+  attrs: string | null;
+}
+
+function parseAttrs(s: string | null): Record<string, string | number | boolean> {
+  if (!s) return {};
+  try {
+    const v: unknown = JSON.parse(s);
+    return v && typeof v === "object" ? (v as Record<string, string | number | boolean>) : {};
+  } catch {
+    return {};
+  }
+}
+
+export function otlpSessionSummaries(database: Database.Database = defaultDb): OtlpSessionSummary[] {
+  const metricRows = (
+    database.prepare("SELECT session_id, name, value, attrs FROM otlp_metric WHERE session_id IS NOT NULL").all() as RawMetric[]
+  ).map((r) => ({ sessionId: r.session_id, name: r.name, value: r.value, attrs: parseAttrs(r.attrs) }));
+  const logRows = (
+    database.prepare("SELECT session_id, name, attrs FROM otlp_log WHERE session_id IS NOT NULL").all() as RawLog[]
+  ).map((r) => ({ sessionId: r.session_id, name: r.name, attrs: parseAttrs(r.attrs) }));
+
+  const cost = aggregateCost(metricRows);
+  const tokens = aggregateTokens(metricRows);
+  const latency = aggregateLatency(logRows);
+
+  const ids = new Set<string>([...cost.keys(), ...tokens.keys(), ...latency.keys()]);
+  return [...ids].map((sessionId) => ({
+    sessionId,
+    costUsd: cost.get(sessionId) ?? 0,
+    tokens: tokens.get(sessionId) ?? emptyTokens(),
+    latency: latency.get(sessionId) ?? emptyLatency(),
+  }));
+}
+
+// Per-session OTLP cost, for folding into the cost reconciliation.
+export function otlpCostMap(database: Database.Database = defaultDb): Map<string, number> {
+  const rows = database
+    .prepare("SELECT session_id, value FROM otlp_metric WHERE name = ? AND session_id IS NOT NULL")
+    .all(OTLP_COST_METRIC) as { session_id: string; value: number }[];
+  const out = new Map<string, number>();
+  for (const r of rows) out.set(r.session_id, (out.get(r.session_id) ?? 0) + r.value);
+  return out;
+}
+
+export function otlpAvailable(database: Database.Database = defaultDb): boolean {
+  const m = database.prepare("SELECT 1 FROM otlp_metric LIMIT 1").get();
+  const l = database.prepare("SELECT 1 FROM otlp_log LIMIT 1").get();
+  return Boolean(m || l);
+}

--- a/src/lib/reconcile.test.ts
+++ b/src/lib/reconcile.test.ts
@@ -15,22 +15,36 @@ const ccSession = (sessionId: string, costUsd: number): UsageSession => ({
 });
 
 describe("reconcileSession", () => {
-  it("prefers ccusage and reports the discrepancy", () => {
-    expect(reconcileSession("s1", 0.8, 1.0)).toEqual({
+  it("prefers ccusage over everything and reports the discrepancy", () => {
+    expect(reconcileSession("s1", 0.8, 1.0, 0.95)).toEqual({
       sessionId: "s1",
       transcriptUsd: 0.8,
       ccusageUsd: 1.0,
+      otlpUsd: 0.95,
       costUsd: 1.0,
       source: "ccusage",
       discrepancyUsd: expect.closeTo(0.2, 5),
     });
   });
 
-  it("falls back to the transcript estimate when ccusage is absent", () => {
+  it("prefers OTLP when ccusage is absent", () => {
+    expect(reconcileSession("s1", 0.8, null, 0.95)).toEqual({
+      sessionId: "s1",
+      transcriptUsd: 0.8,
+      ccusageUsd: null,
+      otlpUsd: 0.95,
+      costUsd: 0.95,
+      source: "otlp",
+      discrepancyUsd: expect.closeTo(0.15, 5),
+    });
+  });
+
+  it("falls back to the transcript estimate when no authoritative source exists", () => {
     expect(reconcileSession("s1", 0.8, null)).toEqual({
       sessionId: "s1",
       transcriptUsd: 0.8,
       ccusageUsd: null,
+      otlpUsd: null,
       costUsd: 0.8,
       source: "transcript",
       discrepancyUsd: null,
@@ -39,13 +53,16 @@ describe("reconcileSession", () => {
 });
 
 describe("reconcileSessions", () => {
-  it("joins sessions to ccusage by id", () => {
+  it("joins sessions to ccusage and the optional OTLP cost map by id", () => {
     const sessions = [
       { id: "s1", cost_usd: 0.8 },
       { id: "s2", cost_usd: 0.5 },
+      { id: "s3", cost_usd: 0.3 },
     ];
-    const result = reconcileSessions(sessions, [ccSession("s1", 1.0)]);
+    const otlp = new Map([["s2", 0.45]]);
+    const result = reconcileSessions(sessions, [ccSession("s1", 1.0)], otlp);
     expect(result[0]).toMatchObject({ source: "ccusage", costUsd: 1.0 });
-    expect(result[1]).toMatchObject({ source: "transcript", costUsd: 0.5, ccusageUsd: null });
+    expect(result[1]).toMatchObject({ source: "otlp", costUsd: 0.45, ccusageUsd: null, otlpUsd: 0.45 });
+    expect(result[2]).toMatchObject({ source: "transcript", costUsd: 0.3, otlpUsd: null });
   });
 });

--- a/src/lib/reconcile.ts
+++ b/src/lib/reconcile.ts
@@ -1,50 +1,60 @@
 import type { UsageSession } from "./ccusage";
 
-// Reconcile the transcript-derived per-session cost (a local estimate) against
-// ccusage's authoritative per-session cost: prefer ccusage when present, and
-// surface the discrepancy so the estimate can be sanity-checked.
-export type CostSource = "ccusage" | "transcript";
+// Reconcile the transcript-derived per-session cost (a local estimate) against the
+// two authoritative sources: ccusage (parsed from the official JSONL) and, when the
+// optional OTLP receiver is enabled, Claude Code's own self-reported cost.usage.
+// Preference order: ccusage > otlp > transcript. The discrepancy (preferred minus
+// our estimate) is surfaced so the estimate can be sanity-checked.
+export type CostSource = "ccusage" | "otlp" | "transcript";
 
 export interface SessionCost {
   sessionId: string;
   transcriptUsd: number;
   ccusageUsd: number | null;
+  otlpUsd: number | null;
   costUsd: number; // preferred figure
   source: CostSource;
-  discrepancyUsd: number | null; // ccusage - transcript, null when ccusage absent
+  discrepancyUsd: number | null; // preferred - transcript, null when only the transcript estimate exists
 }
 
 export function reconcileSession(
   sessionId: string,
   transcriptUsd: number,
   ccusageUsd: number | null,
+  otlpUsd: number | null = null,
 ): SessionCost {
+  let costUsd = transcriptUsd;
+  let source: CostSource = "transcript";
   if (ccusageUsd != null) {
-    return {
-      sessionId,
-      transcriptUsd,
-      ccusageUsd,
-      costUsd: ccusageUsd,
-      source: "ccusage",
-      discrepancyUsd: ccusageUsd - transcriptUsd,
-    };
+    costUsd = ccusageUsd;
+    source = "ccusage";
+  } else if (otlpUsd != null) {
+    costUsd = otlpUsd;
+    source = "otlp";
   }
   return {
     sessionId,
     transcriptUsd,
-    ccusageUsd: null,
-    costUsd: transcriptUsd,
-    source: "transcript",
-    discrepancyUsd: null,
+    ccusageUsd,
+    otlpUsd,
+    costUsd,
+    source,
+    discrepancyUsd: source === "transcript" ? null : costUsd - transcriptUsd,
   };
 }
 
 export function reconcileSessions(
   sessions: { id: string; cost_usd: number }[],
   ccusage: UsageSession[],
+  otlpCost?: Map<string, number>,
 ): SessionCost[] {
   const byId = new Map(ccusage.map((s) => [s.sessionId, s.costUsd]));
   return sessions.map((s) =>
-    reconcileSession(s.id, s.cost_usd, byId.has(s.id) ? (byId.get(s.id) as number) : null),
+    reconcileSession(
+      s.id,
+      s.cost_usd,
+      byId.has(s.id) ? (byId.get(s.id) as number) : null,
+      otlpCost?.get(s.id) ?? null,
+    ),
   );
 }


### PR DESCRIPTION
## Summary
- Adds `src/lib/otlp-map.ts` — a mapping layer that aggregates the isolated `otlp_*` rows (from the Run 89 receiver) onto the dashboard's data model: per-session **cost**, **token breakdown** (input/output/cacheRead/cacheCreation/total), and **request latency** (count, avg, nearest-rank p95). Pure aggregators (`aggregateCost`, `aggregateTokens`, `aggregateLatency`, `percentile`) plus thin DB readers (`otlpSessionSummaries`, `otlpCostMap`, `otlpAvailable`).
- New read path `GET /api/otlp/summary` → `{ available, sessions[], totals }`; returns an empty `available:false` payload when the optional receiver was never fed.
- **Reconciliation extended to a third source.** `reconcile.ts` now folds OTLP's self-reported `cost.usage` into the per-session cost reconciliation with preference order **ccusage > otlp > transcript**, and `/api/usage/reconcile` passes it through (adds `otlpUsd` per session + an `otlpAvailable` flag).
- Stays read-only and isolated: this only *reads* the `otlp_*` tables — the hook-driven model is untouched.

## Test plan
- [x] `npm run lint`
- [x] `npx vitest run` (363 passing — new `otlp-map.test.ts` + extended `reconcile.test.ts`)
- [x] `npm run build` (`/api/otlp/summary` registered)
- [x] `npm run test:e2e` (2 passing, 29 sections unchanged)

Run 90 of **Phase H** (Integrationen & weitere Datenquellen).

https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk)_