### PR TITLE
Accessibility pass + automated axe checks in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,8 +61,9 @@ jobs:
         run: npm run build
 
       # Playwright boots `npm run start` (see playwright.config.ts), seeds via the
-      # ingest API and asserts the dashboard renders, connects and populates.
-      - name: Smoke E2E
+      # ingest API and asserts the dashboard renders, connects and populates. Also
+      # runs the axe-core accessibility audit (e2e/a11y.spec.ts) as a CI gate.
+      - name: Smoke + a11y E2E
         run: npm run test:e2e
 
       - uses: actions/upload-artifact@v4

--- a/e2e/a11y.spec.ts
+++ b/e2e/a11y.spec.ts
@@ -1,0 +1,57 @@
+import { test, expect, request as playwrightRequest, type APIRequestContext, type Page } from "@playwright/test";
+import AxeBuilder from "@axe-core/playwright";
+
+const BASE_URL = "http://127.0.0.1:3100";
+const PROJECT = "a11y-bot";
+const SESSION_ID = `a11y-${Date.now()}`;
+
+// Seed a little data so the widgets render populated states (not just empty ones),
+// driven through the only write path like the smoke test does.
+async function post(ctx: APIRequestContext, event: string, payload: Record<string, unknown>) {
+  await ctx.post("/api/ingest", {
+    headers: { "X-Hook-Event": event, "Content-Type": "application/json" },
+    data: { ...payload, hook_event_name: event },
+  });
+}
+
+test.beforeAll(async () => {
+  const ctx = await playwrightRequest.newContext({ baseURL: BASE_URL });
+  const base = { session_id: SESSION_ID, cwd: `/home/user/projects/${PROJECT}` };
+  await post(ctx, "SessionStart", { ...base, source: "startup" });
+  await post(ctx, "UserPromptSubmit", { ...base, prompt: "Accessibility audit prompt" });
+  await post(ctx, "PostToolUse", { ...base, tool_name: "Read", tool_input: { file_path: "/x.ts" }, tool_response: { ok: true } });
+  await post(ctx, "Stop", { ...base });
+  await ctx.dispose();
+});
+
+// WCAG 2.1 A/AA, the conventional automated bar. Fail only on serious/critical so
+// the gate is meaningful without being noisy about minor best-practice hints.
+async function scan(page: Page) {
+  const results = await new AxeBuilder({ page }).withTags(["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"]).analyze();
+  return results.violations.filter((v) => v.impact === "serious" || v.impact === "critical");
+}
+
+function report(violations: { id: string; impact?: string | null; nodes: unknown[] }[]) {
+  return JSON.stringify(
+    violations.map((v) => ({ id: v.id, impact: v.impact, nodes: v.nodes.length })),
+    null,
+    2,
+  );
+}
+
+test("dashboard has no serious or critical accessibility violations", async ({ page }) => {
+  await page.goto("/");
+  await expect(page.getByRole("heading", { name: "Claude Mission Control" })).toBeVisible();
+  await expect(page.getByTestId("connection-status")).toHaveAttribute("data-state", "connected", { timeout: 15_000 });
+
+  const violations = await scan(page);
+  expect(violations, report(violations)).toEqual([]);
+});
+
+test("session detail page has no serious or critical accessibility violations", async ({ page }) => {
+  await page.goto(`/session?id=${SESSION_ID}`);
+  await expect(page.getByRole("heading", { name: "Accessibility audit prompt" })).toBeVisible({ timeout: 15_000 });
+
+  const violations = await scan(page);
+  expect(violations, report(violations)).toEqual([]);
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "claude-mission-control",
       "version": "0.1.0",
-      "license": "MIT",
+      "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "better-sqlite3": "^12.10.0",
         "ccusage": "^20.0.3",
@@ -24,6 +24,7 @@
         "zod": "^4.4.3"
       },
       "devDependencies": {
+        "@axe-core/playwright": "^4.11.3",
         "@electron/rebuild": "^3.7.0",
         "@playwright/test": "^1.60.0",
         "@tailwindcss/postcss": "^4",
@@ -52,6 +53,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.11.3.tgz",
+      "integrity": "sha512-h/kfksv4F0cVIDlKpT4700OehdRgpvuVskuQ2nb7/JmtWUXpe9ftHAPtwyXGvVSsa6SJ64A9ER7Zrzc/sIvC4w==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.11.4"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.11.3",
     "@electron/rebuild": "^3.7.0",
     "@playwright/test": "^1.60.0",
     "@tailwindcss/postcss": "^4",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -5,7 +5,7 @@
   --panel: #0e1219;
   --panel-border: #1c2230;
   --foreground: #e6e9ef;
-  --muted: #8b94a7;
+  --muted: #9aa3b6;
   --accent: #4f8cff;
 }
 

--- a/src/components/dashboard.tsx
+++ b/src/components/dashboard.tsx
@@ -302,7 +302,7 @@ export function Dashboard() {
               );
             })}
           </div>
-          <footer className="pt-2 text-center text-[11px] text-muted/60">
+          <footer className="pt-2 text-center text-[11px] text-muted/80">
             {t("footer.text")} · <span className="text-muted">by Belkis Aslani</span>
           </footer>
         </div>

--- a/src/components/info-hint.tsx
+++ b/src/components/info-hint.tsx
@@ -20,7 +20,7 @@ export function InfoHint({
       <button
         type="button"
         aria-label="Info"
-        className="text-muted/50 outline-none transition-colors hover:text-muted focus-visible:text-accent"
+        className="text-muted/80 outline-none transition-colors hover:text-muted focus-visible:text-accent"
       >
         <Info className="h-3.5 w-3.5" />
       </button>

--- a/src/components/landing.tsx
+++ b/src/components/landing.tsx
@@ -76,7 +76,7 @@ export function Landing() {
 
         <p className="mx-auto mt-9 max-w-2xl text-xs leading-relaxed text-muted/80">{t("landing.how")}</p>
         <p className="mt-2 text-xs text-accent">{t("landing.demoNote")}</p>
-        <p className="mt-7 text-[11px] uppercase tracking-[0.3em] text-muted/60">{t("landing.scroll")}</p>
+        <p className="mt-7 text-[11px] uppercase tracking-[0.3em] text-muted/80">{t("landing.scroll")}</p>
       </div>
     </section>
   );

--- a/src/components/panel.tsx
+++ b/src/components/panel.tsx
@@ -32,7 +32,11 @@ export function Panel({
         </div>
         {right}
       </header>
-      <div className="min-h-0 flex-1 overflow-auto">{children}</div>
+      {/* tabIndex makes the scroll region keyboard-reachable (WCAG 2.1.1) for panels
+          whose content has no other focusable element. */}
+      <div tabIndex={0} className="min-h-0 flex-1 overflow-auto outline-none">
+        {children}
+      </div>
     </section>
   );
 }

--- a/src/components/tool-call-inspector.tsx
+++ b/src/components/tool-call-inspector.tsx
@@ -103,7 +103,7 @@ function Diff({ lines, label }: { lines: DiffLine[]; label: string }) {
                   : "text-muted"
             }
           >
-            <span className="select-none px-2 text-muted/60">
+            <span className="select-none px-2 text-muted/80">
               {l.type === "add" ? "+" : l.type === "del" ? "−" : " "}
             </span>
             {l.text || " "}

--- a/src/plugins/kanban/widget.tsx
+++ b/src/plugins/kanban/widget.tsx
@@ -81,7 +81,7 @@ export function Kanban() {
                   <Card key={s.id} s={s} onOpen={() => setSelected(s)} />
                 ))}
                 {items.length === 0 && (
-                  <p className="px-1 py-3 text-center text-[11px] text-muted/60">
+                  <p className="px-1 py-3 text-center text-[11px] text-muted/80">
                     {query.trim() ? t("common.noResults") : t("kanban.empty")}
                   </p>
                 )}

--- a/src/plugins/live-stream/widget.tsx
+++ b/src/plugins/live-stream/widget.tsx
@@ -83,29 +83,32 @@ export function LiveStream() {
       ) : filtered.length === 0 ? (
         <WidgetState icon={Activity} title={t("common.noResults")} />
       ) : (
-        <ul role="log" aria-live="polite" aria-label={t("stream.title")} className="divide-y divide-panel-border/60">
-          {filtered.map((e) => {
-            const kind = eventKind(e.event_type);
-            const Icon = ICONS[kind];
-            return (
-              <li
-                key={e.id}
-                className="mc-stream-in flex items-start gap-2.5 px-4 py-2 transition-colors hover:bg-white/[0.03]"
-              >
-                <Icon className={`mt-0.5 h-4 w-4 shrink-0 ${KIND_COLOR[kind]}`} />
-                <div className="min-w-0 flex-1">
-                  <p className="truncate text-sm text-foreground">{e.summary ?? e.event_type}</p>
-                  <p className="truncate font-mono text-[11px] text-muted">
-                    {e.event_type} · {e.session_id.slice(0, 8)}
-                  </p>
-                </div>
-                <span className="shrink-0 whitespace-nowrap text-[11px] text-muted">
-                  {relativeTime(e.created_at, lang)}
-                </span>
-              </li>
-            );
-          })}
-        </ul>
+        // role="log" lives on a wrapper so the inner <ul>/<li> keep their list semantics.
+        <div role="log" aria-live="polite" aria-label={t("stream.title")}>
+          <ul className="divide-y divide-panel-border/60">
+            {filtered.map((e) => {
+              const kind = eventKind(e.event_type);
+              const Icon = ICONS[kind];
+              return (
+                <li
+                  key={e.id}
+                  className="mc-stream-in flex items-start gap-2.5 px-4 py-2 transition-colors hover:bg-white/[0.03]"
+                >
+                  <Icon className={`mt-0.5 h-4 w-4 shrink-0 ${KIND_COLOR[kind]}`} />
+                  <div className="min-w-0 flex-1">
+                    <p className="truncate text-sm text-foreground">{e.summary ?? e.event_type}</p>
+                    <p className="truncate font-mono text-[11px] text-muted">
+                      {e.event_type} · {e.session_id.slice(0, 8)}
+                    </p>
+                  </div>
+                  <span className="shrink-0 whitespace-nowrap text-[11px] text-muted">
+                    {relativeTime(e.created_at, lang)}
+                  </span>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
       )}
     </Panel>
   );

--- a/src/plugins/session-timeline/widget.tsx
+++ b/src/plugins/session-timeline/widget.tsx
@@ -102,7 +102,7 @@ export function SessionTimeline() {
               ))}
             </div>
           </div>
-          <ul className="flex flex-1 flex-col gap-1 overflow-auto">
+          <ul tabIndex={0} className="flex flex-1 flex-col gap-1 overflow-auto outline-none">
             {bars.map((b) => (
               <li key={b.id} className="flex items-center gap-2">
                 <span className="w-24 shrink-0 truncate text-[11px] text-foreground" title={b.title}>


### PR DESCRIPTION
## Summary
- **Automated axe-core audit**: new `e2e/a11y.spec.ts` runs `@axe-core/playwright` against the dashboard and a session detail page, asserting **zero serious/critical WCAG 2.1 A/AA violations**. It runs in the existing CI `e2e` job (no new job), so a11y is now a green-gate.
- **Fixed every violation axe found:**
  - **Contrast (8 nodes):** lifted the dark `--muted` token (`#8b94a7` → `#9aa3b6`) and bumped low-opacity muted text (`/60`, `/50` → `/80`) so small labels (heatmap, session-timeline axis, empty states) clear AA.
  - **`listitem` (100 nodes):** the live stream put `role="log"` directly on the `<ul>`, which dropped list semantics from its `<li>` children — moved `role="log"` to a wrapper `<div>` so the `<ul>`/`<li>` keep their roles.
  - **`scrollable-region-focusable` (4 nodes):** made the Panel scroll container and the session-timeline list keyboard-focusable (`tabIndex=0`) per WCAG 2.1.1.

## Test plan
- [x] `npm run lint`
- [x] `npx vitest run` (393 passing)
- [x] `npm run build`
- [x] `npm run test:e2e` (4 passing: 2 smoke + 2 a11y; smoke unaffected by the live-stream restructure)

Run 96 of **Phase I** (Politur & Performance) — first run of the phase.

https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk)_