### PR TITLE
Live stream audit: restore newest-row slide-in under virtualization

### DIFF
--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -70,7 +70,10 @@ test("seeded activity flows into the live stream and kanban", async ({ page }) =
   await page.goto("/");
 
   // Live stream shows the backlog (delivered via /api/events then SSE).
-  await expect(page.getByRole("log").getByRole("listitem").first()).toBeVisible({ timeout: 15_000 });
+  const newest = page.getByRole("log").getByRole("listitem").first();
+  await expect(newest).toBeVisible({ timeout: 15_000 });
+  // The newest row carries the slide-in animation (regression guard for Run 105).
+  await expect(newest).toHaveClass(/mc-stream-in/);
 
   // Kanban shows the seeded session card by its prompt-derived title, with the
   // project name on it. Scope to the card button so we don't match the project

--- a/src/plugins/live-stream/widget.tsx
+++ b/src/plugins/live-stream/widget.tsx
@@ -126,14 +126,17 @@ export function LiveStream() {
         <div ref={scrollRef} onScroll={onScroll} tabIndex={0} className="h-full overflow-auto outline-none">
           <div role="log" aria-live="polite" aria-label={t("stream.title")}>
             <ul className="divide-y divide-panel-border/60" style={{ paddingTop: win.padTop, paddingBottom: win.padBottom }}>
-              {visible.map((e) => {
+              {visible.map((e, i) => {
                 const kind = eventKind(e.event_type);
                 const Icon = ICONS[kind];
+                // Slide-in only the newest row (global index 0) so a fresh event
+                // animates in at the top without every row re-animating on scroll.
+                const newest = win.start + i === 0;
                 return (
                   <li
                     key={e.id}
                     style={{ height: ROW_H }}
-                    className="flex items-start gap-2.5 px-4 py-2 transition-colors hover:bg-white/[0.03]"
+                    className={`flex items-start gap-2.5 px-4 py-2 transition-colors hover:bg-white/[0.03] ${newest ? "mc-stream-in" : ""}`}
                   >
                     <Icon className={`mt-0.5 h-4 w-4 shrink-0 ${KIND_COLOR[kind]}`} />
                     <div className="min-w-0 flex-1">


### PR DESCRIPTION
The list virtualization in Run 97 dropped the live stream's slide-in. Restore it for the newest row only (global index 0) so a fresh event animates in at the top without every row re-animating on scroll. The SSE indicator (pulse), the "Jetzt live" radar ping and the 1s elapsed timer were verified intact. Adds a smoke assertion that the newest live-stream row carries mc-stream-in to guard the regression.

https://claude.ai/code/session_01BdkgL9mkn1yVQxWMjxFzBk