### PR TITLE
Add Prometheus scrape endpoint (GET /api/metrics)

### DIFF
--- a/src/app/api/metrics/route.ts
+++ b/src/app/api/metrics/route.ts
@@ -1,0 +1,21 @@
+import { db } from "@/lib/db";
+import { collectMetrics, PROM_CONTENT_TYPE, renderPrometheus } from "@/lib/prometheus";
+import { log } from "@/lib/log";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+// Prometheus scrape endpoint (text exposition format 0.0.4). Read-only and local-only
+// (the server binds 127.0.0.1), so Grafana/Prometheus can scrape the same machine.
+export async function GET() {
+  try {
+    const body = renderPrometheus(collectMetrics(db));
+    return new Response(body, { headers: { "Content-Type": PROM_CONTENT_TYPE } });
+  } catch (err) {
+    log.error("/api/metrics failed", err);
+    return new Response("# metrics unavailable\n", {
+      status: 500,
+      headers: { "Content-Type": "text/plain; charset=utf-8" },
+    });
+  }
+}

--- a/src/lib/prometheus.test.ts
+++ b/src/lib/prometheus.test.ts
@@ -1,0 +1,95 @@
+import Database from "better-sqlite3";
+import { afterEach, describe, expect, it } from "vitest";
+import { collectMetrics, renderPrometheus, type PromMetric } from "@/lib/prometheus";
+import { migrate } from "@/lib/migrations";
+
+let open: Database.Database | null = null;
+afterEach(() => {
+  open?.close();
+  open = null;
+});
+
+describe("renderPrometheus", () => {
+  it("emits HELP/TYPE headers, labels, and a trailing newline", () => {
+    const metrics: PromMetric[] = [
+      { name: "mc_up", help: "up", type: "gauge", samples: [{ value: 1 }] },
+      {
+        name: "mc_sessions",
+        help: "by status",
+        type: "gauge",
+        samples: [
+          { value: 2, labels: { status: "active" } },
+          { value: 0, labels: { status: "ended" } },
+        ],
+      },
+    ];
+    const out = renderPrometheus(metrics);
+    expect(out).toBe(
+      [
+        "# HELP mc_up up",
+        "# TYPE mc_up gauge",
+        "mc_up 1",
+        "# HELP mc_sessions by status",
+        "# TYPE mc_sessions gauge",
+        'mc_sessions{status="active"} 2',
+        'mc_sessions{status="ended"} 0',
+        "",
+      ].join("\n"),
+    );
+  });
+
+  it("escapes backslashes, quotes, and newlines in help text and label values", () => {
+    const out = renderPrometheus([
+      {
+        name: "mc_info",
+        help: 'line\nbreak \\ end',
+        type: "gauge",
+        samples: [{ value: 1, labels: { path: 'C:\\a"b' } }],
+      },
+    ]);
+    expect(out).toContain("# HELP mc_info line\\nbreak \\\\ end");
+    expect(out).toContain('mc_info{path="C:\\\\a\\"b"} 1');
+  });
+
+  it("formats non-finite values per the spec", () => {
+    const out = renderPrometheus([
+      { name: "mc_x", help: "x", type: "gauge", samples: [{ value: Infinity }, { value: -Infinity }, { value: NaN }] },
+    ]);
+    expect(out).toContain("mc_x +Inf");
+    expect(out).toContain("mc_x -Inf");
+    expect(out).toContain("mc_x NaN");
+  });
+});
+
+describe("collectMetrics", () => {
+  it("reads aggregates from the database", () => {
+    const db = (open = new Database(":memory:"));
+    migrate(db);
+    db.prepare(
+      `INSERT INTO sessions (id, status, cost_usd, token_input, token_output, token_cache) VALUES (?, ?, ?, ?, ?, ?)`,
+    ).run("s1", "active", 1.5, 1000, 200, 50);
+    db.prepare(
+      `INSERT INTO sessions (id, status, cost_usd, token_input, token_output, token_cache) VALUES (?, ?, ?, ?, ?, ?)`,
+    ).run("s2", "ended", 0.5, 10, 20, 0);
+    db.prepare(`INSERT INTO tool_calls (session_id, tool_name, success) VALUES ('s1', 'Read', 1)`).run();
+    db.prepare(`INSERT INTO tool_calls (session_id, tool_name, success) VALUES ('s1', 'Bash', 0)`).run();
+
+    const byName = new Map(collectMetrics(db).map((m) => [m.name, m]));
+
+    const sessions = byName.get("mc_sessions")!;
+    expect(sessions.samples.find((s) => s.labels?.status === "active")?.value).toBe(1);
+    expect(sessions.samples.find((s) => s.labels?.status === "ended")?.value).toBe(1);
+    expect(sessions.samples.find((s) => s.labels?.status === "waiting")?.value).toBe(0); // default kept
+
+    expect(byName.get("mc_cost_usd")!.samples[0].value).toBeCloseTo(2.0);
+    expect(byName.get("mc_tool_calls_total")!.samples[0].value).toBe(2);
+    expect(byName.get("mc_tool_call_errors_total")!.samples[0].value).toBe(1);
+
+    const tokens = byName.get("mc_tokens")!;
+    expect(tokens.samples.find((s) => s.labels?.type === "input")?.value).toBe(1010);
+    expect(tokens.samples.find((s) => s.labels?.type === "cache")?.value).toBe(50);
+
+    // Renders cleanly end to end.
+    expect(renderPrometheus(collectMetrics(db))).toContain("# TYPE mc_up gauge");
+  });
+});

--- a/src/lib/prometheus.ts
+++ b/src/lib/prometheus.ts
@@ -1,0 +1,139 @@
+import type Database from "better-sqlite3";
+
+// Prometheus text exposition format (version 0.0.4) so Grafana/Prometheus can scrape
+// the dashboard's aggregates alongside the OTLP path. Read-only and local-only (the
+// server binds 127.0.0.1). The renderer is pure; collectMetrics does the DB reads.
+
+export type PromType = "counter" | "gauge";
+
+export interface PromSample {
+  value: number;
+  labels?: Record<string, string>;
+}
+
+export interface PromMetric {
+  name: string;
+  help: string;
+  type: PromType;
+  samples: PromSample[];
+}
+
+export const PROM_CONTENT_TYPE = "text/plain; version=0.0.4; charset=utf-8";
+
+function escapeHelp(s: string): string {
+  return s.replace(/\\/g, "\\\\").replace(/\n/g, "\\n");
+}
+
+function escapeLabelValue(s: string): string {
+  return s.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\n/g, "\\n");
+}
+
+function formatLabels(labels?: Record<string, string>): string {
+  if (!labels) return "";
+  const parts = Object.entries(labels).map(([k, v]) => `${k}="${escapeLabelValue(String(v))}"`);
+  return parts.length ? `{${parts.join(",")}}` : "";
+}
+
+function formatValue(v: number): string {
+  if (Number.isNaN(v)) return "NaN";
+  if (v === Infinity) return "+Inf";
+  if (v === -Infinity) return "-Inf";
+  return String(v);
+}
+
+export function renderPrometheus(metrics: PromMetric[]): string {
+  const lines: string[] = [];
+  for (const m of metrics) {
+    lines.push(`# HELP ${m.name} ${escapeHelp(m.help)}`);
+    lines.push(`# TYPE ${m.name} ${m.type}`);
+    for (const s of m.samples) {
+      lines.push(`${m.name}${formatLabels(s.labels)} ${formatValue(s.value)}`);
+    }
+  }
+  // The exposition format requires a trailing newline.
+  return lines.join("\n") + "\n";
+}
+
+function count(db: Database.Database, sql: string): number {
+  return (db.prepare(sql).get() as { n: number }).n;
+}
+
+export function collectMetrics(db: Database.Database): PromMetric[] {
+  const statusRows = db.prepare(`SELECT status, COUNT(*) AS n FROM sessions GROUP BY status`).all() as {
+    status: string;
+    n: number;
+  }[];
+  const byStatus: Record<string, number> = { active: 0, waiting: 0, ended: 0 };
+  for (const r of statusRows) byStatus[r.status] = r.n;
+
+  const tokens = db
+    .prepare(
+      `SELECT COALESCE(SUM(token_input),0) AS input, COALESCE(SUM(token_output),0) AS output, COALESCE(SUM(token_cache),0) AS cache FROM sessions`,
+    )
+    .get() as { input: number; output: number; cache: number };
+
+  const costUsd = (db.prepare(`SELECT COALESCE(SUM(cost_usd),0) AS n FROM sessions`).get() as { n: number }).n;
+
+  return [
+    { name: "mc_up", help: "1 if the dashboard is serving metrics.", type: "gauge", samples: [{ value: 1 }] },
+    {
+      name: "mc_build_info",
+      help: "Build metadata; value is always 1.",
+      type: "gauge",
+      samples: [{ value: 1, labels: { version: process.env.npm_package_version ?? "unknown" } }],
+    },
+    {
+      name: "mc_sessions",
+      help: "Sessions by current status.",
+      type: "gauge",
+      samples: Object.entries(byStatus).map(([status, value]) => ({ value, labels: { status } })),
+    },
+    {
+      name: "mc_events_total",
+      help: "Total events ingested from hooks.",
+      type: "counter",
+      samples: [{ value: count(db, `SELECT COUNT(*) AS n FROM events`) }],
+    },
+    {
+      name: "mc_tool_calls_total",
+      help: "Total tool calls recorded.",
+      type: "counter",
+      samples: [{ value: count(db, `SELECT COUNT(*) AS n FROM tool_calls`) }],
+    },
+    {
+      name: "mc_tool_call_errors_total",
+      help: "Tool calls that reported failure.",
+      type: "counter",
+      samples: [{ value: count(db, `SELECT COUNT(*) AS n FROM tool_calls WHERE success = 0`) }],
+    },
+    { name: "mc_cost_usd", help: "Estimated cost across all sessions, USD.", type: "gauge", samples: [{ value: costUsd }] },
+    {
+      name: "mc_tokens",
+      help: "Token totals across all sessions, by type.",
+      type: "gauge",
+      samples: [
+        { value: tokens.input, labels: { type: "input" } },
+        { value: tokens.output, labels: { type: "output" } },
+        { value: tokens.cache, labels: { type: "cache" } },
+      ],
+    },
+    {
+      name: "mc_alerts_unread",
+      help: "Unread in-app alerts.",
+      type: "gauge",
+      samples: [{ value: count(db, `SELECT COUNT(*) AS n FROM alerts WHERE read = 0`) }],
+    },
+    {
+      name: "mc_otlp_metric_rows_total",
+      help: "Metric data points received via the optional OTLP receiver.",
+      type: "counter",
+      samples: [{ value: count(db, `SELECT COUNT(*) AS n FROM otlp_metric`) }],
+    },
+    {
+      name: "mc_otlp_log_rows_total",
+      help: "Log records received via the optional OTLP receiver.",
+      type: "counter",
+      samples: [{ value: count(db, `SELECT COUNT(*) AS n FROM otlp_log`) }],
+    },
+  ];
+}


### PR DESCRIPTION
## Summary
- Adds `GET /api/metrics` emitting the **Prometheus text exposition format (version 0.0.4)** with the correct `Content-Type: text/plain; version=0.0.4` so Grafana/Prometheus can scrape the dashboard alongside the OTLP path. Read-only and local-only (the server binds `127.0.0.1`).
- New `src/lib/prometheus.ts`: a **pure renderer** (`renderPrometheus` — HELP/TYPE headers, label rendering, spec-correct escaping of `\`, `"`, `\n`, `+Inf`/`-Inf`/`NaN`, trailing newline) kept separate from `collectMetrics(db)` which does the DB reads.
- Exported metrics: `mc_up`, `mc_build_info{version}`, `mc_sessions{status}`, `mc_events_total`, `mc_tool_calls_total`, `mc_tool_call_errors_total`, `mc_cost_usd`, `mc_tokens{type}`, `mc_alerts_unread`, and `mc_otlp_{metric,log}_rows_total` (ties in the Phase H OTLP receiver). Counters use `_total`; point-in-time values are gauges.

## Test plan
- [x] `npm run lint`
- [x] `npx vitest run` (367 passing — new `prometheus.test.ts`: rendering, escaping, non-finite values, DB collection)
- [x] `npm run build` (`/api/metrics` registered)
- [x] `npm run test:e2e` (2 passing, 29 sections unchanged)

Run 91 of **Phase H** (Integrationen & weitere Datenquellen).

https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk)_