### PR TITLE
Heatmap audit: fix invisible empty cells on light theme + punchcard E2E

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,9 +63,10 @@ jobs:
       # Playwright boots `npm run start` (see playwright.config.ts), seeds via the
       # ingest API and asserts the dashboard renders, connects and populates. Also
       # runs the axe-core accessibility audit (e2e/a11y.spec.ts) and the Phase Z
-      # layout (e2e/layout.spec.ts), tool-graph (e2e/tool-graph.spec.ts) and
-      # budget-gauge (e2e/budget-gauge.spec.ts) audits as CI gates.
-      - name: Smoke + a11y + layout + tool-graph + budget-gauge E2E
+      # layout (e2e/layout.spec.ts), tool-graph (e2e/tool-graph.spec.ts),
+      # budget-gauge (e2e/budget-gauge.spec.ts) and heatmap (e2e/heatmap.spec.ts)
+      # audits as CI gates.
+      - name: Smoke + a11y + Phase Z widget E2E
         run: npm run test:e2e
 
       # Always collect the layout-audit screenshots (Phase Z) for visual review.
@@ -90,6 +91,14 @@ jobs:
         with:
           name: budget-gauge-screenshots
           path: test-results/budget-gauge-shots
+          if-no-files-found: ignore
+
+      # Always collect the heatmap audit screenshots (Phase Z, Run 109).
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: heatmap-screenshots
+          path: test-results/heatmap-shots
           if-no-files-found: ignore
 
       - uses: actions/upload-artifact@v4

--- a/e2e/heatmap.spec.ts
+++ b/e2e/heatmap.spec.ts
@@ -1,0 +1,172 @@
+import { test, expect, type Page } from "@playwright/test";
+
+// The activity heatmap reads /api/activity (hourly buckets). We stub it per page
+// with a varied week — including outliers that exercise the p95 colour clamp — so
+// the punchcard, colour steps and per-cell tooltips render deterministically and
+// the screenshots are reproducible. The fold/level/p95 maths is unit-tested in
+// src/lib/heatmap.test.ts.
+function activityPayload() {
+  const buckets: { bucket: string; event_type: string; count: number }[] = [];
+  const base = new Date("2026-05-18T00:00:00Z"); // a Monday
+  for (let day = 0; day < 7; day++) {
+    for (let h = 0; h < 24; h++) {
+      let c = 0;
+      if (h >= 8 && h <= 20) c = Math.max(0, Math.round(Math.sin((h - 6) / 3) * 6 + (day % 3) * 2));
+      if (day === 2 && h === 14) c = 60; // outlier → p95 clamp
+      if (day === 4 && h === 10) c = 45; // spike
+      if (c > 0) {
+        const d = new Date(base);
+        d.setUTCDate(base.getUTCDate() + day);
+        d.setUTCHours(h);
+        buckets.push({ bucket: d.toISOString().slice(0, 13).replace("T", " "), event_type: "PostToolUse", count: c });
+      }
+    }
+  }
+  return { buckets };
+}
+
+async function stubActivity(page: Page, body: object) {
+  await page.route("**/api/activity*", (route) =>
+    route.fulfill({ contentType: "application/json", body: JSON.stringify(body) }),
+  );
+}
+
+function prime(page: Page, mode: "dark" | "light", lang: "de" | "en") {
+  return page.addInitScript(
+    ([m, l]) => {
+      try {
+        localStorage.setItem("mc-onboarded", "1");
+        localStorage.setItem("mc-theme", JSON.stringify({ mode: m, accent: "#4f8cff" }));
+        localStorage.setItem("mc-lang", l);
+      } catch {
+        /* ignore */
+      }
+    },
+    [mode, lang] as const,
+  );
+}
+
+const IGNORE = [/WebGL/i, /THREE\.WebGLRenderer/i, /Download the React DevTools/i];
+
+function watchConsole(page: Page, errors: string[]) {
+  page.on("console", (m) => {
+    if (m.type() === "error" && !IGNORE.some((re) => re.test(m.text()))) errors.push(m.text());
+  });
+  page.on("pageerror", (e) => {
+    if (!IGNORE.some((re) => re.test(e.message))) errors.push(e.message);
+  });
+}
+
+async function gotoDashboard(page: Page) {
+  await page.goto("/");
+  await expect(page.getByRole("heading", { name: "Claude Mission Control" })).toBeVisible({ timeout: 15_000 });
+  await expect(page.getByTestId("connection-status")).toHaveAttribute("data-state", "connected", { timeout: 15_000 });
+}
+
+const widgetOf = (page: Page) => page.locator("#mc-widget-heatmap");
+const cellsOf = (page: Page) => widgetOf(page).locator("div.aspect-square");
+
+test("punchcard: 7×24 cells, a tooltip on every cell, multiple colour steps", async ({ page }) => {
+  const errors: string[] = [];
+  watchConsole(page, errors);
+
+  await stubActivity(page, activityPayload());
+  await prime(page, "dark", "de");
+  await gotoDashboard(page);
+  const w = widgetOf(page);
+  await w.scrollIntoViewIfNeeded();
+
+  const cells = cellsOf(page);
+  await expect(cells).toHaveCount(7 * 24);
+
+  // Tooltip on every cell (title carries weekday, hour and event count).
+  const titles = await cells.evaluateAll((els) => els.map((e) => e.getAttribute("title") ?? ""));
+  expect(titles.every((t) => /\d{2}:00 — \d+/.test(t))).toBe(true);
+
+  // Colour steps: several distinct background levels are painted, and no cell is
+  // left transparent (the empty/level-0 tint must be visible).
+  const bgs = await cells.evaluateAll((els) => els.map((e) => getComputedStyle(e).backgroundColor));
+  const distinct = new Set(bgs);
+  expect(distinct.size).toBeGreaterThanOrEqual(3);
+  expect(bgs.some((b) => b === "rgba(0, 0, 0, 0)" || b === "transparent")).toBe(false);
+
+  // Legend shows the full 5-step ramp.
+  await expect(w.getByText("weniger")).toBeVisible();
+  await expect(w.getByText("mehr")).toBeVisible();
+
+  expect(errors, `console errors:\n${errors.join("\n")}`).toEqual([]);
+});
+
+test("light theme: empty cells stay visible (level-0 tint)", async ({ page }) => {
+  const errors: string[] = [];
+  watchConsole(page, errors);
+
+  await stubActivity(page, activityPayload());
+  await prime(page, "light", "de");
+  await gotoDashboard(page);
+  const w = widgetOf(page);
+  await w.scrollIntoViewIfNeeded();
+  await expect(cellsOf(page).first()).toBeVisible();
+
+  // An empty cell ("… — 0 Events") must use the dark level-0 tint on white, not an
+  // invisible white-on-white fill. The tint is rgba(15, 23, 42, 0.06).
+  const emptyBg = await cellsOf(page).evaluateAll((els) => {
+    const cell = els.find((e) => /— 0 /.test(e.getAttribute("title") ?? ""));
+    return cell ? getComputedStyle(cell).backgroundColor : null;
+  });
+  expect(emptyBg).toContain("15, 23, 42");
+
+  expect(errors, `console errors:\n${errors.join("\n")}`).toEqual([]);
+});
+
+test("empty activity shows the empty state, no cells", async ({ page }) => {
+  const errors: string[] = [];
+  watchConsole(page, errors);
+
+  await stubActivity(page, { buckets: [] });
+  await prime(page, "dark", "de");
+  await gotoDashboard(page);
+  const w = widgetOf(page);
+  await w.scrollIntoViewIfNeeded();
+
+  await expect(w.getByText("Noch keine Aktivität.")).toBeVisible();
+  await expect(cellsOf(page)).toHaveCount(0);
+
+  expect(errors, `console errors:\n${errors.join("\n")}`).toEqual([]);
+});
+
+// Visual matrix: every theme × breakpoint (+ an English desktop pass), as CI artifacts.
+const VIEWPORTS = [
+  { name: "mobile", width: 390, height: 844 },
+  { name: "desktop", width: 1440, height: 900 },
+  { name: "qhd", width: 2560, height: 1440 },
+  { name: "uhd", width: 3840, height: 2160 },
+] as const;
+const MODES = ["dark", "light"] as const;
+
+for (const vp of VIEWPORTS) {
+  for (const mode of MODES) {
+    const langs: ("de" | "en")[] = vp.name === "desktop" ? ["de", "en"] : ["de"];
+    for (const lang of langs) {
+      const label = `${vp.name}-${mode}-${lang}`;
+      test(`heatmap visual — ${label}`, async ({ page }, testInfo) => {
+        const errors: string[] = [];
+        watchConsole(page, errors);
+
+        await stubActivity(page, activityPayload());
+        await page.setViewportSize({ width: vp.width, height: vp.height });
+        await prime(page, mode, lang);
+        await gotoDashboard(page);
+        const w = widgetOf(page);
+        await w.scrollIntoViewIfNeeded();
+        await expect(cellsOf(page).first()).toBeVisible({ timeout: 15_000 });
+        await page.waitForTimeout(400);
+
+        const shot = await w.screenshot({ path: `test-results/heatmap-shots/${label}.png` });
+        await testInfo.attach(label, { body: shot, contentType: "image/png" });
+
+        expect(errors, `console errors (${label}):\n${errors.join("\n")}`).toEqual([]);
+      });
+    }
+  }
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -7,6 +7,8 @@
   --foreground: #e6e9ef;
   --muted: #9aa3b6;
   --accent: #4f8cff;
+  /* Empty (level-0) heatmap cell. A faint light tint reads on dark panels. */
+  --mc-heat-0: rgba(255, 255, 255, 0.04);
 }
 
 /* Light token set — swapped in via data-theme on <html>. Charts/tooltips that
@@ -21,6 +23,9 @@
      is fine on dark), incl. text on the accent/20 tint. A custom accent is set
      inline and wins over this. */
   --accent: #1e40af;
+  /* On white panels a 4%-white empty cell is invisible; use a faint dark tint so
+     the punchcard grid stays legible (shared by both heatmap widgets). */
+  --mc-heat-0: rgba(15, 23, 42, 0.06);
 }
 
 /* The bright -300/-400 semantic hues are tuned for dark panels and fail WCAG-AA on


### PR DESCRIPTION
## Run 109 — Phase Z: Activity Heatmap visual & functional acceptance

Visual & functional pass over the activity heatmap (punchcard cells, colour steps, p95 clamp, per-cell tooltip), per the roadmap's Phase Z.

### Fix
The level-0 (empty) cell colour was broken on the **light theme**. Both heatmap widgets use `var(--mc-heat-0, rgba(255,255,255,0.04))`, but `--mc-heat-0` was **never defined** — so empty cells fell back to 4%-white, which is invisible on the light theme's white panels and erased the punchcard grid (only the blue active cells showed). `--mc-heat-0` is now defined per theme (faint light tint on dark, faint dark tint on white). This also fixes the **calendar heatmap**, which shares the token.

| before (light) | after (light) |
|---|---|
| empty cells invisible (white-on-white) | empty cells show a faint grey tint; full grid legible |

### New audit spec `e2e/heatmap.spec.ts`
`/api/activity` is stubbed per page with a varied week (including outliers that exercise the **p95 colour clamp**), so the audit is deterministic and the screenshots reproducible:
- the **7×24 punchcard** renders;
- **every cell carries a tooltip** (`title` with weekday/hour/count);
- **multiple colour steps** are painted, with **no transparent cells** (empty/level-0 tint visible);
- the empty/level-0 tint **stays visible on the light theme** (regression guard for the fix);
- the **empty state** shows when there is no activity;
- a **screenshot matrix** over de/en × light/dark × mobile/desktop/qhd/uhd under a clean-console gate.

The fold/level/p95 maths is already covered by `src/lib/heatmap.test.ts`.

### CI
`.github/workflows/ci.yml` uploads the heatmap screenshots as an artifact (`heatmap-screenshots`).

### Definition of Done
- `npm run lint` ✓
- `npm test` ✓ (409)
- `npm run build` ✓
- `npm run test:e2e` ✓ (61 passed, incl. the new audit)
- golden rule intact (read-only; data still flows Hooks → /api/ingest → SQLite → UI)

https://claude.ai/code/session_01UEgRzpHQh5WY2WKZgcscZA

---
_Generated by [Claude Code](https://claude.ai/code/session_01UEgRzpHQh5WY2WKZgcscZA)_