### PR TITLE
Phase Z layout audit: no-overflow + clean-console gate across breakpoints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,9 +62,18 @@ jobs:
 
       # Playwright boots `npm run start` (see playwright.config.ts), seeds via the
       # ingest API and asserts the dashboard renders, connects and populates. Also
-      # runs the axe-core accessibility audit (e2e/a11y.spec.ts) as a CI gate.
-      - name: Smoke + a11y E2E
+      # runs the axe-core accessibility audit (e2e/a11y.spec.ts) and the Phase Z
+      # layout audit (e2e/layout.spec.ts) as CI gates.
+      - name: Smoke + a11y + layout E2E
         run: npm run test:e2e
+
+      # Always collect the layout-audit screenshots (Phase Z) for visual review.
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: layout-screenshots
+          path: test-results/layout-shots
+          if-no-files-found: ignore
 
       - uses: actions/upload-artifact@v4
         if: failure()

--- a/e2e/layout.spec.ts
+++ b/e2e/layout.spec.ts
@@ -1,0 +1,95 @@
+import { test, expect, request as playwrightRequest, type APIRequestContext, type Page } from "@playwright/test";
+
+const BASE_URL = "http://127.0.0.1:3100";
+const PROJECT = "layout-bot";
+
+// Seed a little data through the only write path so panels render populated states.
+async function seed() {
+  const ctx: APIRequestContext = await playwrightRequest.newContext({ baseURL: BASE_URL });
+  const base = { session_id: `layout-${Date.now()}`, cwd: `/home/user/projects/${PROJECT}` };
+  const post = (event: string, payload: Record<string, unknown>) =>
+    ctx.post("/api/ingest", {
+      headers: { "X-Hook-Event": event, "Content-Type": "application/json" },
+      data: { ...payload, hook_event_name: event },
+    });
+  await post("SessionStart", { ...base, source: "startup" });
+  await post("UserPromptSubmit", { ...base, prompt: "Layout audit prompt" });
+  await post("PostToolUse", { ...base, tool_name: "Read", tool_input: { file_path: "/x.ts" }, tool_response: { ok: true } });
+  await post("Stop", { ...base });
+  await ctx.dispose();
+}
+
+test.beforeAll(seed);
+
+// Force a deterministic theme/lang and skip the first-run wizard before any script runs.
+function prime(page: Page, mode: "dark" | "light", lang: "de" | "en") {
+  return page.addInitScript(
+    ([m, l]) => {
+      try {
+        localStorage.setItem("mc-onboarded", "1");
+        localStorage.setItem("mc-theme", JSON.stringify({ mode: m, accent: "#4f8cff" }));
+        localStorage.setItem("mc-lang", l);
+      } catch {
+        /* ignore */
+      }
+    },
+    [mode, lang] as const,
+  );
+}
+
+// Browser console noise we explicitly tolerate (none expected, but WebGL backends
+// occasionally emit info/warnings from the 3D graph under headless GPU).
+const IGNORE = [/WebGL/i, /THREE\.WebGLRenderer/i, /Download the React DevTools/i];
+
+const VIEWPORTS = [
+  { name: "mobile", width: 390, height: 844 },
+  { name: "desktop", width: 1440, height: 900 },
+  { name: "qhd", width: 2560, height: 1440 },
+  { name: "uhd", width: 3840, height: 2160 },
+] as const;
+
+const MODES = ["dark", "light"] as const;
+
+for (const vp of VIEWPORTS) {
+  for (const mode of MODES) {
+    // German for every breakpoint+theme; one English pass at desktop to catch
+    // translation-length overflow.
+    const langs: ("de" | "en")[] = vp.name === "desktop" ? ["de", "en"] : ["de"];
+    for (const lang of langs) {
+      const label = `${vp.name}-${mode}-${lang}`;
+      test(`layout: no overflow, clean console — ${label}`, async ({ page }, testInfo) => {
+        const errors: string[] = [];
+        page.on("console", (m) => {
+          if (m.type() === "error" && !IGNORE.some((re) => re.test(m.text()))) errors.push(m.text());
+        });
+        page.on("pageerror", (e) => {
+          if (!IGNORE.some((re) => re.test(e.message))) errors.push(e.message);
+        });
+
+        await page.setViewportSize({ width: vp.width, height: vp.height });
+        await prime(page, mode, lang);
+        await page.goto("/");
+        await expect(page.getByRole("heading", { name: "Claude Mission Control" })).toBeVisible({ timeout: 15_000 });
+        // The SSE stream keeps the network busy, so "networkidle" never fires —
+        // wait for the live connection instead, then let charts/animations settle.
+        await expect(page.getByTestId("connection-status")).toHaveAttribute("data-state", "connected", {
+          timeout: 15_000,
+        });
+        await page.waitForTimeout(800);
+
+        // No horizontal overflow at any breakpoint.
+        const overflow = await page.evaluate(() => {
+          const el = document.scrollingElement || document.documentElement;
+          return el.scrollWidth - el.clientWidth;
+        });
+        expect(overflow, `horizontal overflow (${label})`).toBeLessThanOrEqual(1);
+
+        // Collect a screenshot as a CI artifact for visual review.
+        const shot = await page.screenshot({ path: `test-results/layout-shots/${label}.png`, fullPage: false });
+        await testInfo.attach(label, { body: shot, contentType: "image/png" });
+
+        expect(errors, `console errors (${label}):\n${errors.join("\n")}`).toEqual([]);
+      });
+    }
+  }
+}


### PR DESCRIPTION
## Summary
First run of **Phase Z** (visual + functional audit before release) — the **layout & grid** check.

- New `e2e/layout.spec.ts`: a Playwright audit over a matrix of **viewports** (mobile 390, desktop 1440, QHD 2560, UHD 3840) × **themes** (dark/light) × **languages** (de/en — en at desktop). For each combination it:
  - waits for the live SSE connection (the stream keeps the network busy, so `networkidle` is intentionally avoided),
  - asserts **no horizontal overflow** (`scrollWidth ≤ clientWidth`),
  - asserts a **clean browser console** (no errors / page errors; only WebGL/devtools noise is tolerated),
  - captures a **screenshot** per combination.
- CI now **always** uploads these as the `layout-screenshots` artifact for visual review (the audit also runs as a hard gate).

## Findings
- ✅ No horizontal overflow at any breakpoint/theme/language.
- ✅ No console or hydration errors.
- ✅ KPI bar, panels and gutters align with equal per-row heights (fixed height classes).
- 📝 Follow-up (not a defect): the 3-column kanban is dense at 390px (timestamps wrap) — to be addressed in the dedicated **Kanban audit (Run 104)**.

## Test plan
- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm run test:e2e` (15 passing: 2 smoke + 3 a11y + 10 layout)
- [x] Spot-checked desktop + mobile screenshots

Run 100 of **Phase Z** (Runs 100–119).

https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk)_