### PR TITLE
Budget-gauge audit: ARIA progressbar + tested thresholds + state E2E

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,9 +63,9 @@ jobs:
       # Playwright boots `npm run start` (see playwright.config.ts), seeds via the
       # ingest API and asserts the dashboard renders, connects and populates. Also
       # runs the axe-core accessibility audit (e2e/a11y.spec.ts) and the Phase Z
-      # layout (e2e/layout.spec.ts) and tool-graph (e2e/tool-graph.spec.ts) audits
-      # as CI gates.
-      - name: Smoke + a11y + layout + tool-graph E2E
+      # layout (e2e/layout.spec.ts), tool-graph (e2e/tool-graph.spec.ts) and
+      # budget-gauge (e2e/budget-gauge.spec.ts) audits as CI gates.
+      - name: Smoke + a11y + layout + tool-graph + budget-gauge E2E
         run: npm run test:e2e
 
       # Always collect the layout-audit screenshots (Phase Z) for visual review.
@@ -82,6 +82,14 @@ jobs:
         with:
           name: tool-graph-screenshots
           path: test-results/tool-graph-shots
+          if-no-files-found: ignore
+
+      # Always collect the budget-gauge audit screenshots (Phase Z, Run 108).
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: budget-gauge-screenshots
+          path: test-results/budget-gauge-shots
           if-no-files-found: ignore
 
       - uses: actions/upload-artifact@v4

--- a/e2e/budget-gauge.spec.ts
+++ b/e2e/budget-gauge.spec.ts
@@ -1,0 +1,178 @@
+import { test, expect, type Page } from "@playwright/test";
+
+// The budget gauge is fed by ccusage, which has no data in CI. So we stub
+// /api/budget per page to drive every threshold/overage state deterministically —
+// which also makes the audit screenshots reproducible. The real read path
+// (ccusage → /api/budget) is covered by src/lib/budget.test.ts.
+
+type Tier = { pct: number; over: boolean } | null;
+
+function gaugePayload(daily: Tier, monthly: Tier) {
+  const dailyUsd = 15;
+  const monthlyUsd = 300;
+  const status = (budget: number, t: Tier) =>
+    t == null
+      ? { budgetUsd: null, spentUsd: 0, pct: null }
+      : { budgetUsd: budget, spentUsd: +(budget * t.pct).toFixed(2), pct: t.pct };
+  const proj = (budget: number, t: Tier) =>
+    t == null
+      ? { projectedUsd: 0, budgetUsd: null, projectedPct: null, overBudget: false }
+      : { projectedUsd: +(budget * t.pct * 1.3).toFixed(2), budgetUsd: budget, projectedPct: t.pct * 1.3, overBudget: t.over };
+  return {
+    budgets: { dailyUsd: daily ? dailyUsd : null, monthlyUsd: monthly ? monthlyUsd : null },
+    status: { daily: status(dailyUsd, daily), monthly: status(monthlyUsd, monthly) },
+    projection: { daily: proj(dailyUsd, daily), monthly: proj(monthlyUsd, monthly) },
+  };
+}
+
+async function stubBudget(page: Page, body: object) {
+  await page.route("**/api/budget", (route) =>
+    route.fulfill({ contentType: "application/json", body: JSON.stringify(body) }),
+  );
+}
+
+function prime(page: Page, mode: "dark" | "light", lang: "de" | "en") {
+  return page.addInitScript(
+    ([m, l]) => {
+      try {
+        localStorage.setItem("mc-onboarded", "1");
+        localStorage.setItem("mc-theme", JSON.stringify({ mode: m, accent: "#4f8cff" }));
+        localStorage.setItem("mc-lang", l);
+      } catch {
+        /* ignore */
+      }
+    },
+    [mode, lang] as const,
+  );
+}
+
+// 3D graph WebGL noise + the React DevTools nudge are not real errors here.
+const IGNORE = [/WebGL/i, /THREE\.WebGLRenderer/i, /Download the React DevTools/i];
+
+function watchConsole(page: Page, errors: string[]) {
+  page.on("console", (m) => {
+    if (m.type() === "error" && !IGNORE.some((re) => re.test(m.text()))) errors.push(m.text());
+  });
+  page.on("pageerror", (e) => {
+    if (!IGNORE.some((re) => re.test(e.message))) errors.push(e.message);
+  });
+}
+
+async function gotoDashboard(page: Page) {
+  await page.goto("/");
+  await expect(page.getByRole("heading", { name: "Claude Mission Control" })).toBeVisible({ timeout: 15_000 });
+  await expect(page.getByTestId("connection-status")).toHaveAttribute("data-state", "connected", { timeout: 15_000 });
+}
+
+const widgetOf = (page: Page) => page.locator("#mc-widget-budget-gauge");
+
+test("threshold colours, overage cap + alarm, ARIA progressbar values", async ({ page }) => {
+  const errors: string[] = [];
+  watchConsole(page, errors);
+
+  // Daily under budget (green); monthly over budget (red) with an over-budget
+  // projection → the alarm banner shows.
+  await stubBudget(page, gaugePayload({ pct: 0.4, over: false }, { pct: 1.1, over: true }));
+  await prime(page, "dark", "de");
+  await gotoDashboard(page);
+  const w = widgetOf(page);
+  await w.scrollIntoViewIfNeeded();
+
+  const daily = w.getByRole("progressbar", { name: "Heute" });
+  const monthly = w.getByRole("progressbar", { name: "Dieser Monat" });
+
+  // Display + ARIA: the gauges expose their fraction to assistive tech, and the
+  // amounts/percent are shown.
+  await expect(daily).toBeVisible();
+  await expect(daily).toHaveAttribute("aria-valuenow", "40");
+  await expect(daily).toHaveAttribute("aria-valuemax", "100");
+  await expect(daily).toHaveAttribute("aria-valuetext", "$6.00 / $15.00 · 40%");
+  await expect(w.getByText("$6.00 / $15.00 · 40%")).toBeVisible();
+
+  // Threshold colours: green under 75%, red once at/over budget.
+  await expect(daily.locator("div").first()).toHaveClass(/bg-emerald-500/);
+  await expect(monthly.locator("div").first()).toHaveClass(/bg-red-500/);
+
+  // Overage: the bar value clamps to 100 even though spend projects past it…
+  await expect(monthly).toHaveAttribute("aria-valuenow", "100");
+  // …while the visible label still reports the true 110%.
+  await expect(w.getByText(/· 110%$/)).toBeVisible();
+
+  // Alarm banner for the over-budget projection.
+  await expect(w.getByText(/über Budget/i)).toBeVisible();
+
+  expect(errors, `console errors:\n${errors.join("\n")}`).toEqual([]);
+});
+
+test("amber warning tier between 75% and budget", async ({ page }) => {
+  const errors: string[] = [];
+  watchConsole(page, errors);
+
+  await stubBudget(page, gaugePayload({ pct: 0.82, over: false }, { pct: 0.5, over: false }));
+  await prime(page, "dark", "de");
+  await gotoDashboard(page);
+  const w = widgetOf(page);
+  await w.scrollIntoViewIfNeeded();
+
+  const daily = w.getByRole("progressbar", { name: "Heute" });
+  await expect(daily).toHaveAttribute("aria-valuenow", "82");
+  await expect(daily.locator("div").first()).toHaveClass(/bg-amber-500/);
+  // Under-budget projection → no alarm banner.
+  await expect(w.getByText(/über Budget/i)).toHaveCount(0);
+
+  expect(errors, `console errors:\n${errors.join("\n")}`).toEqual([]);
+});
+
+test("no budget set shows the configuration hint, no gauges", async ({ page }) => {
+  const errors: string[] = [];
+  watchConsole(page, errors);
+
+  await stubBudget(page, gaugePayload(null, null));
+  await prime(page, "dark", "de");
+  await gotoDashboard(page);
+  const w = widgetOf(page);
+  await w.scrollIntoViewIfNeeded();
+
+  await expect(w.getByText("Kein Budget gesetzt.")).toBeVisible();
+  await expect(w.getByText("MC_BUDGET_DAILY")).toBeVisible();
+  await expect(w.getByRole("progressbar")).toHaveCount(0);
+
+  expect(errors, `console errors:\n${errors.join("\n")}`).toEqual([]);
+});
+
+// Visual matrix: every theme × breakpoint (+ an English desktop pass), collected as
+// CI artifacts. A representative payload exercises green, red and the alarm banner.
+const VIEWPORTS = [
+  { name: "mobile", width: 390, height: 844 },
+  { name: "desktop", width: 1440, height: 900 },
+  { name: "qhd", width: 2560, height: 1440 },
+  { name: "uhd", width: 3840, height: 2160 },
+] as const;
+const MODES = ["dark", "light"] as const;
+
+for (const vp of VIEWPORTS) {
+  for (const mode of MODES) {
+    const langs: ("de" | "en")[] = vp.name === "desktop" ? ["de", "en"] : ["de"];
+    for (const lang of langs) {
+      const label = `${vp.name}-${mode}-${lang}`;
+      test(`budget-gauge visual — ${label}`, async ({ page }, testInfo) => {
+        const errors: string[] = [];
+        watchConsole(page, errors);
+
+        await stubBudget(page, gaugePayload({ pct: 0.45, over: false }, { pct: 1.08, over: true }));
+        await page.setViewportSize({ width: vp.width, height: vp.height });
+        await prime(page, mode, lang);
+        await gotoDashboard(page);
+        const w = widgetOf(page);
+        await w.scrollIntoViewIfNeeded();
+        await expect(w.getByRole("progressbar").first()).toBeVisible({ timeout: 15_000 });
+        await page.waitForTimeout(700); // let the bar width/colour transition settle
+
+        const shot = await w.screenshot({ path: `test-results/budget-gauge-shots/${label}.png` });
+        await testInfo.attach(label, { body: shot, contentType: "image/png" });
+
+        expect(errors, `console errors (${label}):\n${errors.join("\n")}`).toEqual([]);
+      });
+    }
+  }
+}

--- a/src/lib/budget.test.ts
+++ b/src/lib/budget.test.ts
@@ -1,6 +1,6 @@
 import Database from "better-sqlite3";
 import { afterEach, describe, expect, it } from "vitest";
-import { computeBudget, dayElapsedFraction, getBudgets, monthElapsedFraction, projectSpend } from "@/lib/budget";
+import { computeBudget, dayElapsedFraction, gaugeTone, getBudgets, monthElapsedFraction, projectSpend } from "@/lib/budget";
 import { setConfig } from "@/lib/config";
 import { migrate } from "@/lib/migrations";
 import type { UsageReport } from "@/lib/ccusage";
@@ -102,5 +102,23 @@ describe("elapsed fractions", () => {
   it("computes month fraction from day of month", () => {
     // 2026-05 has 31 days; on the 16th ~ (15 + 0.5)/31.
     expect(monthElapsedFraction(new Date(2026, 4, 16, 12, 0, 0))).toBeCloseTo((15 + 0.5) / 31, 3);
+  });
+});
+
+describe("gaugeTone", () => {
+  it("is ok below 75% of budget", () => {
+    expect(gaugeTone(0)).toBe("ok");
+    expect(gaugeTone(0.5)).toBe("ok");
+    expect(gaugeTone(0.7499)).toBe("ok");
+  });
+
+  it("warns from 75% up to the budget", () => {
+    expect(gaugeTone(0.75)).toBe("warn");
+    expect(gaugeTone(0.99)).toBe("warn");
+  });
+
+  it("flags over once the budget is reached or exceeded", () => {
+    expect(gaugeTone(1)).toBe("over");
+    expect(gaugeTone(1.5)).toBe("over");
   });
 });

--- a/src/lib/budget.ts
+++ b/src/lib/budget.ts
@@ -21,6 +21,16 @@ export interface BudgetStatus {
   monthly: BudgetUsage;
 }
 
+// Gauge severity from fraction-of-budget used: green under 75%, amber from 75%,
+// red once the budget is reached or exceeded. Kept pure so the thresholds are
+// unit-tested independently of the widget.
+export type GaugeTone = "ok" | "warn" | "over";
+export function gaugeTone(pct: number): GaugeTone {
+  if (pct >= 1) return "over";
+  if (pct >= 0.75) return "warn";
+  return "ok";
+}
+
 function positive(s: string | null | undefined): number | null {
   if (s == null) return null;
   const n = Number(s);

--- a/src/plugins/budget-gauge/widget.tsx
+++ b/src/plugins/budget-gauge/widget.tsx
@@ -6,7 +6,13 @@ import { Panel } from "@/components/panel";
 import { WidgetState } from "@/components/widget-state";
 import { useT } from "@/lib/i18n";
 import { formatMoney } from "@/lib/format";
-import type { BudgetProjection } from "@/lib/budget";
+import { gaugeTone, type BudgetProjection, type GaugeTone } from "@/lib/budget";
+
+const TONE_BAR: Record<GaugeTone, string> = {
+  ok: "bg-emerald-500",
+  warn: "bg-amber-500",
+  over: "bg-red-500",
+};
 
 interface BudgetUsage {
   budgetUsd: number | null;
@@ -80,19 +86,26 @@ function Gauge({
   const { t } = useT();
   if (usage.budgetUsd == null) return null;
   const pct = usage.pct ?? 0;
-  const color = pct >= 1 ? "bg-red-500" : pct >= 0.75 ? "bg-amber-500" : "bg-emerald-500";
+  const shownPct = Math.round(pct * 100);
+  const color = TONE_BAR[gaugeTone(pct)];
   const showProjected = proj != null && usage.spentUsd > 0;
+  const valueText = `${formatMoney(usage.spentUsd, "USD")} / ${formatMoney(usage.budgetUsd, "USD")} · ${shownPct}%`;
 
   return (
     <div>
       <div className="mb-1 flex items-center justify-between text-xs">
         <span className="font-semibold text-foreground">{label}</span>
-        <span className="tabular-nums text-muted">
-          {formatMoney(usage.spentUsd, "USD")} / {formatMoney(usage.budgetUsd, "USD")} ·{" "}
-          {Math.round(pct * 100)}%
-        </span>
+        <span className="tabular-nums text-muted">{valueText}</span>
       </div>
-      <div className="h-2.5 w-full overflow-hidden rounded-full bg-background/70">
+      <div
+        role="progressbar"
+        aria-label={label}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-valuenow={Math.min(100, Math.max(0, shownPct))}
+        aria-valuetext={valueText}
+        className="h-2.5 w-full overflow-hidden rounded-full bg-background/70"
+      >
         <div
           className={`h-full rounded-full ${color} transition-all duration-500`}
           style={{ width: `${Math.min(pct, 1) * 100}%` }}


### PR DESCRIPTION
## Run 108 — Phase Z: Budget-Gauge visual & functional acceptance

Visual & functional pass over the budget gauge (threshold colours, display, overage, animation), per the roadmap's Phase Z.

### Changes
- **Accessibility** (`src/plugins/budget-gauge/widget.tsx`): the gauge bars were plain `div`s with no semantics (no `role="progressbar"` existed anywhere in the app). Each bar now exposes `role="progressbar"` with `aria-label`, `aria-valuemin/max/now` (clamped to 0..100) and an `aria-valuetext` carrying the spend / budget / percent.
- **Tested thresholds** (`src/lib/budget.ts` + `budget.test.ts`): the colour logic moved into a pure, unit-tested `gaugeTone(pct)` — green under 75%, amber from 75%, red at/over budget.
- **New audit spec** `e2e/budget-gauge.spec.ts`: the gauge is fed by ccusage (no data in CI), so `/api/budget` is **stubbed per page** to drive every state deterministically (and make the screenshots reproducible):
  - **green / amber / over-budget** threshold colours;
  - **overage** — the bar value clamps to 100% while the label still reports the true percent (e.g. 110%);
  - the **over-budget alarm banner**;
  - the **"no budget set"** configuration hint (no gauges);
  - **screenshot matrix** — de/en × light/dark × mobile/desktop/qhd/uhd, under a clean-console gate.
- **CI** (`.github/workflows/ci.yml`): uploads the budget-gauge screenshots as an artifact (`budget-gauge-screenshots`).

### Verified visually
Dark/Light, German/English — green/amber/over-budget bars, alarm banner, projection text and the empty state all render cleanly, no console errors.

### Definition of Done
- `npm run lint` ✓
- `npm test` ✓ (409)
- `npm run build` ✓
- `npm run test:e2e` ✓ (48 passed, incl. the new audit)
- golden rule intact (read-only; data still flows Hooks → /api/ingest → SQLite → UI)

https://claude.ai/code/session_01UEgRzpHQh5WY2WKZgcscZA

---
_Generated by [Claude Code](https://claude.ai/code/session_01UEgRzpHQh5WY2WKZgcscZA)_