### PR TITLE
Stabilize tool-graph audit spec: ignore recharts' transient "reading 'tick'"

### DIFF
--- a/e2e/tool-graph.spec.ts
+++ b/e2e/tool-graph.spec.ts
@@ -48,9 +48,10 @@ function prime(page: Page, mode: "dark" | "light", lang: "de" | "en") {
   );
 }
 
-// Headless WebGL (SwiftShader) and three.js can emit benign info/warnings, and the
-// React DevTools nudge is noise. None are real errors for this audit.
-const IGNORE = [/WebGL/i, /THREE\.WebGLRenderer/i, /Download the React DevTools/i];
+// The full dashboard renders here, so tolerate benign noise from other widgets:
+// headless-WebGL/three.js info, the React DevTools nudge, and recharts' transient
+// "reading 'tick'" while a chart's ResponsiveContainer settles (as layout.spec does).
+const IGNORE = [/WebGL/i, /THREE\.WebGLRenderer/i, /Download the React DevTools/i, /reading 'tick'/];
 
 function watchConsole(page: Page, errors: string[]) {
   page.on("console", (m) => {


### PR DESCRIPTION
## Follow-up to #133 — also stabilize `tool-graph.spec.ts`

PR #133 added `/reading 'tick'/` to the IGNORE list of five Phase Z audit specs. The **tool-graph** spec (Run 107) was missed and has the same issue: it renders the whole dashboard, so its clean-console gate occasionally caught recharts' transient `Cannot read properties of undefined (reading 'tick')` from other (chart) widgets — flaking on the first (mobile) navigation (observed in a later full-suite run).

Add `/reading 'tick'/` to `e2e/tool-graph.spec.ts`'s IGNORE list, matching the other specs and `layout.spec`. Test-only, one line.

With this, all six Phase Z widget audit specs (tool-graph, budget-gauge, heatmap, tool-frequency, file-hotspots, session-timeline) tolerate the known recharts transient.

https://claude.ai/code/session_01UEgRzpHQh5WY2WKZgcscZA

---
_Generated by [Claude Code](https://claude.ai/code/session_01UEgRzpHQh5WY2WKZgcscZA)_