### PR TITLE
Fix: header dropdowns rendered behind widget tiles (z-index stacking)

### DIFF
--- a/e2e/header-zindex.spec.ts
+++ b/e2e/header-zindex.spec.ts
@@ -1,0 +1,90 @@
+import { test, expect, type Page } from "@playwright/test";
+
+// Regression guard: header dropdowns/popovers (theme picker, search results, …)
+// open downward over the first widget row. The header has backdrop-blur (its own
+// stacking context); without an elevated z-index the whole header subtree — and
+// thus its popovers — painted *below* the grid, so the lower part of a popover sat
+// behind the tiles and was not clickable. The header now sits at `relative z-40`,
+// above the grid. These tests assert popover content that overlaps a widget is the
+// topmost element (and clickable), in both themes.
+
+function prime(page: Page, mode: "dark" | "light") {
+  return page.addInitScript((m) => {
+    try {
+      localStorage.setItem("mc-onboarded", "1");
+      localStorage.setItem("mc-theme", JSON.stringify({ mode: m, accent: "#4f8cff" }));
+      localStorage.setItem("mc-lang", "de");
+    } catch {
+      /* ignore */
+    }
+  }, mode);
+}
+
+async function gotoDashboard(page: Page) {
+  await page.goto("/");
+  await expect(page.getByRole("heading", { name: "Claude Mission Control" })).toBeVisible({ timeout: 15_000 });
+  await expect(page.getByTestId("connection-status")).toHaveAttribute("data-state", "connected", { timeout: 15_000 });
+}
+
+// Is the element at the centre of `box` the expected node (not a widget tile)?
+async function topmostAt(page: Page, box: { x: number; y: number; width: number; height: number }) {
+  return page.evaluate(
+    ({ x, y }) => {
+      const el = document.elementFromPoint(x, y) as HTMLElement | null;
+      return {
+        overWidget: el?.closest('[id^="mc-widget-"]')?.id ?? null,
+        aria: el?.getAttribute("aria-label") ?? null,
+        inLink: !!el?.closest('a[href^="/session"]'),
+      };
+    },
+    { x: box.x + box.width / 2, y: box.y + box.height / 2 },
+  );
+}
+
+for (const mode of ["dark", "light"] as const) {
+  test(`theme popover accent swatch is on top of the grid + clickable — ${mode}`, async ({ page }) => {
+    await prime(page, mode);
+    await gotoDashboard(page);
+
+    // The KPI bar is the first widget, directly under the header.
+    const kpi = await page.locator("#mc-widget-kpi-bar").boundingBox();
+    expect(kpi).not.toBeNull();
+
+    await page.getByRole("button", { name: "Design" }).click(); // open theme popover
+    const swatch = page.getByRole("button", { name: "#4f8cff" }).first();
+    const sb = await swatch.boundingBox();
+    expect(sb).not.toBeNull();
+
+    // The swatch must actually overlap the KPI widget (otherwise the test is moot).
+    if (sb && kpi) expect(sb.y).toBeGreaterThan(kpi.y);
+
+    // It must be the topmost element there — not covered by the tile.
+    const hit = await topmostAt(page, sb!);
+    expect(hit.overWidget).toBeNull();
+    expect(hit.aria).toBe("#4f8cff");
+
+    // And actually clickable (would throw "intercepts pointer events" if behind).
+    await swatch.click();
+  });
+}
+
+test("search results dropdown is on top of the grid", async ({ page }) => {
+  await prime(page, "dark");
+  await page.route("**/api/search*", (route) =>
+    route.fulfill({
+      json: { hits: Array.from({ length: 8 }, (_, i) => ({ kind: "prompt", ref_id: i, session_id: `s${i}`, text: `search hit ${i}` })) },
+    }),
+  );
+  await gotoDashboard(page);
+
+  await page.locator('input[type="search"]').fill("hit");
+  const links = page.locator('a[href^="/session?id="]');
+  await expect(links.first()).toBeVisible();
+
+  // The deepest result extends well into the widget area; it must stay on top.
+  const last = await links.last().boundingBox();
+  expect(last).not.toBeNull();
+  const hit = await topmostAt(page, last!);
+  expect(hit.overWidget).toBeNull();
+  expect(hit.inLink).toBe(true);
+});

--- a/src/components/dashboard.tsx
+++ b/src/components/dashboard.tsx
@@ -439,7 +439,7 @@ function Header({
   const shownHits = query.trim().length >= 2 ? hits : [];
 
   return (
-    <header className="mc-fade-in flex items-center justify-between gap-3 rounded-xl border border-panel-border bg-panel/60 px-5 py-3 backdrop-blur">
+    <header className="mc-fade-in relative z-40 flex items-center justify-between gap-3 rounded-xl border border-panel-border bg-panel/60 px-5 py-3 backdrop-blur">
       <div className="flex min-w-0 items-center gap-3">
         <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-background/80 ring-1 ring-accent/25">
           <RadarLogo className="h-7 w-7" />


### PR DESCRIPTION
## Fix: header dropdowns were behind the widget tiles (not clickable)

**Bug (reported):** on the website, header popups aren't clickable where they overlap the tiles.

**Root cause:** the `<header>` uses `backdrop-blur`, which makes it its own **stacking context**. With no elevated z-index it painted *before* the widget grid (DOM order), so the lower part of every header dropdown that overflows down over the first widget row was painted **behind** the tiles → not clickable. Confirmed via `elementFromPoint`: the theme popover's accent swatch (at y≈173, over the KPI tile y≈130–225) resolved to `#mc-widget-kpi-bar`, not the swatch.

**Fix:** lift the header to `relative z-40` so its whole subtree — and thus **all** its popovers (theme picker, search results, facets, time range, views, notifications) — paints above the grid. One change covers every header button since they all live inside `<header>`. Root-level overlays (gallery modal z-50, tool-graph fullscreen z-60, toasts z-90) stay above the header as intended.

After the fix, `elementFromPoint` at the swatch / deepest search result returns the popover element (not a tile), and clicks land — in both dark and light.

### Regression guard `e2e/header-zindex.spec.ts`
- theme popover accent swatch overlapping the KPI tile is the topmost element + clickable (dark + light);
- the search-results dropdown stays on top over the widget area.

### Checks
- `npm run lint` ✓ · `npm test` ✓ (409) · `npm run build` ✓
- new regression spec ✓ (3 tests); CI runs the full suite.

https://claude.ai/code/session_01UEgRzpHQh5WY2WKZgcscZA

---
_Generated by [Claude Code](https://claude.ai/code/session_01UEgRzpHQh5WY2WKZgcscZA)_