### PR TITLE
Add CSV/JSON data export + document the schema

### DIFF
--- a/docs/EXPORT.md
+++ b/docs/EXPORT.md
@@ -1,0 +1,85 @@
+# Data export & schema
+
+Claude Mission Control keeps everything in one local SQLite database
+(`data/mission-control.db`). All export paths are **read-only** and local-only.
+
+## Ways to export
+
+| Method | What you get |
+| --- | --- |
+| **Command palette** (`⌘/Ctrl-K` → "Export…") | Downloads via the browser: full JSON bundle, or `sessions` / `events` as CSV. |
+| **`GET /api/export`** | JSON bundle of every whitelisted table (file download). |
+| **`GET /api/export?table=<name>&format=json\|csv`** | One table as JSON or CSV (file download). |
+| **`npm run export-log`** | A Markdown transcript **and** a structured `log-<stamp>.json` (sessions with their events) under `exports/`. |
+
+`format` defaults to `json`. Unknown tables return `400` with the list of valid
+names. CSV follows RFC 4180 (quotes doubled; fields containing `,` `"` CR or LF are
+quoted); object/array cells are embedded as JSON.
+
+## Exportable tables
+
+The `/api/export` whitelist (each newest-first, row-capped):
+
+`sessions`, `events`, `tool_calls`, `prompts`, `alerts`, `alert_rules`,
+`otlp_metric`, `otlp_log`.
+
+## Schema (key columns)
+
+The full, authoritative schema is the append-only migration list in
+`src/lib/migrations-sql.mjs`. Summary of the main tables:
+
+### `sessions`
+One row per Claude Code session.
+
+| Column | Type | Notes |
+| --- | --- | --- |
+| `id` | TEXT (PK) | Session UUID. |
+| `project_path`, `project_name` | TEXT | Working directory + derived name. |
+| `title` | TEXT | Derived from the first prompt. |
+| `status` | TEXT | `active` \| `waiting` \| `ended`. |
+| `source` | TEXT | SessionStart source. |
+| `first_seen`, `last_seen`, `ended_at` | DATETIME | Lifecycle timestamps (UTC). |
+| `token_input`, `token_output`, `token_cache` | INTEGER | Per-session token totals. |
+| `cost_usd` | REAL | Estimated session cost. |
+| `branch`, `git_commit`, `remote_url` | TEXT | Git context (read at SessionStart). |
+| `transcript_path` | TEXT | Path to the JSONL transcript. |
+| `machine` | TEXT | NULL = local; a label marks rows synced from another machine. |
+
+### `events`
+Append-only stream of hook events.
+
+| Column | Type | Notes |
+| --- | --- | --- |
+| `id` | INTEGER (PK) | Autoincrement. |
+| `session_id` | TEXT | FK → `sessions.id`. |
+| `event_type` | TEXT | Hook event name. |
+| `tool_name` | TEXT | When applicable. |
+| `summary` | TEXT | Human-readable one-liner. |
+| `payload_json` | TEXT | Raw (sanitized) hook payload. |
+| `created_at` | DATETIME | UTC. |
+
+### `tool_calls`
+One row per tool invocation.
+
+| Column | Type | Notes |
+| --- | --- | --- |
+| `id` | INTEGER (PK) | Autoincrement. |
+| `session_id` | TEXT | FK → `sessions.id`. |
+| `tool_name` | TEXT | |
+| `target` | TEXT | What the tool acted on (file/command/…). |
+| `duration_ms` | INTEGER | |
+| `success` | INTEGER | `1`/`0`. |
+| `created_at` | DATETIME | UTC. |
+
+### `prompts`
+Redacted user prompts. Columns: `id`, `session_id`, `text`, `created_at`.
+
+### `alerts` / `alert_rules`
+In-app alerting. `alert_rules`: `id`, `type`, `threshold`, `enabled`, `label`.
+`alerts`: `id`, `rule_id`, `type`, `message`, `session_id`, `dedup_key`, `read`,
+`created_at`.
+
+### `otlp_metric` / `otlp_log`
+Rows from the optional OTLP receiver. Common columns: `id`, `received_at`, `ts`,
+`name`, `session_id`, `model`, plus `value` (metrics) or `body` (logs) and an
+`attrs` JSON blob.

--- a/scripts/export-log.mjs
+++ b/scripts/export-log.mjs
@@ -47,10 +47,12 @@ const clock = (s) => {
 
 let totalEvents = 0;
 const body = [];
+const structured = []; // machine-readable sibling of the Markdown transcript
 
 for (const s of sessions) {
   const evs = eventsFor.all(s.id);
   totalEvents += evs.length;
+  structured.push({ ...s, events: evs });
   const title = s.title || `Session ${s.id.slice(0, 8)}`;
   body.push(`## ${s.project_name || "—"} — ${title}`);
   body.push(
@@ -72,4 +74,14 @@ const stamp = new Date().toISOString().replace(/[:T]/g, "-").slice(0, 19);
 const outFile = path.join(outDir, `log-${stamp}.md`);
 writeFileSync(outFile, header + "\n" + body.join("\n") + "\n");
 
-console.log(`✓ Export: ${path.relative(process.cwd(), outFile)} (${sessions.length} Sessions, ${totalEvents} Events)`);
+// Structured JSON sibling (sessions with their events) for machine consumption.
+const jsonFile = path.join(outDir, `log-${stamp}.json`);
+writeFileSync(
+  jsonFile,
+  JSON.stringify({ generatedAt: new Date().toISOString(), sessions: structured }, null, 2) + "\n",
+);
+
+console.log(
+  `✓ Export: ${path.relative(process.cwd(), outFile)} + ${path.relative(process.cwd(), jsonFile)} ` +
+    `(${sessions.length} Sessions, ${totalEvents} Events)`,
+);

--- a/src/app/api/export/route.ts
+++ b/src/app/api/export/route.ts
@@ -1,0 +1,74 @@
+import { NextResponse } from "next/server";
+import { db } from "@/lib/db";
+import { toCsv, toJson } from "@/lib/export-format";
+import { log } from "@/lib/log";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+// Read-only data export. Whitelisted tables only, each with a sane row cap, newest
+// first. `?table=<name>&format=json|csv` downloads one table; no table downloads a
+// JSON bundle of all of them. Local-only, like every other read path.
+const TABLES: Record<string, { sql: string; limit: number }> = {
+  sessions: { sql: "SELECT * FROM sessions ORDER BY datetime(last_seen) DESC", limit: 5000 },
+  events: { sql: "SELECT * FROM events ORDER BY id DESC", limit: 50000 },
+  tool_calls: { sql: "SELECT * FROM tool_calls ORDER BY id DESC", limit: 50000 },
+  prompts: { sql: "SELECT * FROM prompts ORDER BY id DESC", limit: 20000 },
+  alerts: { sql: "SELECT * FROM alerts ORDER BY id DESC", limit: 10000 },
+  alert_rules: { sql: "SELECT * FROM alert_rules ORDER BY id ASC", limit: 1000 },
+  otlp_metric: { sql: "SELECT * FROM otlp_metric ORDER BY id DESC", limit: 50000 },
+  otlp_log: { sql: "SELECT * FROM otlp_log ORDER BY id DESC", limit: 50000 },
+};
+
+function readTable(name: string): Record<string, unknown>[] {
+  const def = TABLES[name];
+  return db.prepare(`${def.sql} LIMIT ${def.limit}`).all() as Record<string, unknown>[];
+}
+
+function stamp(): string {
+  return new Date().toISOString().replace(/[:T]/g, "-").slice(0, 19);
+}
+
+export async function GET(req: Request) {
+  try {
+    const url = new URL(req.url);
+    const table = url.searchParams.get("table");
+    const format = url.searchParams.get("format") === "csv" ? "csv" : "json";
+
+    if (!table) {
+      // Full JSON bundle of every whitelisted table.
+      const tables: Record<string, Record<string, unknown>[]> = {};
+      for (const name of Object.keys(TABLES)) tables[name] = readTable(name);
+      const bundle = toJson({ generatedAt: new Date().toISOString(), tables });
+      return new Response(bundle, {
+        headers: {
+          "Content-Type": "application/json; charset=utf-8",
+          "Content-Disposition": `attachment; filename="mission-control-export-${stamp()}.json"`,
+        },
+      });
+    }
+
+    if (!(table in TABLES)) {
+      return NextResponse.json({ error: "unknown table", tables: Object.keys(TABLES) }, { status: 400 });
+    }
+
+    const rows = readTable(table);
+    if (format === "csv") {
+      return new Response(toCsv(rows), {
+        headers: {
+          "Content-Type": "text/csv; charset=utf-8",
+          "Content-Disposition": `attachment; filename="${table}-${stamp()}.csv"`,
+        },
+      });
+    }
+    return new Response(toJson(rows), {
+      headers: {
+        "Content-Type": "application/json; charset=utf-8",
+        "Content-Disposition": `attachment; filename="${table}-${stamp()}.json"`,
+      },
+    });
+  } catch (err) {
+    log.error("/api/export failed", err);
+    return NextResponse.json({ error: "export failed" }, { status: 500 });
+  }
+}

--- a/src/components/command-palette.tsx
+++ b/src/components/command-palette.tsx
@@ -104,6 +104,13 @@ export function CommandPalette({
     };
     list.push({ id: "digest-day", group: t("cmd.actions"), label: t("cmd.digestDay"), keywords: "report summary", run: () => openDigest("day") });
     list.push({ id: "digest-week", group: t("cmd.actions"), label: t("cmd.digestWeek"), keywords: "report summary", run: () => openDigest("week") });
+    const openExport = (query: string) => {
+      window.open(`/api/export${query}`, "_blank", "noopener");
+      close();
+    };
+    list.push({ id: "export-json", group: t("cmd.actions"), label: t("cmd.exportJson"), keywords: "export download backup json", run: () => openExport("") });
+    list.push({ id: "export-sessions-csv", group: t("cmd.actions"), label: t("cmd.exportSessionsCsv"), keywords: "export download csv sessions", run: () => openExport("?table=sessions&format=csv") });
+    list.push({ id: "export-events-csv", group: t("cmd.actions"), label: t("cmd.exportEventsCsv"), keywords: "export download csv events", run: () => openExport("?table=events&format=csv") });
     list.push({ id: "reset", group: t("cmd.actions"), label: t("layout.reset"), run: () => { onResetLayout(); close(); } });
     list.push({ id: "gallery", group: t("cmd.actions"), label: t("gallery.title"), run: () => { onOpenGallery(); close(); } });
     list.push({

--- a/src/lib/export-format.test.ts
+++ b/src/lib/export-format.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { toCsv, toJson } from "@/lib/export-format";
+
+describe("toJson", () => {
+  it("pretty-prints", () => {
+    expect(toJson({ a: 1 })).toBe('{\n  "a": 1\n}');
+  });
+});
+
+describe("toCsv", () => {
+  it("writes a header and rows with CRLF and a trailing newline", () => {
+    const csv = toCsv([
+      { id: 1, name: "a" },
+      { id: 2, name: "b" },
+    ]);
+    expect(csv).toBe("id,name\r\n1,a\r\n2,b\r\n");
+  });
+
+  it("escapes commas, quotes, and newlines per RFC 4180", () => {
+    const csv = toCsv([{ text: 'he said "hi", ok', note: "line1\nline2" }]);
+    expect(csv).toBe('text,note\r\n"he said ""hi"", ok","line1\nline2"\r\n');
+  });
+
+  it("serializes objects/arrays as JSON and blanks null/undefined", () => {
+    const csv = toCsv([{ meta: { k: 1 }, tags: ["x", "y"], empty: null, missing: undefined }]);
+    expect(csv).toBe('meta,tags,empty,missing\r\n"{""k"":1}","[""x"",""y""]",,\r\n');
+  });
+
+  it("unions keys across heterogeneous rows in first-seen order", () => {
+    const csv = toCsv([{ a: 1 }, { b: 2 }]);
+    expect(csv).toBe("a,b\r\n1,\r\n,2\r\n");
+  });
+
+  it("respects an explicit column list", () => {
+    const csv = toCsv([{ a: 1, b: 2, c: 3 }], ["c", "a"]);
+    expect(csv).toBe("c,a\r\n3,1\r\n");
+  });
+
+  it("returns the header alone for empty rows with explicit columns, and '' with none", () => {
+    expect(toCsv([], ["a", "b"])).toBe("a,b\r\n");
+    expect(toCsv([])).toBe("");
+  });
+});

--- a/src/lib/export-format.ts
+++ b/src/lib/export-format.ts
@@ -1,0 +1,33 @@
+// Pure serializers for the data-export feature: JSON and RFC 4180 CSV. Kept free of
+// any DB or browser dependency so they're trivially testable and reusable by the
+// /api/export route and the export scripts.
+
+export function toJson(data: unknown): string {
+  return JSON.stringify(data, null, 2);
+}
+
+function csvCell(value: unknown): string {
+  if (value === null || value === undefined) return "";
+  // Objects/arrays are serialized as JSON so a cell never breaks the row shape.
+  const raw = typeof value === "object" ? JSON.stringify(value) : String(value);
+  // Quote when the value contains a comma, quote, CR or LF; escape quotes by doubling.
+  if (/[",\r\n]/.test(raw)) return `"${raw.replace(/"/g, '""')}"`;
+  return raw;
+}
+
+// Serialize an array of records to CSV. Columns default to the union of keys across
+// rows (first-seen order), so heterogeneous rows still line up. Always ends with a
+// trailing newline; an empty input yields just the header (or "" when no columns).
+export function toCsv(rows: Record<string, unknown>[], columns?: string[]): string {
+  const cols = columns ?? inferColumns(rows);
+  if (cols.length === 0) return "";
+  const header = cols.map(csvCell).join(",");
+  const body = rows.map((row) => cols.map((c) => csvCell(row[c])).join(","));
+  return [header, ...body].join("\r\n") + "\r\n";
+}
+
+function inferColumns(rows: Record<string, unknown>[]): string[] {
+  const seen = new Set<string>();
+  for (const row of rows) for (const k of Object.keys(row)) seen.add(k);
+  return [...seen];
+}

--- a/src/lib/i18n.tsx
+++ b/src/lib/i18n.tsx
@@ -271,6 +271,9 @@ const DE: Record<string, string> = {
   "cmd.goto": "Gehe zu",
   "cmd.digestDay": "Tages-Digest öffnen",
   "cmd.digestWeek": "Wochen-Digest öffnen",
+  "cmd.exportJson": "Exportieren: alle Daten (JSON)",
+  "cmd.exportSessionsCsv": "Exportieren: Sessions (CSV)",
+  "cmd.exportEventsCsv": "Exportieren: Events (CSV)",
 
   "layout.drag": "Zum Umordnen ziehen",
   "layout.reset": "Layout zurücksetzen",
@@ -695,6 +698,9 @@ const EN: Record<string, string> = {
   "cmd.goto": "Go to",
   "cmd.digestDay": "Open daily digest",
   "cmd.digestWeek": "Open weekly digest",
+  "cmd.exportJson": "Export: all data (JSON)",
+  "cmd.exportSessionsCsv": "Export: sessions (CSV)",
+  "cmd.exportEventsCsv": "Export: events (CSV)",
 
   "layout.drag": "Drag to reorder",
   "layout.reset": "Reset layout",


### PR DESCRIPTION
## Summary
- New read-only **`GET /api/export`**: no params → a **JSON bundle** of every whitelisted table; `?table=<name>&format=json|csv` → one table as JSON or CSV. All responses are file downloads (`Content-Disposition`), local-only, with per-table row caps and a table whitelist (`sessions`, `events`, `tool_calls`, `prompts`, `alerts`, `alert_rules`, `otlp_metric`, `otlp_log`).
- **Command-palette** actions (⌘/Ctrl-K) to download: all data (JSON), sessions (CSV), events (CSV) — mirroring the existing digest `window.open` pattern.
- **Extended `scripts/export-log.mjs`**: now also writes a structured `log-<stamp>.json` (sessions with their events) next to the Markdown transcript.
- **`docs/EXPORT.md`**: documents the export methods and the table schema (authoritative source remains `migrations-sql.mjs`).
- Pure, unit-tested serializers in `src/lib/export-format.ts`: `toJson` + RFC 4180 `toCsv` (quote escaping, key-union across heterogeneous rows, object/array cells as JSON, explicit-column support).

## Test plan
- [x] `npm run lint`
- [x] `npx vitest run` (388 passing — new `export-format.test.ts`: 7 tests)
- [x] `npm run build` (`/api/export` registered)
- [x] `npm run test:e2e` (2 passing, 30 sections unchanged)
- [x] `node --check scripts/export-log.mjs`

Run 94 of **Phase H** (Integrationen & weitere Datenquellen).

https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk)_