### PR TITLE
Run 118c: prompt-history audit (+ session drilldown)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,8 +72,8 @@ jobs:
       # (e2e/model-donut.spec.ts), sankey-flow/tag-cloud (e2e/sankey-flow.spec.ts),
       # project-leaderboard/reliability/git-correlation
       # (e2e/project-leaderboard.spec.ts), streak/subagent-tree
-      # (e2e/streak.spec.ts) and velocity/session-duration
-      # (e2e/velocity.spec.ts) audits as CI gates.
+      # (e2e/streak.spec.ts), velocity/session-duration (e2e/velocity.spec.ts)
+      # and prompt-history (e2e/prompt-history.spec.ts) audits as CI gates.
       - name: Smoke + a11y + Phase Z widget E2E
         run: npm run test:e2e
 
@@ -237,6 +237,14 @@ jobs:
         with:
           name: session-duration-screenshots
           path: test-results/session-duration-shots
+          if-no-files-found: ignore
+
+      # Always collect the prompt-history audit screenshots (Phase Z, Run 118c).
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: prompt-history-screenshots
+          path: test-results/prompt-history-shots
           if-no-files-found: ignore
 
       - uses: actions/upload-artifact@v4

--- a/e2e/prompt-history.spec.ts
+++ b/e2e/prompt-history.spec.ts
@@ -1,0 +1,154 @@
+import { test, expect, type Page } from "@playwright/test";
+
+// Run 118c — prompt-history: a chronological, searchable list of prompts with a
+// token estimate and a drill-down to the originating session. /api/prompts is
+// stubbed per page so the list, search, token estimate and drill-down links are
+// deterministic and the screenshots reproducible. The extraction/redaction maths
+// is unit-tested in src/lib/prompts.test.ts.
+function dbTime(minAgo: number): string {
+  const d = new Date(Date.now() - minAgo * 60_000);
+  const p = (n: number) => String(n).padStart(2, "0");
+  return `${d.getUTCFullYear()}-${p(d.getUTCMonth() + 1)}-${p(d.getUTCDate())} ${p(d.getUTCHours())}:${p(d.getUTCMinutes())}:${p(d.getUTCSeconds())}`;
+}
+const PROMPTS = {
+  prompts: [
+    { id: 1, session_id: "s-alpha", project: "my_dash", text: "Build the dashboard and wire the hooks", token_estimate: 1200, created_at: dbTime(5) },
+    { id: 2, session_id: "s-beta", project: "shopify-bot", text: "Analyze recent orders for outliers", token_estimate: 800, created_at: dbTime(40) },
+    { id: 3, session_id: "s-alpha", project: "my_dash", text: "Refactor the auth flow", token_estimate: 0, created_at: dbTime(120) },
+  ],
+};
+
+async function stub(page: Page, prompts: object = PROMPTS) {
+  await page.route("**/api/prompts*", (route) => route.fulfill({ json: prompts }));
+  await page.route("**/api/search*", (route) => route.fulfill({ json: { hits: [] } }));
+}
+
+function prime(page: Page, mode: "dark" | "light", lang: "de" | "en") {
+  return page.addInitScript(
+    ([m, l]) => {
+      try {
+        localStorage.setItem("mc-onboarded", "1");
+        localStorage.setItem("mc-theme", JSON.stringify({ mode: m, accent: "#4f8cff" }));
+        localStorage.setItem("mc-lang", l);
+      } catch {
+        /* ignore */
+      }
+    },
+    [mode, lang] as const,
+  );
+}
+
+// The full dashboard renders here, so tolerate noise from other widgets: 3D-graph
+// WebGL info, the React DevTools nudge, and recharts' transient "reading 'tick'"
+// while a chart's ResponsiveContainer settles on first paint (as layout.spec does).
+const IGNORE = [/WebGL/i, /THREE\.WebGLRenderer/i, /Download the React DevTools/i, /reading 'tick'/];
+
+function watchConsole(page: Page, errors: string[]) {
+  page.on("console", (m) => {
+    if (m.type() === "error" && !IGNORE.some((re) => re.test(m.text()))) errors.push(m.text());
+  });
+  page.on("pageerror", (e) => {
+    if (!IGNORE.some((re) => re.test(e.message))) errors.push(e.message);
+  });
+}
+
+async function gotoDashboard(page: Page) {
+  await page.goto("/");
+  await expect(page.getByRole("heading", { name: "Claude Mission Control" })).toBeVisible({ timeout: 15_000 });
+  await expect(page.getByTestId("connection-status")).toHaveAttribute("data-state", "connected", { timeout: 15_000 });
+}
+
+const w = (page: Page) => page.locator("#mc-widget-prompt-history");
+
+test("prompt-history: chronological list, token estimate, drilldown links", async ({ page }) => {
+  const errors: string[] = [];
+  watchConsole(page, errors);
+  await stub(page);
+  await prime(page, "dark", "de");
+  await gotoDashboard(page);
+  const ph = w(page);
+  await ph.scrollIntoViewIfNeeded();
+
+  // All prompts listed.
+  await expect(ph.locator("li")).toHaveCount(3);
+  await expect(ph.getByText("Build the dashboard and wire the hooks")).toBeVisible();
+
+  // Token estimate shown only when > 0 (2 of the 3).
+  await expect(ph.getByText(/Tokens/)).toHaveCount(2);
+
+  // Each entry is a drill-down link to its session detail page.
+  await expect(ph.locator("li a").first()).toHaveAttribute("href", "/session?id=s-alpha");
+  await expect(ph.locator("li", { hasText: "Analyze recent orders" }).locator("a")).toHaveAttribute(
+    "href",
+    "/session?id=s-beta",
+  );
+
+  expect(errors, `console errors:\n${errors.join("\n")}`).toEqual([]);
+});
+
+test("prompt-history: global search filters, and a no-match shows no-results", async ({ page }) => {
+  const errors: string[] = [];
+  watchConsole(page, errors);
+  await stub(page);
+  await prime(page, "dark", "de");
+  await gotoDashboard(page);
+  const ph = w(page);
+  await ph.scrollIntoViewIfNeeded();
+
+  const search = page.locator('input[type="search"]');
+  await search.fill("orders");
+  await expect(ph.locator("li")).toHaveCount(1);
+  await expect(ph.getByText("Analyze recent orders for outliers")).toBeVisible();
+
+  await search.fill("zzz-no-such-term");
+  await expect(ph.getByText("Keine Treffer.")).toBeVisible();
+  await expect(ph.locator("li")).toHaveCount(0);
+
+  expect(errors, `console errors:\n${errors.join("\n")}`).toEqual([]);
+});
+
+test("prompt-history: empty state when there are no prompts", async ({ page }) => {
+  const errors: string[] = [];
+  watchConsole(page, errors);
+  await stub(page, { prompts: [] });
+  await prime(page, "dark", "de");
+  await gotoDashboard(page);
+  const ph = w(page);
+  await ph.scrollIntoViewIfNeeded();
+  await expect(ph.getByText("Noch keine Prompts.")).toBeVisible();
+  await expect(ph.locator("li")).toHaveCount(0);
+  expect(errors, `console errors:\n${errors.join("\n")}`).toEqual([]);
+});
+
+// Visual matrix: every theme × breakpoint (+ an English desktop pass), as CI artifacts.
+const VIEWPORTS = [
+  { name: "mobile", width: 390, height: 844 },
+  { name: "desktop", width: 1440, height: 900 },
+  { name: "qhd", width: 2560, height: 1440 },
+  { name: "uhd", width: 3840, height: 2160 },
+] as const;
+const MODES = ["dark", "light"] as const;
+
+for (const vp of VIEWPORTS) {
+  for (const mode of MODES) {
+    const langs: ("de" | "en")[] = vp.name === "desktop" ? ["de", "en"] : ["de"];
+    for (const lang of langs) {
+      const label = `${vp.name}-${mode}-${lang}`;
+      test(`prompt-history visual — ${label}`, async ({ page }, testInfo) => {
+        const errors: string[] = [];
+        watchConsole(page, errors);
+        await stub(page);
+        await page.setViewportSize({ width: vp.width, height: vp.height });
+        await prime(page, mode, lang);
+        await gotoDashboard(page);
+        const ph = w(page);
+        await ph.scrollIntoViewIfNeeded();
+        await expect(ph.locator("li").first()).toBeVisible({ timeout: 15_000 });
+        await page.waitForTimeout(400);
+        const shot = await ph.screenshot({ path: `test-results/prompt-history-shots/${label}.png` });
+        await testInfo.attach(label, { body: shot, contentType: "image/png" });
+        expect(errors, `console errors (${label}):\n${errors.join("\n")}`).toEqual([]);
+      });
+    }
+  }
+}

--- a/src/plugins/prompt-history/widget.tsx
+++ b/src/plugins/prompt-history/widget.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import Link from "next/link";
 import { MessageSquare } from "lucide-react";
 import { Panel } from "@/components/panel";
 import { WidgetState } from "@/components/widget-state";
@@ -52,22 +53,27 @@ export function PromptHistory() {
           {filtered.map((p) => (
             <li key={p.id} className="mc-stream-in relative py-2 pl-5">
               <span className="absolute -left-[5px] top-3.5 h-2.5 w-2.5 rounded-full border-2 border-panel bg-accent" />
-              <p className="whitespace-pre-wrap break-words text-sm text-foreground">{p.text}</p>
-              <div className="mt-1 flex items-center gap-2 text-[11px] text-muted">
-                <span className="truncate font-mono" title={p.project}>
-                  {p.project}
-                </span>
-                <span aria-hidden>·</span>
-                <span className="whitespace-nowrap">{relativeTime(p.created_at, lang)}</span>
-                {p.token_estimate > 0 && (
-                  <>
-                    <span aria-hidden>·</span>
-                    <span className="whitespace-nowrap tabular-nums">
-                      ~{formatCompact(p.token_estimate)} {t("prompts.tokens")}
-                    </span>
-                  </>
-                )}
-              </div>
+              <Link
+                href={`/session?id=${encodeURIComponent(p.session_id)}`}
+                className="-mx-1 block rounded-md px-1 py-0.5 transition-colors hover:bg-white/[0.03]"
+              >
+                <p className="whitespace-pre-wrap break-words text-sm text-foreground">{p.text}</p>
+                <div className="mt-1 flex items-center gap-2 text-[11px] text-muted">
+                  <span className="truncate font-mono" title={p.project}>
+                    {p.project}
+                  </span>
+                  <span aria-hidden>·</span>
+                  <span className="whitespace-nowrap">{relativeTime(p.created_at, lang)}</span>
+                  {p.token_estimate > 0 && (
+                    <>
+                      <span aria-hidden>·</span>
+                      <span className="whitespace-nowrap tabular-nums">
+                        ~{formatCompact(p.token_estimate)} {t("prompts.tokens")}
+                      </span>
+                    </>
+                  )}
+                </div>
+              </Link>
             </li>
           ))}
         </ol>


### PR DESCRIPTION
## Run 118c — Phase Z: Prompt-Verlauf

Final slice of the fanned-out Run 118 (118a streak+subagent · 118b velocity+duration · **118c prompts**).

### Fix
- **prompt-history click→drilldown:** entries were inert. Each prompt is now a link to its originating session (`/session?id=...`), matching the kanban/git-correlation drilldown pattern and the Run 118c roadmap entry.

### New audit spec `e2e/prompt-history.spec.ts` (`/api/prompts` stubbed)
- the **chronological list**;
- the **token estimate** shown only when > 0 (2 of 3);
- the per-entry **drilldown links** to the session detail page;
- **global search** filtering down + the **no-results** state;
- the **empty** state;
- a screenshot matrix under a clean-console gate.

Extraction/redaction maths is covered by `src/lib/prompts.test.ts`.

### CI
Uploads `prompt-history-screenshots` artifact.

### Definition of Done
- `npm run lint` ✓ · `npm test` ✓ (409) · `npm run build` ✓
- `npm run test:e2e` ✓ — **283 passed, exit 0** (full suite run at the end of Run 118, as requested)
- golden rule intact (read-only)

https://claude.ai/code/session_01UEgRzpHQh5WY2WKZgcscZA

---
_Generated by [Claude Code](https://claude.ai/code/session_01UEgRzpHQh5WY2WKZgcscZA)_