### PR TITLE
File-hotspots audit: dark-on-dark tiles, click-to-search, treemap E2E

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,8 +64,9 @@ jobs:
       # ingest API and asserts the dashboard renders, connects and populates. Also
       # runs the axe-core accessibility audit (e2e/a11y.spec.ts) and the Phase Z
       # layout (e2e/layout.spec.ts), tool-graph (e2e/tool-graph.spec.ts),
-      # budget-gauge (e2e/budget-gauge.spec.ts), heatmap (e2e/heatmap.spec.ts) and
-      # tool-frequency (e2e/tool-frequency.spec.ts) audits as CI gates.
+      # budget-gauge (e2e/budget-gauge.spec.ts), heatmap (e2e/heatmap.spec.ts),
+      # tool-frequency (e2e/tool-frequency.spec.ts) and file-hotspots
+      # (e2e/file-hotspots.spec.ts) audits as CI gates.
       - name: Smoke + a11y + Phase Z widget E2E
         run: npm run test:e2e
 
@@ -107,6 +108,14 @@ jobs:
         with:
           name: tool-frequency-screenshots
           path: test-results/tool-frequency-shots
+          if-no-files-found: ignore
+
+      # Always collect the file-hotspots audit screenshots (Phase Z, Run 111).
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: file-hotspots-screenshots
+          path: test-results/file-hotspots-shots
           if-no-files-found: ignore
 
       - uses: actions/upload-artifact@v4

--- a/e2e/file-hotspots.spec.ts
+++ b/e2e/file-hotspots.spec.ts
@@ -1,0 +1,184 @@
+import { test, expect, type Page } from "@playwright/test";
+
+// The file-hotspots treemap reads /api/files?days=N. We stub it per page (varying
+// by the days param) so tiles, the colour ramp, tooltips, the click-to-search and
+// the range toggle are deterministic — and the screenshots reproducible. The SQL
+// rollup is unit-tested in src/lib/files.test.ts.
+type FileHotspot = { path: string; name: string; edits: number; added: number; removed: number; churn: number };
+const f = (path: string, edits: number, added: number, removed: number): FileHotspot => ({
+  path,
+  name: path.split("/").pop() ?? path,
+  edits,
+  added,
+  removed,
+  churn: added + removed,
+});
+
+const D30: FileHotspot[] = [
+  f("src/components/dashboard.tsx", 40, 1200, 300),
+  f("src/lib/ingest.ts", 25, 600, 150),
+  f("src/plugins/tool-graph/widget.tsx", 18, 420, 90),
+  f("src/lib/db.ts", 12, 300, 60),
+  f("README.md", 9, 200, 40),
+  f("package.json", 5, 30, 10),
+];
+const D7: FileHotspot[] = [f("src/auth/session.ts", 20, 800, 100), f("src/lib/db.ts", 8, 200, 40)];
+const D0: FileHotspot[] = [f("src/components/dashboard.tsx", 90, 3000, 800), f("src/lib/ingest.ts", 50, 1400, 300)];
+
+async function stubFiles(page: Page) {
+  await page.route("**/api/files*", (route) => {
+    const days = new URL(route.request().url()).searchParams.get("days");
+    const files = days === "7" ? D7 : days === "30" ? D30 : D0;
+    route.fulfill({ json: { files } });
+  });
+}
+
+function prime(page: Page, mode: "dark" | "light", lang: "de" | "en") {
+  return page.addInitScript(
+    ([m, l]) => {
+      try {
+        localStorage.setItem("mc-onboarded", "1");
+        localStorage.setItem("mc-theme", JSON.stringify({ mode: m, accent: "#4f8cff" }));
+        localStorage.setItem("mc-lang", l);
+      } catch {
+        /* ignore */
+      }
+    },
+    [mode, lang] as const,
+  );
+}
+
+const IGNORE = [/WebGL/i, /THREE\.WebGLRenderer/i, /Download the React DevTools/i];
+
+function watchConsole(page: Page, errors: string[]) {
+  page.on("console", (m) => {
+    if (m.type() === "error" && !IGNORE.some((re) => re.test(m.text()))) errors.push(m.text());
+  });
+  page.on("pageerror", (e) => {
+    if (!IGNORE.some((re) => re.test(e.message))) errors.push(e.message);
+  });
+}
+
+async function gotoDashboard(page: Page) {
+  await page.goto("/");
+  await expect(page.getByRole("heading", { name: "Claude Mission Control" })).toBeVisible({ timeout: 15_000 });
+  await expect(page.getByTestId("connection-status")).toHaveAttribute("data-state", "connected", { timeout: 15_000 });
+}
+
+const widgetOf = (page: Page) => page.locator("#mc-widget-file-hotspots");
+const surfaceOf = (page: Page) => widgetOf(page).locator("svg.recharts-surface");
+
+test("treemap: tiles, opaque colour ramp, tooltip, click-to-search", async ({ page }) => {
+  const errors: string[] = [];
+  watchConsole(page, errors);
+
+  await stubFiles(page);
+  await prime(page, "dark", "de");
+  await gotoDashboard(page);
+  const w = widgetOf(page);
+  await w.scrollIntoViewIfNeeded();
+  await expect(surfaceOf(page)).toBeVisible();
+
+  // Tiles render with labels (the largest is wide enough to show its full name).
+  await expect(w.getByText("dashboard.tsx")).toBeVisible();
+
+  // Colours: tile fills must be opaque rgb(...) — a semi-transparent fill would go
+  // pale and unreadable on the light theme (regression guard for the contrast fix).
+  const fills = await surfaceOf(page).locator("rect").evaluateAll((els) => els.map((e) => e.getAttribute("fill") ?? ""));
+  expect(fills.length).toBeGreaterThan(1);
+  expect(fills.every((c) => /^rgb\(/.test(c))).toBe(true);
+  expect(fills.some((c) => /rgba\(/.test(c))).toBe(false);
+
+  // Tooltip on hover: full path + edits/added/removed.
+  const box = await surfaceOf(page).boundingBox();
+  expect(box).not.toBeNull();
+  if (box) await page.mouse.move(box.x + 90, box.y + 70);
+  await expect(w.locator("div.font-mono")).toContainText("/", { timeout: 5_000 });
+  await expect(w.getByText(/×\s*Bearbeitungen/)).toBeVisible();
+
+  // Click a tile → the global search is set to that file's name.
+  if (box) await page.mouse.click(box.x + 90, box.y + 70);
+  const search = page.locator('input[type="search"]');
+  await expect(search).toHaveValue(/.+\.(tsx|ts|md|json)$/);
+  expect(D30.map((d) => d.name)).toContain(await search.inputValue());
+
+  expect(errors, `console errors:\n${errors.join("\n")}`).toEqual([]);
+});
+
+test("range toggle refetches the treemap, with aria-pressed", async ({ page }) => {
+  const errors: string[] = [];
+  watchConsole(page, errors);
+
+  await stubFiles(page);
+  await prime(page, "dark", "de");
+  await gotoDashboard(page);
+  const w = widgetOf(page);
+  await w.scrollIntoViewIfNeeded();
+
+  const btn30 = w.getByRole("button", { name: "30T" });
+  const btn7 = w.getByRole("button", { name: "7T" });
+
+  await expect(btn30).toHaveAttribute("aria-pressed", "true");
+  await expect(w.getByText("dashboard.tsx")).toBeVisible();
+
+  // 7 days → a different file set; the 7d-only file appears, the 30d top is gone.
+  await btn7.click();
+  await expect(btn7).toHaveAttribute("aria-pressed", "true");
+  await expect(btn30).toHaveAttribute("aria-pressed", "false");
+  await expect(w.getByText("session.ts")).toBeVisible();
+  await expect(w.getByText("dashboard.tsx")).toHaveCount(0);
+
+  expect(errors, `console errors:\n${errors.join("\n")}`).toEqual([]);
+});
+
+test("empty state when no file changes", async ({ page }) => {
+  const errors: string[] = [];
+  watchConsole(page, errors);
+
+  await page.route("**/api/files*", (route) => route.fulfill({ json: { files: [] } }));
+  await prime(page, "dark", "de");
+  await gotoDashboard(page);
+  const w = widgetOf(page);
+  await w.scrollIntoViewIfNeeded();
+
+  await expect(w.getByText("Noch keine Datei-Änderungen.")).toBeVisible();
+  await expect(surfaceOf(page)).toHaveCount(0);
+
+  expect(errors, `console errors:\n${errors.join("\n")}`).toEqual([]);
+});
+
+// Visual matrix: every theme × breakpoint (+ an English desktop pass), as CI artifacts.
+const VIEWPORTS = [
+  { name: "mobile", width: 390, height: 844 },
+  { name: "desktop", width: 1440, height: 900 },
+  { name: "qhd", width: 2560, height: 1440 },
+  { name: "uhd", width: 3840, height: 2160 },
+] as const;
+const MODES = ["dark", "light"] as const;
+
+for (const vp of VIEWPORTS) {
+  for (const mode of MODES) {
+    const langs: ("de" | "en")[] = vp.name === "desktop" ? ["de", "en"] : ["de"];
+    for (const lang of langs) {
+      const label = `${vp.name}-${mode}-${lang}`;
+      test(`file-hotspots visual — ${label}`, async ({ page }, testInfo) => {
+        const errors: string[] = [];
+        watchConsole(page, errors);
+
+        await stubFiles(page);
+        await page.setViewportSize({ width: vp.width, height: vp.height });
+        await prime(page, mode, lang);
+        await gotoDashboard(page);
+        const w = widgetOf(page);
+        await w.scrollIntoViewIfNeeded();
+        await expect(surfaceOf(page)).toBeVisible({ timeout: 15_000 });
+        await page.waitForTimeout(500);
+
+        const shot = await w.screenshot({ path: `test-results/file-hotspots-shots/${label}.png` });
+        await testInfo.attach(label, { body: shot, contentType: "image/png" });
+
+        expect(errors, `console errors (${label}):\n${errors.join("\n")}`).toEqual([]);
+      });
+    }
+  }
+}

--- a/src/plugins/file-hotspots/widget.tsx
+++ b/src/plugins/file-hotspots/widget.tsx
@@ -6,6 +6,7 @@ import { FileCode2 } from "lucide-react";
 import { Panel } from "@/components/panel";
 import { WidgetState } from "@/components/widget-state";
 import { useLive } from "@/components/live-provider";
+import { useSearch } from "@/components/search";
 import { useT } from "@/lib/i18n";
 import type { FileHotspot } from "@/lib/files";
 
@@ -21,6 +22,16 @@ function clip(s: string, n: number): string {
   return s.length > n ? s.slice(0, n - 1) + "…" : s;
 }
 
+// Solid tile colour: the accent blue pre-blended over the dark chart base by
+// intensity. A semi-transparent blue would blend over the panel, turning pale and
+// unreadable on the light theme's white panel; this keeps the treemap dark-on-dark
+// in both themes (identical to the old look on the dark panel #0e1219).
+function heatFill(intensity: number): string {
+  const a = 0.22 + 0.68 * Math.max(0, Math.min(1, intensity));
+  const mix = (c: number, base: number) => Math.round(c * a + base * (1 - a));
+  return `rgb(${mix(79, 14)}, ${mix(140, 18)}, ${mix(255, 25)})`;
+}
+
 function FileCell({
   x = 0,
   y = 0,
@@ -29,6 +40,7 @@ function FileCell({
   name = "",
   value = 0,
   max = 1,
+  onPick,
 }: {
   x?: number;
   y?: number;
@@ -37,12 +49,17 @@ function FileCell({
   name?: string;
   value?: number;
   max?: number;
+  onPick?: (name: string) => void;
 }) {
   const intensity = max > 0 ? value / max : 0;
-  const fill = `rgba(79,140,255,${0.22 + 0.68 * intensity})`;
+  const fill = heatFill(intensity);
   const showLabel = width > 56 && height > 18;
+  const clickable = !!onPick && !!name;
   return (
-    <g>
+    <g
+      onClick={clickable ? () => onPick!(name) : undefined}
+      style={clickable ? { cursor: "pointer" } : undefined}
+    >
       <rect x={x} y={y} width={width} height={height} fill={fill} stroke="#0e1219" strokeWidth={1} rx={2} />
       {showLabel && (
         <text x={x + 5} y={y + 14} fill="#e5e7eb" fontSize={11}>
@@ -82,6 +99,7 @@ function HotspotTooltip({
 export function FileHotspots() {
   const { t } = useT();
   const { tick } = useLive();
+  const { setQuery } = useSearch();
   const [range, setRange] = useState<Range>("30");
   const [files, setFiles] = useState<FileHotspot[] | null>(null);
 
@@ -116,6 +134,7 @@ export function FileHotspots() {
             <button
               key={r}
               onClick={() => setRange(r)}
+              aria-pressed={range === r}
               className={`px-2 py-1 ${range === r ? "bg-accent/20 text-accent" : "text-muted hover:text-foreground"}`}
             >
               {t(RANGE_LABEL[r])}
@@ -131,7 +150,7 @@ export function FileHotspots() {
       ) : (
         <div className="h-full w-full p-2">
           <ResponsiveContainer width="100%" height="100%">
-            <Treemap data={data} dataKey="size" stroke="#0e1219" content={<FileCell max={max} />}>
+            <Treemap data={data} dataKey="size" stroke="#0e1219" content={<FileCell max={max} onPick={setQuery} />}>
               <Tooltip content={<HotspotTooltip />} />
             </Treemap>
           </ResponsiveContainer>


### PR DESCRIPTION
## Run 111 — Phase Z: File-Hotspots (Treemap) visual & functional acceptance

Visual & functional pass over the file-hotspots treemap (tiles, colours, tooltip, click), per the roadmap's Phase Z.

### Fixes
- **Colours (light-theme contrast):** tiles used a semi-transparent blue (`rgba`). On the dark panel that blends to the intended dark blue, but on the light theme's **white panel** the tiles turned pale and the near-white labels lost contrast. The ramp is now **pre-blended over the dark chart base into an opaque `rgb()`**, so the treemap stays dark-on-dark in both themes — pixel-identical on the dark panel, readable on light. (Matches the "charts stay dark by design" note in `globals.css`.)
- **Click:** the tiles had **no click action** (Run 111 lists "Klick"). Clicking a tile now sets the **global search** to the file name, drilling the dashboard's search-driven widgets into that file (reuses the existing `useSearch` context).
- **a11y:** added `aria-pressed` to the 7d/30d/All range toggle (matches the toggle convention; same gap fixed in Run 110).

### New audit spec `e2e/file-hotspots.spec.ts`
`/api/files` is stubbed per page (payload varies by the `days` param):
- **tiles** render with labels;
- the **colour fills are opaque `rgb(...)`** (regression guard for the contrast fix);
- the **tooltip** shows path + edits/added/removed on hover;
- **clicking a tile sets the global search** to that file;
- the **range toggle** refetches with `aria-pressed` tracking;
- the **empty state**;
- a **screenshot matrix** over de/en × light/dark × mobile/desktop/qhd/uhd under a clean-console gate.

The SQL rollup is already covered by `src/lib/files.test.ts`.

### CI
`.github/workflows/ci.yml` uploads the file-hotspots screenshots as an artifact (`file-hotspots-screenshots`).

### Definition of Done
- `npm run lint` ✓
- `npm test` ✓ (409)
- `npm run build` ✓
- `npm run test:e2e` ✓ (86 passed; one pre-existing heatmap screenshot test was flaky and passed on retry — unrelated to this widget)
- golden rule intact (read-only; data still flows Hooks → /api/ingest → SQLite → UI)

https://claude.ai/code/session_01UEgRzpHQh5WY2WKZgcscZA

---
_Generated by [Claude Code](https://claude.ai/code/session_01UEgRzpHQh5WY2WKZgcscZA)_