### PR TITLE
Performance pass: virtualized live stream, index + memo, bundle budget

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,8 @@ MC_HOOK_TOKEN=
 # Retention caps for the high-volume tables (<=0 disables). Default 100000 each.
 # MC_MAX_EVENTS=100000
 # MC_MAX_TOOL_CALLS=100000
+# Client-bundle budget in KB for `npm run bundle:budget` (after a build). Default 3300.
+# MC_BUNDLE_BUDGET_KB=3300
 # Max concurrent live (SSE) dashboard connections. Default 64.
 # MC_MAX_SSE_CLIENTS=64
 # Database snapshots: how many to keep and where. Defaults: 14, ./backups

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "unprotect": "node scripts/protect.mjs unlock",
     "import-history": "node scripts/import-history.mjs",
     "machine:sync": "node scripts/sync-machine.mjs",
+    "bundle:budget": "node scripts/bundle-budget.mjs",
     "install-hooks": "node scripts/install-hooks.mjs",
     "build:standalone": "next build && node scripts/assemble-standalone.mjs",
     "rebuild:standalone": "node scripts/rebuild-standalone.mjs",

--- a/scripts/bundle-budget.mjs
+++ b/scripts/bundle-budget.mjs
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+// Bundle budget gate: sums the client JS chunks emitted by `next build` and fails if
+// they exceed a budget, so a stray heavy import can't silently bloat the dashboard.
+//
+//   npm run build && npm run bundle:budget
+//   MC_BUNDLE_BUDGET_KB=3500 npm run bundle:budget   # override the budget
+//
+// Measures raw bytes of .next/static/chunks/**/*.js (a stable proxy for client weight).
+
+import { readdirSync, statSync, existsSync } from "node:fs";
+import path from "node:path";
+
+const BUDGET_KB = Number(process.env.MC_BUNDLE_BUDGET_KB) > 0 ? Number(process.env.MC_BUNDLE_BUDGET_KB) : 3300;
+const chunksDir = path.join(process.cwd(), ".next", "static", "chunks");
+
+if (!existsSync(chunksDir)) {
+  console.error(`No build output at ${chunksDir}. Run \`npm run build\` first.`);
+  process.exit(1);
+}
+
+/** @type {{ file: string, bytes: number }[]} */
+const files = [];
+function walk(dir) {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) walk(full);
+    else if (entry.name.endsWith(".js")) files.push({ file: path.relative(chunksDir, full), bytes: statSync(full).size });
+  }
+}
+walk(chunksDir);
+
+const totalKb = files.reduce((s, f) => s + f.bytes, 0) / 1024;
+const top = [...files].sort((a, b) => b.bytes - a.bytes).slice(0, 5);
+
+console.log(`Client JS chunks: ${files.length} files, ${totalKb.toFixed(0)} KB total (budget ${BUDGET_KB} KB).`);
+console.log("Largest:");
+for (const f of top) console.log(`  ${(f.bytes / 1024).toFixed(0).padStart(5)} KB  ${f.file}`);
+
+if (totalKb > BUDGET_KB) {
+  console.error(`\n✗ Over budget by ${(totalKb - BUDGET_KB).toFixed(0)} KB. Trim imports or raise MC_BUNDLE_BUDGET_KB.`);
+  process.exit(1);
+}
+console.log(`\n✓ Within budget (${(BUDGET_KB - totalKb).toFixed(0)} KB to spare).`);

--- a/src/lib/migrations-sql.mjs
+++ b/src/lib/migrations-sql.mjs
@@ -251,4 +251,10 @@ export const MIGRATIONS = [
   ALTER TABLE sessions ADD COLUMN machine TEXT;
   CREATE INDEX IF NOT EXISTS idx_sessions_machine ON sessions(machine);
   `,
+
+  // v19 — performance: time-windowed tool_calls queries (anomaly, velocity, errors,
+  // token-burn) filtered/grouped on created_at with no covering index, forcing scans.
+  `
+  CREATE INDEX IF NOT EXISTS idx_tool_calls_created ON tool_calls(created_at);
+  `,
 ];

--- a/src/lib/virtual.test.ts
+++ b/src/lib/virtual.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { windowRange } from "@/lib/virtual";
+
+describe("windowRange", () => {
+  it("returns the visible slice plus overscan and matching padding", () => {
+    // 1000 rows of 50px, 400px viewport scrolled to 5000px (row 100).
+    const w = windowRange({ scrollTop: 5000, viewport: 400, rowHeight: 50, count: 1000, overscan: 5 });
+    expect(w.start).toBe(95); // 100 - overscan
+    expect(w.end).toBe(113); // 100 + ceil(400/50)=8 + overscan 5
+    expect(w.padTop).toBe(95 * 50);
+    expect(w.padBottom).toBe((1000 - 113) * 50);
+  });
+
+  it("clamps at the top", () => {
+    const w = windowRange({ scrollTop: 0, viewport: 400, rowHeight: 50, count: 1000, overscan: 6 });
+    expect(w.start).toBe(0);
+    expect(w.padTop).toBe(0);
+  });
+
+  it("clamps at the bottom (end never exceeds count, padBottom >= 0)", () => {
+    const w = windowRange({ scrollTop: 1_000_000, viewport: 400, rowHeight: 50, count: 1000 });
+    expect(w.end).toBe(1000);
+    expect(w.padBottom).toBe(0);
+  });
+
+  it("renders everything for degenerate inputs", () => {
+    expect(windowRange({ scrollTop: 0, viewport: 0, rowHeight: 50, count: 10 })).toEqual({
+      start: 0,
+      end: 10,
+      padTop: 0,
+      padBottom: 0,
+    });
+    expect(windowRange({ scrollTop: 0, viewport: 400, rowHeight: 0, count: 10 }).end).toBe(10);
+    expect(windowRange({ scrollTop: 0, viewport: 400, rowHeight: 50, count: 0 }).end).toBe(0);
+  });
+});

--- a/src/lib/virtual.ts
+++ b/src/lib/virtual.ts
@@ -1,0 +1,36 @@
+// Tiny, dependency-free fixed-height list virtualization. Pure math so it's testable
+// and reusable: given the scroll position, viewport height and row height, it returns
+// the slice of rows to render plus the top/bottom padding that preserves scroll height.
+
+export interface VirtualWindow {
+  start: number;
+  end: number; // exclusive
+  padTop: number;
+  padBottom: number;
+}
+
+export function windowRange(opts: {
+  scrollTop: number;
+  viewport: number;
+  rowHeight: number;
+  count: number;
+  overscan?: number;
+}): VirtualWindow {
+  const { count } = opts;
+  const overscan = opts.overscan ?? 6;
+  // Degenerate inputs (no measurement yet / empty) → render everything.
+  if (opts.rowHeight <= 0 || opts.viewport <= 0 || count <= 0) {
+    return { start: 0, end: count, padTop: 0, padBottom: 0 };
+  }
+  const scrollTop = Math.max(0, opts.scrollTop);
+  const first = Math.floor(scrollTop / opts.rowHeight);
+  const visible = Math.ceil(opts.viewport / opts.rowHeight);
+  const start = Math.max(0, first - overscan);
+  const end = Math.min(count, first + visible + overscan);
+  return {
+    start,
+    end,
+    padTop: start * opts.rowHeight,
+    padBottom: Math.max(0, (count - end) * opts.rowHeight),
+  };
+}

--- a/src/plugins/kanban/widget.tsx
+++ b/src/plugins/kanban/widget.tsx
@@ -49,6 +49,13 @@ export function Kanban() {
     [sessions, facets, query],
   );
 
+  // Group once per change instead of filtering the list three times each render.
+  const byStatus = useMemo(() => {
+    const g: Record<SessionStatus, SessionCard[]> = { active: [], waiting: [], ended: [] };
+    for (const s of filtered) g[s.status].push(s);
+    return g;
+  }, [filtered]);
+
   // Keep the open detail in sync with refreshed data; close it if the session is gone.
   const selectedLive = useMemo(
     () => (selected ? sessions.find((s) => s.id === selected.id) ?? null : null),
@@ -63,7 +70,7 @@ export function Kanban() {
     >
       <div className="grid h-full grid-cols-3 gap-px bg-panel-border/50">
         {COLUMNS.map((status) => {
-          const items = filtered.filter((s) => s.status === status);
+          const items = byStatus[status];
           const meta = STATUS_META[status];
           return (
             <div key={status} className="flex min-h-0 flex-col bg-panel">

--- a/src/plugins/live-stream/widget.tsx
+++ b/src/plugins/live-stream/widget.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import {
   Activity,
   Bell,
@@ -21,6 +21,11 @@ import { useSearch, matchesQuery } from "@/components/search";
 import { usePluginConfig } from "@/components/plugin-config";
 import { useT } from "@/lib/i18n";
 import { eventKind, KIND_COLOR, relativeTime, type EventKind } from "@/lib/format";
+import { windowRange } from "@/lib/virtual";
+
+// Estimated row height (icon + two truncated lines + padding). Used only for
+// windowing math; overscan absorbs small deviations.
+const ROW_H = 53;
 
 const ICONS: Record<EventKind, LucideIcon> = {
   "session-start": Play,
@@ -50,9 +55,42 @@ export function LiveStream() {
 
   const limit = typeof values.limit === "number" ? values.limit : 100;
 
-  const filtered = events
-    .filter((e) => matchesQuery(query, e.summary, e.event_type, e.tool_name, e.session_id))
-    .slice(0, limit);
+  const filtered = useMemo(
+    () =>
+      events
+        .filter((e) => matchesQuery(query, e.summary, e.event_type, e.tool_name, e.session_id))
+        .slice(0, limit),
+    [events, query, limit],
+  );
+
+  // Fixed-height list virtualization: only render the rows in (or near) view.
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const rafRef = useRef<number | null>(null);
+  const [scrollTop, setScrollTop] = useState(0);
+  const [viewport, setViewport] = useState(0);
+  const showList = events.length > 0 && filtered.length > 0;
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const measure = () => setViewport(el.clientHeight);
+    measure();
+    const ro = new ResizeObserver(measure);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [showList]);
+
+  const onScroll = () => {
+    const el = scrollRef.current;
+    if (!el || rafRef.current != null) return;
+    rafRef.current = requestAnimationFrame(() => {
+      rafRef.current = null;
+      setScrollTop(el.scrollTop);
+    });
+  };
+
+  const win = windowRange({ scrollTop, viewport, rowHeight: ROW_H, count: filtered.length, overscan: 8 });
+  const visible = filtered.slice(win.start, win.end);
 
   return (
     <Panel
@@ -84,30 +122,34 @@ export function LiveStream() {
         <WidgetState icon={Activity} title={t("common.noResults")} />
       ) : (
         // role="log" lives on a wrapper so the inner <ul>/<li> keep their list semantics.
-        <div role="log" aria-live="polite" aria-label={t("stream.title")}>
-          <ul className="divide-y divide-panel-border/60">
-            {filtered.map((e) => {
-              const kind = eventKind(e.event_type);
-              const Icon = ICONS[kind];
-              return (
-                <li
-                  key={e.id}
-                  className="mc-stream-in flex items-start gap-2.5 px-4 py-2 transition-colors hover:bg-white/[0.03]"
-                >
-                  <Icon className={`mt-0.5 h-4 w-4 shrink-0 ${KIND_COLOR[kind]}`} />
-                  <div className="min-w-0 flex-1">
-                    <p className="truncate text-sm text-foreground">{e.summary ?? e.event_type}</p>
-                    <p className="truncate font-mono text-[11px] text-muted">
-                      {e.event_type} · {e.session_id.slice(0, 8)}
-                    </p>
-                  </div>
-                  <span className="shrink-0 whitespace-nowrap text-[11px] text-muted">
-                    {relativeTime(e.created_at, lang)}
-                  </span>
-                </li>
-              );
-            })}
-          </ul>
+        // Only the rows in view are mounted; top/bottom padding preserves scroll height.
+        <div ref={scrollRef} onScroll={onScroll} tabIndex={0} className="h-full overflow-auto outline-none">
+          <div role="log" aria-live="polite" aria-label={t("stream.title")}>
+            <ul className="divide-y divide-panel-border/60" style={{ paddingTop: win.padTop, paddingBottom: win.padBottom }}>
+              {visible.map((e) => {
+                const kind = eventKind(e.event_type);
+                const Icon = ICONS[kind];
+                return (
+                  <li
+                    key={e.id}
+                    style={{ height: ROW_H }}
+                    className="flex items-start gap-2.5 px-4 py-2 transition-colors hover:bg-white/[0.03]"
+                  >
+                    <Icon className={`mt-0.5 h-4 w-4 shrink-0 ${KIND_COLOR[kind]}`} />
+                    <div className="min-w-0 flex-1">
+                      <p className="truncate text-sm text-foreground">{e.summary ?? e.event_type}</p>
+                      <p className="truncate font-mono text-[11px] text-muted">
+                        {e.event_type} · {e.session_id.slice(0, 8)}
+                      </p>
+                    </div>
+                    <span className="shrink-0 whitespace-nowrap text-[11px] text-muted">
+                      {relativeTime(e.created_at, lang)}
+                    </span>
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
         </div>
       )}
     </Panel>


### PR DESCRIPTION
## Summary
- **Virtualized live stream.** New dependency-free fixed-height windowing (`src/lib/virtual.ts`, pure + unit-tested) so the live stream mounts only the rows in view (plus overscan), with top/bottom padding preserving scroll height. Its filtering is now memoized. List semantics + a11y are preserved (the scroll container is keyboard-focusable; `role="log"` wraps the `<ul>`).
- **Query/index tuning.** Migration **v19** adds `idx_tool_calls_created` on `tool_calls(created_at)` — the hot time-windowed queries (anomaly, velocity, errors, token-burn) filtered/grouped on `created_at` with no covering index, forcing scans.
- **Memoized aggregates.** The kanban now groups sessions by status in a single memoized pass instead of filtering the list three times per render.
- **Bundle analysis + budget.** New dependency-free `scripts/bundle-budget.mjs` (`npm run bundle:budget`) sums the built client JS chunks and fails if they exceed `MC_BUNDLE_BUDGET_KB` (default **3300 KB**; current build ≈ **2929 KB**, 371 KB to spare). Documented in `.env.example`.

## Test plan
- [x] `npm run lint`
- [x] `npx vitest run` (397 passing — new `virtual.test.ts`)
- [x] `npm run build`
- [x] `npm run test:e2e` (4 passing: smoke + a11y; live-stream virtualization verified intact)
- [x] `npm run bundle:budget` (within budget)

Run 97 of **Phase I** (Politur & Performance).

https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk)_