### PR TITLE
Tool-graph (3D) audit: fix loading flash + cross-theme E2E audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,8 +63,9 @@ jobs:
       # Playwright boots `npm run start` (see playwright.config.ts), seeds via the
       # ingest API and asserts the dashboard renders, connects and populates. Also
       # runs the axe-core accessibility audit (e2e/a11y.spec.ts) and the Phase Z
-      # layout audit (e2e/layout.spec.ts) as CI gates.
-      - name: Smoke + a11y + layout E2E
+      # layout (e2e/layout.spec.ts) and tool-graph (e2e/tool-graph.spec.ts) audits
+      # as CI gates.
+      - name: Smoke + a11y + layout + tool-graph E2E
         run: npm run test:e2e
 
       # Always collect the layout-audit screenshots (Phase Z) for visual review.
@@ -73,6 +74,14 @@ jobs:
         with:
           name: layout-screenshots
           path: test-results/layout-shots
+          if-no-files-found: ignore
+
+      # Always collect the tool-graph audit screenshots (Phase Z, Run 107).
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: tool-graph-screenshots
+          path: test-results/tool-graph-shots
           if-no-files-found: ignore
 
       - uses: actions/upload-artifact@v4

--- a/e2e/tool-graph.spec.ts
+++ b/e2e/tool-graph.spec.ts
@@ -1,0 +1,182 @@
+import { test, expect, request as playwrightRequest, type APIRequestContext, type Page } from "@playwright/test";
+
+const BASE_URL = "http://127.0.0.1:3100";
+const PROJECT = "graph-bot";
+
+// Seed one active session with a prompt and several tools touching varied targets
+// (file, command, url, pattern) so the 3D graph builds a rich, multi-kind
+// Session → Tool → Resource structure with a clear central session hub.
+async function seed() {
+  const ctx: APIRequestContext = await playwrightRequest.newContext({ baseURL: BASE_URL });
+  const base = { session_id: `graph-${Date.now()}`, cwd: `/home/user/projects/${PROJECT}` };
+  const post = (event: string, payload: Record<string, unknown>) =>
+    ctx.post("/api/ingest", {
+      headers: { "X-Hook-Event": event, "Content-Type": "application/json" },
+      data: { ...payload, hook_event_name: event },
+    });
+  await post("SessionStart", { ...base, source: "startup" });
+  await post("UserPromptSubmit", { ...base, prompt: "Build the 3D tool-graph audit fixture." });
+  const tools: [string, Record<string, unknown>][] = [
+    ["Read", { file_path: "/home/user/projects/graph-bot/src/a.ts" }],
+    ["Edit", { file_path: "/home/user/projects/graph-bot/src/b.ts" }],
+    ["Bash", { command: "npm run build" }],
+    ["Grep", { pattern: "buildGraph" }],
+    ["WebFetch", { url: "https://example.com/docs" }],
+  ];
+  for (const [tool, input] of tools) {
+    await post("PreToolUse", { ...base, tool_name: tool, tool_input: input });
+    await post("PostToolUse", { ...base, tool_name: tool, tool_input: input, tool_response: { ok: true } });
+  }
+  await ctx.dispose();
+}
+
+test.beforeAll(seed);
+
+// Force a deterministic theme/lang and skip the first-run wizard before any script runs.
+function prime(page: Page, mode: "dark" | "light", lang: "de" | "en") {
+  return page.addInitScript(
+    ([m, l]) => {
+      try {
+        localStorage.setItem("mc-onboarded", "1");
+        localStorage.setItem("mc-theme", JSON.stringify({ mode: m, accent: "#4f8cff" }));
+        localStorage.setItem("mc-lang", l);
+      } catch {
+        /* ignore */
+      }
+    },
+    [mode, lang] as const,
+  );
+}
+
+// Headless WebGL (SwiftShader) and three.js can emit benign info/warnings, and the
+// React DevTools nudge is noise. None are real errors for this audit.
+const IGNORE = [/WebGL/i, /THREE\.WebGLRenderer/i, /Download the React DevTools/i];
+
+function watchConsole(page: Page, errors: string[]) {
+  page.on("console", (m) => {
+    if (m.type() === "error" && !IGNORE.some((re) => re.test(m.text()))) errors.push(m.text());
+  });
+  page.on("pageerror", (e) => {
+    if (!IGNORE.some((re) => re.test(e.message))) errors.push(e.message);
+  });
+}
+
+async function gotoDashboard(page: Page) {
+  await page.goto("/");
+  await expect(page.getByRole("heading", { name: "Claude Mission Control" })).toBeVisible({ timeout: 15_000 });
+  // SSE keeps the network busy, so wait for the live connection rather than idle.
+  await expect(page.getByTestId("connection-status")).toHaveAttribute("data-state", "connected", { timeout: 15_000 });
+}
+
+const widgetOf = (page: Page) => page.locator("#mc-widget-tool-graph");
+
+// Nodes live inside a WebGL <canvas>, so there is no DOM element to target, the force
+// layout is randomised per run, and continuous 3D rendering makes the page slow to
+// drive when the graph is busy. So clicking a specific node deterministically is not
+// feasible. We instead *exercise* the click handlers: click a small grid (ordered
+// outward from the centre, where a single-session hub tends to settle), time-capped,
+// and — when a node happens to be hit — verify its detail card opens and closes. The
+// hard gates are load/labels/fullscreen/console + the screenshot matrix; the
+// clean-console check guards onNodeClick/onBackgroundClick against regressions.
+async function exerciseNodeClick(page: Page, container: ReturnType<typeof widgetOf>): Promise<boolean> {
+  const box = await container.locator("canvas").first().boundingBox();
+  if (!box) return false;
+  const close = container.getByRole("button", { name: "Schließen" });
+  const n = 5;
+  const pts: [number, number][] = [];
+  for (let r = 1; r <= n; r++)
+    for (let c = 1; c <= n; c++) pts.push([box.x + (box.width * c) / (n + 1), box.y + (box.height * r) / (n + 1)]);
+  const cx = box.x + box.width / 2;
+  const cy = box.y + box.height / 2;
+  pts.sort((a, b) => (a[0] - cx) ** 2 + (a[1] - cy) ** 2 - ((b[0] - cx) ** 2 + (b[1] - cy) ** 2));
+  const deadline = Date.now() + 6000;
+  for (const [x, y] of pts) {
+    if (Date.now() > deadline) break;
+    await page.mouse.click(x, y);
+    await page.waitForTimeout(10);
+    if ((await close.count()) > 0 && (await close.isVisible())) return true;
+  }
+  return false;
+}
+
+test("graph loads, shows labels, handles node click + fullscreen — clean console", async ({ page }) => {
+  test.setTimeout(60_000);
+  const errors: string[] = [];
+  watchConsole(page, errors);
+
+  await prime(page, "dark", "de");
+  await gotoDashboard(page);
+  const widget = widgetOf(page);
+  await widget.scrollIntoViewIfNeeded();
+
+  // Loading never sticks as a false "empty": once settled we get either the WebGL
+  // canvas or the explicit no-WebGL hint — never a crash, never a stale empty.
+  const canvas = widget.locator("canvas");
+  const noWebgl = widget.getByText(/WebGL/i);
+  await expect(canvas.or(noWebgl).first()).toBeVisible({ timeout: 20_000 });
+  const hasCanvas = (await canvas.count()) > 0;
+
+  if (hasCanvas) {
+    // Let the force layout + zoomToFit settle. The widget (unlike the demo engine)
+    // does not auto-rotate, so nodes then hold still for hit-testing.
+    await page.waitForTimeout(4000);
+    // Labels: the legend lists the node kinds present in the graph, translated.
+    await expect(widget.getByText("Session", { exact: true })).toBeVisible();
+    await expect(widget.getByText("Tool", { exact: true })).toBeVisible();
+
+    // Node click → exercise the handlers; verify the detail card open/close path
+    // whenever a node is actually hit.
+    if (await exerciseNodeClick(page, widget)) {
+      const close = widget.getByRole("button", { name: "Schließen" });
+      await close.click();
+      await expect(close).toBeHidden();
+    }
+  }
+
+  // Fullscreen toggle: maximise → fixed overlay + shrink control; Escape restores.
+  await widget.getByRole("button", { name: "Vollbild" }).click();
+  const overlay = page.locator(".fixed.inset-0");
+  await expect(overlay).toBeVisible();
+  await expect(page.getByRole("button", { name: "Verkleinern" })).toBeVisible();
+  await page.keyboard.press("Escape");
+  await expect(overlay).toHaveCount(0);
+
+  expect(errors, `console errors:\n${errors.join("\n")}`).toEqual([]);
+});
+
+// Visual matrix: every theme × breakpoint (plus an English desktop pass), each
+// collected as a CI artifact for review. Mirrors the Phase Z layout audit.
+const VIEWPORTS = [
+  { name: "mobile", width: 390, height: 844 },
+  { name: "desktop", width: 1440, height: 900 },
+  { name: "qhd", width: 2560, height: 1440 },
+  { name: "uhd", width: 3840, height: 2160 },
+] as const;
+const MODES = ["dark", "light"] as const;
+
+for (const vp of VIEWPORTS) {
+  for (const mode of MODES) {
+    const langs: ("de" | "en")[] = vp.name === "desktop" ? ["de", "en"] : ["de"];
+    for (const lang of langs) {
+      const label = `${vp.name}-${mode}-${lang}`;
+      test(`tool-graph visual — ${label}`, async ({ page }, testInfo) => {
+        const errors: string[] = [];
+        watchConsole(page, errors);
+
+        await page.setViewportSize({ width: vp.width, height: vp.height });
+        await prime(page, mode, lang);
+        await gotoDashboard(page);
+        const widget = widgetOf(page);
+        await widget.scrollIntoViewIfNeeded();
+        await expect(widget.locator("canvas").or(widget.getByText(/WebGL/i)).first()).toBeVisible({ timeout: 20_000 });
+        // Let the simulation settle so the screenshot is fitted, not mid-layout.
+        await page.waitForTimeout(4000);
+
+        const shot = await widget.screenshot({ path: `test-results/tool-graph-shots/${label}.png` });
+        await testInfo.attach(label, { body: shot, contentType: "image/png" });
+
+        expect(errors, `console errors (${label}):\n${errors.join("\n")}`).toEqual([]);
+      });
+    }
+  }
+}

--- a/src/plugins/tool-graph/widget.tsx
+++ b/src/plugins/tool-graph/widget.tsx
@@ -105,6 +105,9 @@ export function ToolGraph() {
   const threeRef = useRef<any>(null);
   const [threeReady, setThreeReady] = useState(false);
   const [webglOk, setWebglOk] = useState(true);
+  // False until the first /api/graph fetch settles, so initial paint shows a
+  // loading state instead of a misleading "no tool calls yet" empty flash.
+  const [loaded, setLoaded] = useState(false);
   const sig = useRef("");
 
   // WebGL support is only knowable on the client; assume ok during SSR/first paint
@@ -146,7 +149,8 @@ export function ToolGraph() {
           setData(d);
           setSelected((cur) => (cur ? d.nodes.find((n) => n.id === cur.id) ?? null : null));
         })
-        .catch(() => {});
+        .catch(() => {})
+        .finally(() => setLoaded(true));
     }, delay);
     return () => clearTimeout(t);
   }, [tick]);
@@ -403,6 +407,8 @@ export function ToolGraph() {
         <div ref={wrapRef} className="relative h-full w-full">
           {!webglOk ? (
             <WidgetState icon={Boxes} title={t("graph.noWebgl")} />
+          ) : !loaded ? (
+            <WidgetState icon={Boxes} title={t("common.loading")} loading />
           ) : data.nodes.length === 0 ? (
             <WidgetState icon={Boxes} title={t("graph.empty")} />
           ) : dims.w > 0 ? (


### PR DESCRIPTION
## Run 107 — Phase Z: Tool-Graph (3D) visual & functional acceptance

Visual & functional pass over the 3D tool-call graph (load, labels, node click, fullscreen, performance), per the roadmap's Phase Z.

### Changes
- **Fix a false-empty flash** (`src/plugins/tool-graph/widget.tsx`): on first paint the widget showed *"no tool calls yet"* before the first `/api/graph` fetch settled, because the empty branch was checked ahead of any loaded flag. It now shows a proper **loading** state until the first fetch resolves (success or failure).
- **New audit spec** `e2e/tool-graph.spec.ts`:
  - graph **loads** — a WebGL `<canvas>` *or* a clean no-WebGL fallback, never a crash/stale empty;
  - **labels** — the translated legend renders the present node kinds;
  - **fullscreen** toggle — maximise → fixed overlay + shrink control → Escape restores;
  - **node-click** handlers exercised;
  - **screenshot matrix** — de/en × light/dark × mobile/desktop/qhd/uhd, collected as a CI artifact;
  - all under a **clean-console** gate.
- **CI** (`.github/workflows/ci.yml`): uploads the tool-graph screenshots as an artifact (`tool-graph-screenshots`).

### Audit note (node click)
Clicking an *exact* node inside the WebGL canvas is not deterministically automatable — the force layout is randomised per run and continuous 3D rendering saturates the main thread (blind scanning timed out under full-suite load). So the **node-click → detail-card → close** path was verified **manually** during the audit (detail card showing project/status + working close), and the spec only *exercises* the click handlers within a time cap (the clean-console gate catches handler regressions).

### Verified visually
Dark/Light, German/English, mobile — graph fitted, correct translations, no console errors.

### Definition of Done
- `npm run lint` ✓
- `npm test` ✓ (406)
- `npm run build` ✓
- `npm run test:e2e` ✓ (35 passed, incl. the new audit)
- golden rule intact (read-only; data still flows Hooks → /api/ingest → SQLite → UI)

https://claude.ai/code/session_01UEgRzpHQh5WY2WKZgcscZA

---
_Generated by [Claude Code](https://claude.ai/code/session_01UEgRzpHQh5WY2WKZgcscZA)_