### PR TITLE
Run 115: model-donut & token-burn audit (fix donut currency, aria-pressed, E2E)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,8 +67,9 @@ jobs:
       # budget-gauge (e2e/budget-gauge.spec.ts), heatmap (e2e/heatmap.spec.ts),
       # tool-frequency (e2e/tool-frequency.spec.ts), file-hotspots
       # (e2e/file-hotspots.spec.ts), session-timeline
-      # (e2e/session-timeline.spec.ts), latency (e2e/latency.spec.ts) and
-      # error-rate/incidents (e2e/error-rate.spec.ts) audits as CI gates.
+      # (e2e/session-timeline.spec.ts), latency (e2e/latency.spec.ts),
+      # error-rate/incidents (e2e/error-rate.spec.ts) and model-donut/token-burn
+      # (e2e/model-donut.spec.ts) audits as CI gates.
       - name: Smoke + a11y + Phase Z widget E2E
         run: npm run test:e2e
 
@@ -149,6 +150,21 @@ jobs:
         with:
           name: incidents-screenshots
           path: test-results/incidents-shots
+          if-no-files-found: ignore
+
+      # Always collect the model-donut + token-burn audit screenshots (Phase Z, Run 115).
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: model-donut-screenshots
+          path: test-results/model-donut-shots
+          if-no-files-found: ignore
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: token-burn-screenshots
+          path: test-results/token-burn-shots
           if-no-files-found: ignore
 
       - uses: actions/upload-artifact@v4

--- a/e2e/model-donut.spec.ts
+++ b/e2e/model-donut.spec.ts
@@ -1,0 +1,204 @@
+import { test, expect, type Page } from "@playwright/test";
+
+// Run 115 — model-donut (per-model token/cost share) + token-burn (estimated token
+// burn per tool). model-donut reads /api/usage, token-burn /api/token-burn; both
+// are stubbed per page so segments, legend, center total, the mode toggle and the
+// burn bars are deterministic and the screenshots reproducible. The share/burn
+// maths is unit-tested in src/lib/{model-usage,token-burn}.test.ts.
+const USAGE = {
+  days: [],
+  months: [],
+  blocks: [],
+  burn: null,
+  available: true,
+  totals: { inputTokens: 0, outputTokens: 0, cacheTokens: 0, totalTokens: 0, costUsd: 0, costEur: 0 },
+  models: [
+    { model: "claude-opus-4-7", inputTokens: 200000, outputTokens: 120000, cacheTokens: 480000, totalTokens: 800000, costUsd: 12.5, costEur: 11.5 },
+    { model: "claude-sonnet-4-6", inputTokens: 400000, outputTokens: 300000, cacheTokens: 800000, totalTokens: 1500000, costUsd: 4.2, costEur: 3.86 },
+    { model: "claude-haiku-4-5", inputTokens: 200000, outputTokens: 100000, cacheTokens: 300000, totalTokens: 600000, costUsd: 0.8, costEur: 0.74 },
+  ],
+};
+const BURN = {
+  tools: [
+    { tool: "Bash", calls: 120, tokens: 480000, share: 0.42 },
+    { tool: "Read", calls: 90, tokens: 300000, share: 0.26 },
+    { tool: "Edit", calls: 60, tokens: 200000, share: 0.17 },
+    { tool: "WebFetch", calls: 20, tokens: 120000, share: 0.1 },
+    { tool: "Grep", calls: 40, tokens: 50000, share: 0.05 },
+  ],
+};
+
+async function stub(page: Page, usage: object = USAGE, burn: object = BURN) {
+  await page.route("**/api/usage", (route) => route.fulfill({ json: usage }));
+  await page.route("**/api/token-burn*", (route) => route.fulfill({ json: burn }));
+}
+
+function prime(page: Page, mode: "dark" | "light", lang: "de" | "en") {
+  return page.addInitScript(
+    ([m, l]) => {
+      try {
+        localStorage.setItem("mc-onboarded", "1");
+        localStorage.setItem("mc-theme", JSON.stringify({ mode: m, accent: "#4f8cff" }));
+        localStorage.setItem("mc-lang", l);
+      } catch {
+        /* ignore */
+      }
+    },
+    [mode, lang] as const,
+  );
+}
+
+// The full dashboard renders here, so tolerate noise from other widgets: 3D-graph
+// WebGL info, the React DevTools nudge, and recharts' transient "reading 'tick'"
+// while a chart's ResponsiveContainer settles on first paint (as layout.spec does).
+const IGNORE = [/WebGL/i, /THREE\.WebGLRenderer/i, /Download the React DevTools/i, /reading 'tick'/];
+
+function watchConsole(page: Page, errors: string[]) {
+  page.on("console", (m) => {
+    if (m.type() === "error" && !IGNORE.some((re) => re.test(m.text()))) errors.push(m.text());
+  });
+  page.on("pageerror", (e) => {
+    if (!IGNORE.some((re) => re.test(e.message))) errors.push(e.message);
+  });
+}
+
+async function gotoDashboard(page: Page) {
+  await page.goto("/");
+  await expect(page.getByRole("heading", { name: "Claude Mission Control" })).toBeVisible({ timeout: 15_000 });
+  await expect(page.getByTestId("connection-status")).toHaveAttribute("data-state", "connected", { timeout: 15_000 });
+}
+
+const VIEWPORTS = [
+  { name: "mobile", width: 390, height: 844 },
+  { name: "desktop", width: 1440, height: 900 },
+  { name: "qhd", width: 2560, height: 1440 },
+  { name: "uhd", width: 3840, height: 2160 },
+] as const;
+const MODES = ["dark", "light"] as const;
+
+function visualMatrix(widgetId: string, dir: string) {
+  for (const vp of VIEWPORTS) {
+    for (const mode of MODES) {
+      const langs: ("de" | "en")[] = vp.name === "desktop" ? ["de", "en"] : ["de"];
+      for (const lang of langs) {
+        const label = `${vp.name}-${mode}-${lang}`;
+        test(`${dir} visual — ${label}`, async ({ page }, testInfo) => {
+          const errors: string[] = [];
+          watchConsole(page, errors);
+          await stub(page);
+          await page.setViewportSize({ width: vp.width, height: vp.height });
+          await prime(page, mode, lang);
+          await gotoDashboard(page);
+          const w = page.locator(`#mc-widget-${widgetId}`);
+          await w.scrollIntoViewIfNeeded();
+          await expect(w).toBeVisible();
+          await page.waitForTimeout(900);
+          const shot = await w.screenshot({ path: `test-results/${dir}-shots/${label}.png` });
+          await testInfo.attach(label, { body: shot, contentType: "image/png" });
+          expect(errors, `console errors (${label}):\n${errors.join("\n")}`).toEqual([]);
+        });
+      }
+    }
+  }
+}
+
+// ── model-donut ──────────────────────────────────────────────────────────────
+const mdOf = (page: Page) => page.locator("#mc-widget-model-donut");
+
+test("model-donut: segments, legend, center total, mode toggle", async ({ page }) => {
+  const errors: string[] = [];
+  watchConsole(page, errors);
+  await stub(page);
+  await prime(page, "dark", "de");
+  await gotoDashboard(page);
+  const w = mdOf(page);
+  await w.scrollIntoViewIfNeeded();
+
+  // One donut segment per model.
+  await expect(w.locator("path.recharts-sector")).toHaveCount(3);
+
+  // Legend with each model's name + percentage.
+  await expect(w.getByText("opus-4-7")).toBeVisible();
+  await expect(w.getByText("sonnet-4-6")).toBeVisible();
+  await expect(w.getByText("71%")).toBeVisible(); // opus cost share
+
+  // Center total: cost mode is USD (regression guard — was mislabelled €).
+  await expect(w.getByText("$17.50")).toBeVisible();
+
+  // Mode toggle exposes its pressed state and switches the metric.
+  const btnCost = w.getByRole("button", { name: "Kosten" });
+  const btnTokens = w.getByRole("button", { name: "Tokens" });
+  await expect(btnCost).toHaveAttribute("aria-pressed", "true");
+  await btnTokens.click();
+  await expect(btnTokens).toHaveAttribute("aria-pressed", "true");
+  await expect(btnCost).toHaveAttribute("aria-pressed", "false");
+  await expect(w.getByText("2.9M")).toBeVisible(); // total tokens
+  await expect(w.getByText("$17.50")).toHaveCount(0);
+
+  // Note: per-segment hover shows the same name+share the legend already asserts
+  // above; recharts' pie-arc hover isn't reliably reproducible via synthetic mouse
+  // events headless, so we verify that data through the (deterministic) legend
+  // rather than gating CI on a flaky arc hover.
+
+  expect(errors, `console errors:\n${errors.join("\n")}`).toEqual([]);
+});
+
+test("model-donut: empty state when no model data", async ({ page }) => {
+  const errors: string[] = [];
+  watchConsole(page, errors);
+  await stub(page, { ...USAGE, models: [] });
+  await prime(page, "dark", "de");
+  await gotoDashboard(page);
+  const w = mdOf(page);
+  await w.scrollIntoViewIfNeeded();
+  await expect(w.getByText("Noch keine Modelldaten.")).toBeVisible();
+  await expect(w.locator("path.recharts-sector")).toHaveCount(0);
+  expect(errors, `console errors:\n${errors.join("\n")}`).toEqual([]);
+});
+
+visualMatrix("model-donut", "model-donut");
+
+// ── token-burn ───────────────────────────────────────────────────────────────
+const tbOf = (page: Page) => page.locator("#mc-widget-token-burn");
+
+test("token-burn: proportional bars, shares, hover title", async ({ page }) => {
+  const errors: string[] = [];
+  watchConsole(page, errors);
+  await stub(page);
+  await prime(page, "dark", "de");
+  await gotoDashboard(page);
+  const w = tbOf(page);
+  await w.scrollIntoViewIfNeeded();
+
+  // One bar per tool, biggest first; the inline breakdown (~tokens · share · calls).
+  await expect(w.locator("li")).toHaveCount(5);
+  await expect(w.getByText("Bash")).toBeVisible();
+  await expect(w.getByText(/~480k · 42% · 120×/)).toBeVisible();
+
+  // Bar widths are proportional and non-increasing; the top bar fills the track.
+  const widths = await w.locator("li div.h-full").evaluateAll((els) =>
+    els.map((e) => parseFloat((e as HTMLElement).style.width)),
+  );
+  expect(widths[0]).toBe(100);
+  for (let i = 1; i < widths.length; i++) expect(widths[i]).toBeLessThanOrEqual(widths[i - 1]);
+
+  // The tool name carries a hover title.
+  await expect(w.locator("li").first().locator("span[title='Bash']")).toBeVisible();
+
+  expect(errors, `console errors:\n${errors.join("\n")}`).toEqual([]);
+});
+
+test("token-burn: empty state when no tool data", async ({ page }) => {
+  const errors: string[] = [];
+  watchConsole(page, errors);
+  await stub(page, USAGE, { tools: [] });
+  await prime(page, "dark", "de");
+  await gotoDashboard(page);
+  const w = tbOf(page);
+  await w.scrollIntoViewIfNeeded();
+  await expect(w.getByText("Noch keine Tool-Daten.")).toBeVisible();
+  await expect(w.locator("li")).toHaveCount(0);
+  expect(errors, `console errors:\n${errors.join("\n")}`).toEqual([]);
+});
+
+visualMatrix("token-burn", "token-burn");

--- a/src/plugins/model-donut/widget.tsx
+++ b/src/plugins/model-donut/widget.tsx
@@ -41,7 +41,9 @@ export function ModelDonut() {
   }, []);
 
   const { slices, total } = modelShare(usage?.models ?? [], mode);
-  const fmt = (n: number) => (mode === "cost" ? formatMoney(n, "EUR") : formatCompact(n));
+  // modelShare uses ccusage's native USD for cost mode, so label it in USD (a € sign
+  // on a USD value would misstate the amount).
+  const fmt = (n: number) => (mode === "cost" ? formatMoney(n, "USD") : formatCompact(n));
   const label = (s: ModelSlice) => (s.full === OTHER ? t("donut.other") : s.name);
 
   return (
@@ -55,6 +57,7 @@ export function ModelDonut() {
             <button
               key={m}
               onClick={() => setMode(m)}
+              aria-pressed={mode === m}
               className={`px-2 py-1 ${mode === m ? "bg-accent/20 text-accent" : "text-muted hover:text-foreground"}`}
             >
               {m === "tokens" ? t("tokens.modeTokens") : t("tokens.modeCost")}


### PR DESCRIPTION
## Run 115 — Phase Z: Modelle-Donut & Token-Verbrauch

Per the updated coverage matrix (#137), Run 115 covers **model-donut** (per-model token/cost share) and **token-burn** (estimated token burn per tool).

### Fixes
- **model-donut currency bug:** cost mode uses ccusage's native **USD** values but formatted them with a **€** sign (`formatMoney(n, "EUR")`), overstating the amount. Now formatted in USD to match the underlying value (center total + tooltip).
- **model-donut a11y:** added `aria-pressed` to the tokens/cost mode toggle.

token-burn was already solid (sorted bars, inline ~tokens · share · calls, tool hover title, clean states).

### New audit spec `e2e/model-donut.spec.ts` (`/api/usage` + `/api/token-burn` stubbed)
- **model-donut:** 3 segments, legend names + %, **USD center total** (regression guard), mode toggle switching the metric with `aria-pressed`, empty state.
- **token-burn:** one bar per tool biggest-first with proportional non-increasing widths, the ~tokens · share · calls breakdown, the tool hover title, empty state.
- A screenshot matrix per widget under a clean-console gate.

The per-segment hover shows the same name + share the **legend** already asserts; recharts' pie-arc hover isn't reproducible via synthetic mouse events headless, so that data is verified through the legend rather than a flaky arc hover (it would have been a flaky CI gate). Share/burn maths is covered by `src/lib/{model-usage,token-burn}.test.ts`.

### CI
Uploads `model-donut-screenshots` and `token-burn-screenshots` artifacts.

### Definition of Done
- `npm run lint` ✓ · `npm test` ✓ (409) · `npm run build` ✓
- `npm run test:e2e` ✓ — **162 passed, exit 0** (full suite, real exit code; model-donut functional tests stable across repeated runs)
- golden rule intact (read-only)

https://claude.ai/code/session_01UEgRzpHQh5WY2WKZgcscZA

---
_Generated by [Claude Code](https://claude.ai/code/session_01UEgRzpHQh5WY2WKZgcscZA)_