### PR TITLE
Typography & readability audit: long-text stress test + scroll-region a11y

### DIFF
--- a/e2e/typography.spec.ts
+++ b/e2e/typography.spec.ts
@@ -1,0 +1,81 @@
+import { test, expect, request as playwrightRequest, type APIRequestContext, type Page } from "@playwright/test";
+
+const BASE_URL = "http://127.0.0.1:3100";
+
+// Pathological strings: a very long unbroken token (worst case for truncation) plus
+// a long, space-separated sentence (worst case for wrapping / translation length).
+const LONG_TOKEN = "Supercalifragilistic" + "x".repeat(220);
+const LONG_SENTENCE =
+  "Refaktoriere den kompletten Authentifizierungs- und Autorisierungs-Stack inklusive aller Randfälle " +
+  "und schreibe ausführliche Integrationstests für jede einzelne Route " +
+  LONG_TOKEN;
+const LONG_PROJECT = "projekt-" + "a".repeat(200);
+const LONG_FILE = "/home/user/projects/" + LONG_PROJECT + "/src/" + "b".repeat(200) + ".tsx";
+
+async function seed() {
+  const ctx: APIRequestContext = await playwrightRequest.newContext({ baseURL: BASE_URL });
+  const base = { session_id: `typo-${Date.now()}`, cwd: `/home/user/projects/${LONG_PROJECT}` };
+  const post = (event: string, payload: Record<string, unknown>) =>
+    ctx.post("/api/ingest", {
+      headers: { "X-Hook-Event": event, "Content-Type": "application/json" },
+      data: { ...payload, hook_event_name: event },
+    });
+  await post("SessionStart", { ...base, source: "startup" });
+  await post("UserPromptSubmit", { ...base, prompt: LONG_SENTENCE });
+  await post("PreToolUse", { ...base, tool_name: "Edit", tool_input: { file_path: LONG_FILE } });
+  await post("PostToolUse", { ...base, tool_name: "Edit", tool_input: { file_path: LONG_FILE }, tool_response: { ok: true } });
+  await post("Stop", { ...base });
+  await ctx.dispose();
+}
+
+test.beforeAll(seed);
+
+function prime(page: Page, lang: "de" | "en") {
+  return page.addInitScript((l) => {
+    try {
+      localStorage.setItem("mc-onboarded", "1");
+      localStorage.setItem("mc-lang", l);
+    } catch {
+      /* ignore */
+    }
+  }, lang);
+}
+
+for (const vp of [
+  { name: "mobile", width: 390, height: 844 },
+  { name: "desktop", width: 1440, height: 900 },
+  { name: "qhd", width: 2560, height: 1440 },
+] as const) {
+  for (const lang of ["de", "en"] as const) {
+    test(`long text does not break the layout — ${vp.name}-${lang}`, async ({ page }) => {
+      await page.setViewportSize({ width: vp.width, height: vp.height });
+      await prime(page, lang);
+      await page.goto("/");
+      await expect(page.getByTestId("connection-status")).toHaveAttribute("data-state", "connected", {
+        timeout: 15_000,
+      });
+      await page.waitForTimeout(500);
+
+      const result = await page.evaluate(() => {
+        const el = document.scrollingElement || document.documentElement;
+        const overflow = el.scrollWidth - el.clientWidth;
+        const offenders: string[] = [];
+        if (overflow > 1) {
+          const w = window.innerWidth;
+          for (const node of Array.from(document.querySelectorAll<HTMLElement>("*"))) {
+            const r = node.getBoundingClientRect();
+            if (r.right > w + 1 && r.width > 0 && r.width <= el.scrollWidth) {
+              offenders.push(`${node.tagName}.${node.className?.toString().slice(0, 80)} | ${node.textContent?.slice(0, 40)}`);
+              if (offenders.length >= 8) break;
+            }
+          }
+        }
+        return { overflow, offenders };
+      });
+      expect(
+        result.overflow,
+        `horizontal overflow (${vp.name}-${lang}):\n${result.offenders.join("\n")}`,
+      ).toBeLessThanOrEqual(1);
+    });
+  }
+}

--- a/src/components/dashboard.tsx
+++ b/src/components/dashboard.tsx
@@ -701,7 +701,7 @@ function FacetBar() {
   }, [tick]);
 
   const cls =
-    "hidden rounded-full border border-panel-border bg-background/40 px-2.5 py-1 text-xs text-muted outline-none transition-colors hover:border-accent/50 focus:border-accent sm:block";
+    "hidden max-w-[10rem] truncate rounded-full border border-panel-border bg-background/40 px-2.5 py-1 text-xs text-muted outline-none transition-colors hover:border-accent/50 focus:border-accent sm:block";
 
   return (
     <>

--- a/src/plugins/calendar-heatmap/widget.tsx
+++ b/src/plugins/calendar-heatmap/widget.tsx
@@ -68,7 +68,7 @@ export function CalendarHeatmap() {
       ) : cal.total === 0 ? (
         <WidgetState icon={CalendarRange} title={t("calendar.empty")} />
       ) : (
-        <div className="flex h-full flex-col justify-center gap-2 overflow-auto p-4">
+        <div tabIndex={0} className="flex h-full flex-col justify-center gap-2 overflow-auto p-4 outline-none">
           <div className="inline-flex min-w-min flex-col gap-1">
             <div className="flex text-[9px] text-muted">
               {segments.map((s, i) => (

--- a/src/plugins/compaction-timeline/widget.tsx
+++ b/src/plugins/compaction-timeline/widget.tsx
@@ -71,7 +71,7 @@ export function CompactionTimeline() {
             </div>
           </div>
 
-          <ul className="min-h-0 flex-1 space-y-1.5 overflow-auto">
+          <ul tabIndex={0} className="min-h-0 flex-1 space-y-1.5 overflow-auto outline-none">
             {compactions.slice(0, 30).map((c) => (
               <li key={c.id} className="mc-stream-in flex items-center gap-2 text-sm">
                 <Layers className="h-3.5 w-3.5 shrink-0 text-orange-400" />

--- a/src/plugins/model-donut/widget.tsx
+++ b/src/plugins/model-donut/widget.tsx
@@ -103,7 +103,7 @@ export function ModelDonut() {
             </div>
           </div>
 
-          <ul className="flex min-w-0 flex-1 flex-col justify-center gap-1.5 overflow-auto text-xs">
+          <ul tabIndex={0} className="flex min-w-0 flex-1 flex-col justify-center gap-1.5 overflow-auto text-xs outline-none">
             {slices.map((s, i) => (
               <li key={s.full} className="flex items-center justify-between gap-2">
                 <span className="flex min-w-0 items-center gap-1.5">

--- a/src/plugins/reliability/widget.tsx
+++ b/src/plugins/reliability/widget.tsx
@@ -32,7 +32,7 @@ export function Reliability() {
       ) : filtered.length === 0 ? (
         <WidgetState icon={ShieldCheck} title={t("common.noResults")} />
       ) : (
-        <ul className="flex h-full flex-col justify-center gap-2.5 overflow-auto p-4">
+        <ul tabIndex={0} className="flex h-full flex-col justify-center gap-2.5 overflow-auto p-4 outline-none">
           {filtered.map((p) => {
             const c = rateColor(p.successRate);
             return (

--- a/src/plugins/tag-cloud/widget.tsx
+++ b/src/plugins/tag-cloud/widget.tsx
@@ -48,7 +48,7 @@ export function TagCloud() {
       ) : filtered.length === 0 ? (
         <WidgetState icon={Hash} title={t("common.noResults")} />
       ) : (
-        <div className="flex h-full flex-wrap content-start items-baseline gap-x-3 gap-y-1.5 overflow-auto p-4 leading-tight">
+        <div tabIndex={0} className="flex h-full flex-wrap content-start items-baseline gap-x-3 gap-y-1.5 overflow-auto p-4 leading-tight outline-none">
           {filtered.map((tc) => {
             const s = scale(tc.count);
             return (

--- a/src/plugins/tool-frequency/widget.tsx
+++ b/src/plugins/tool-frequency/widget.tsx
@@ -86,7 +86,7 @@ export function ToolFrequency() {
       ) : tools.length === 0 ? (
         <WidgetState icon={Hammer} title={t("tools.empty")} />
       ) : (
-        <ul className="flex h-full flex-col justify-center gap-2 overflow-auto p-4">
+        <ul tabIndex={0} className="flex h-full flex-col justify-center gap-2 overflow-auto p-4 outline-none">
           {tools.map((tool) => (
             <li key={tool.tool} title={tool.avgDurationMs != null ? `⌀ ${tool.avgDurationMs} ms` : undefined}>
               <div className="mb-1 flex items-center justify-between gap-2 text-xs">


### PR DESCRIPTION
## Summary
Phase Z **typography & readability** audit (Run 102).

- New `e2e/typography.spec.ts`: a stress test that seeds **pathological long/unbroken** session titles, project names and file paths, then asserts **no horizontal overflow** across mobile / desktop / QHD in **de + en** (worst cases for truncation and translation length).
- It surfaced — and this PR fixes — two real issues:
  - **Header project filter** grew to fit a 200-char project option and blew out the header → capped with `max-w-[10rem] truncate`.
  - **Widget-internal scroll lists** (tag cloud, top-tools, reliability, compactions, model-donut legend, year calendar) weren't keyboard-focusable when their content overflows → added `tabIndex={0}` (WCAG 2.1.1), matching the Panel/timeline fix from Run 96.

### Note on test isolation
These bugs only manifest with lots of data. The shared Playwright DB persists across local runs, so re-running can accumulate the stress data; CI uses a fresh DB and runs `a11y`/`layout` before `typography` seeds, so the suite is green. Verified with a wiped data dir.

## Test plan
- [x] `npm run lint`
- [x] `npx vitest run` (400 passing)
- [x] `npm run build`
- [x] `npm run test:e2e` on a clean data dir (22 passing: 4 a11y + 10 layout + 2 smoke + 6 typography)

Run 102 of **Phase Z**.

https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk)_