### PR TITLE
Kanban audit: readable mobile columns + functional card/filter test

### DIFF
--- a/e2e/kanban.spec.ts
+++ b/e2e/kanban.spec.ts
@@ -1,0 +1,65 @@
+import { test, expect, request as playwrightRequest, type APIRequestContext, type Page } from "@playwright/test";
+
+const BASE_URL = "http://127.0.0.1:3100";
+const PROJECT = "kanban-bot";
+const TITLE = "Kanban audit session";
+const SESSION_ID = `kanban-${Date.now()}`;
+
+test.beforeAll(async () => {
+  const ctx: APIRequestContext = await playwrightRequest.newContext({ baseURL: BASE_URL });
+  const base = { session_id: SESSION_ID, cwd: `/home/user/projects/${PROJECT}` };
+  const post = (event: string, payload: Record<string, unknown>) =>
+    ctx.post("/api/ingest", {
+      headers: { "X-Hook-Event": event, "Content-Type": "application/json" },
+      data: { ...payload, hook_event_name: event },
+    });
+  await post("SessionStart", { ...base, source: "startup" });
+  await post("UserPromptSubmit", { ...base, prompt: TITLE });
+  await post("PostToolUse", { ...base, tool_name: "Read", tool_input: { file_path: "/x.ts" }, tool_response: { ok: true } });
+  await post("SessionEnd", { ...base }); // → "ended" column
+  await ctx.dispose();
+});
+
+function prime(page: Page) {
+  return page.addInitScript(() => {
+    try {
+      localStorage.setItem("mc-onboarded", "1");
+    } catch {
+      /* ignore */
+    }
+  });
+}
+
+function card(page: Page) {
+  return page.getByRole("button").filter({ hasText: TITLE }).first();
+}
+
+test("card opens the detail dialog with a drilldown link, then closes", async ({ page }) => {
+  await prime(page);
+  await page.goto("/");
+  await expect(page.getByTestId("connection-status")).toHaveAttribute("data-state", "connected", { timeout: 15_000 });
+
+  await expect(card(page)).toBeVisible({ timeout: 15_000 });
+  await card(page).click();
+
+  const dialog = page.getByRole("dialog");
+  await expect(dialog).toBeVisible();
+  await expect(dialog.getByRole("heading", { name: TITLE })).toBeVisible();
+  await expect(dialog.getByText(PROJECT, { exact: true })).toBeVisible();
+  // Drilldown to the full session page.
+  await expect(dialog.getByRole("link")).toHaveAttribute("href", `/session?id=${SESSION_ID}`);
+
+  await page.keyboard.press("Escape");
+  await expect(dialog).toBeHidden();
+});
+
+test("status facet filters the board", async ({ page }) => {
+  await prime(page);
+  // The seeded session is ended → visible under status=ended, hidden under status=active.
+  await page.goto("/?status=ended");
+  await expect(card(page)).toBeVisible({ timeout: 15_000 });
+
+  await page.goto("/?status=active");
+  await expect(page.getByTestId("connection-status")).toHaveAttribute("data-state", "connected", { timeout: 15_000 });
+  await expect(card(page)).toHaveCount(0);
+});

--- a/src/plugins/kanban/widget.tsx
+++ b/src/plugins/kanban/widget.tsx
@@ -68,12 +68,14 @@ export function Kanban() {
       icon={<KanbanSquare className="h-4 w-4 text-accent" />}
       info={t("kanban.info")}
     >
-      <div className="grid h-full grid-cols-3 gap-px bg-panel-border/50">
+      {/* On phones the 3 columns become a horizontal swipe with readable widths;
+          from sm up they're an even 3-column grid. */}
+      <div className="flex h-full snap-x gap-px overflow-x-auto bg-panel-border/50 sm:grid sm:grid-cols-3 sm:overflow-x-hidden">
         {COLUMNS.map((status) => {
           const items = byStatus[status];
           const meta = STATUS_META[status];
           return (
-            <div key={status} className="flex min-h-0 flex-col bg-panel">
+            <div key={status} className="flex min-h-0 w-[78%] shrink-0 snap-start flex-col bg-panel sm:w-auto sm:shrink">
               <div className="flex items-center justify-between px-3 py-2">
                 <span className={`flex items-center gap-1.5 text-xs font-semibold ${meta.text}`}>
                   <span className={`h-2 w-2 rounded-full ${meta.dot}`} />


### PR DESCRIPTION
## Summary
Phase Z **Kanban (Sessions)** audit (Run 104).

- **Fixes the dense mobile kanban** flagged back in Run 100: at `< sm` the three columns were squeezed to ~120px and card footers wrapped/overlapped. The board now becomes a **horizontal swipe** with readable column widths (`w-[78%]`, snap) on phones and stays an even **3-column grid** from `sm` up. No page-level overflow is introduced (it scrolls internally; the columns contain focusable cards so the scroll region stays keyboard-accessible).
- **Functional test** `e2e/kanban.spec.ts`:
  - clicking a card opens the **detail dialog** (heading, project, and the **drilldown link** to `/session?id=…`), and **Escape** closes it;
  - the **status facet** (`?status=…`) filters the board (ended card shows under `ended`, hidden under `active`).

## Test plan
- [x] `npm run lint`
- [x] `npx vitest run` (406 passing)
- [x] `npm run build`
- [x] `npm run test:e2e` on a clean data dir (24 passing: +2 kanban)
- [x] Reviewed the regenerated mobile screenshot — columns are now readable

Run 104 of **Phase Z**.

https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk)_