### PR TITLE
Z-Demo-3: calmer demo cadence (slower tick, no jumps)

### DIFF
--- a/src/lib/demo.test.ts
+++ b/src/lib/demo.test.ts
@@ -11,6 +11,7 @@ import {
   demoSessionDuration,
   demoSessions,
   startDemo,
+  TICK_MS,
 } from "./demo";
 
 // Z-Demo-1: the in-browser demo engine must be deterministic. Each snapshot
@@ -59,17 +60,24 @@ describe("demo live evolution is monotonic and persistent", () => {
   it("cost/tokens only rise and ended sessions never disappear", () => {
     vi.useFakeTimers({ now: new Date("2026-05-24T12:00:00.000Z") });
     try {
-      startDemo(); // 4 sessions + 30 pre-warm steps, then a 1100ms interval
+      startDemo(); // 4 sessions + 30 pre-warm steps, then a TICK_MS interval
       let prevCost = -1;
       let prevTokens = -1;
       let prevEnded = -1;
       for (let i = 0; i < 150; i++) {
-        vi.advanceTimersByTime(1100); // one step
+        vi.advanceTimersByTime(TICK_MS); // one step
         const today = demoUsage().days.at(-1)!;
         expect(today.costUsd).toBeGreaterThanOrEqual(prevCost);
         expect(today.totalTokens).toBeGreaterThanOrEqual(prevTokens);
         const ended = demoSessions().filter((s) => s.status === "ended").length;
         expect(ended).toBeGreaterThanOrEqual(prevEnded);
+        // Z-Demo-3: values are carried forward in small increments — never a jump.
+        // A single tick accrues at most one tool call, so the per-tick deltas are
+        // tightly bounded (no re-rolling that would lurch the figures up and down).
+        if (prevTokens >= 0) {
+          expect(today.totalTokens - prevTokens).toBeLessThanOrEqual(4000);
+          expect(today.costUsd - prevCost).toBeLessThanOrEqual(0.02);
+        }
         prevCost = today.costUsd;
         prevTokens = today.totalTokens;
         prevEnded = ended;

--- a/src/lib/demo.ts
+++ b/src/lib/demo.ts
@@ -96,6 +96,10 @@ let started = false;
 const MAX_LIVE = 5;
 const MAX_ENDED = 300;
 const GRAPH_WINDOW = 14;
+// Z-Demo-3 — calmer cadence. A slower tick (was 1100ms) so the dashboard breathes
+// instead of flickering; values are carried forward in small increments rather
+// than re-rolled, so nothing jumps.
+export const TICK_MS = 2400;
 
 // Live economy — strictly monotonic. Each completed tool call accrues a small,
 // always-positive amount of tokens/cost, so the demo's figures only ever climb in
@@ -264,13 +268,16 @@ function accrue() {
 
 function step() {
   const live = sessions.filter((s) => s.status !== "ended");
-  if (live.length < 3 || chance(0.14)) {
+  // Spawn new sessions sparingly so the picture evolves gently (was 0.14).
+  if (live.length < 3 || chance(0.07)) {
     newSession();
     return;
   }
   const s = pick(live);
   const r = liveRng();
-  if (r < 0.68) {
+  // Bias toward smooth tool-call progression over lifecycle flips: most ticks
+  // just advance existing work (was 0.68 / 0.80 / 0.87).
+  if (r < 0.75) {
     accrue();
     const tool = pick(TOOLS);
     if (tool === "Task") {
@@ -285,10 +292,10 @@ function step() {
       s.tools.push(target);
     }
     s.status = "active";
-  } else if (r < 0.8) {
+  } else if (r < 0.85) {
     emit(s, "Stop", null, "Response complete — waiting for input");
     s.status = "waiting";
-  } else if (r < 0.87) {
+  } else if (r < 0.9) {
     emit(s, "SessionEnd", null, "Session ended (clear)");
     s.status = "ended";
     s.ended_at = dbNow();
@@ -311,7 +318,7 @@ export function startDemo() {
   sidCounter = 0;
   for (let i = 0; i < 4; i++) newSession();
   for (let i = 0; i < 30; i++) step(); // pre-warm so the graph isn't empty
-  setInterval(step, 1100);
+  setInterval(step, TICK_MS);
 }
 
 // ── API-shaped getters ───────────────────────────────────────────────────────


### PR DESCRIPTION
## Z-Demo-3 — Ruhigerer Takt

> **Gestackt auf #152 (Z-Demo-2) → #151 (Z-Demo-1).** Solange die Vorgänger nicht in `main` sind, zeigt dieser Diff auch deren Änderungen. **Bitte der Reihe nach mergen (#151 → #152 → #153)**, dann kollabiert der Diff hier auf reine Z-Demo-3-Änderungen.

Entschleunigt die öffentliche Demo (`src/lib/demo.ts`, nur aktiv bei `NEXT_PUBLIC_MC_DEMO=1`).

### Änderungen
- **Langsamerer Takt:** Live-Tick `1100ms → 2400ms` (`TICK_MS`) — das Dashboard atmet statt zu flackern.
- **Sanftere Fluktuation:** neue Sessions seltener (`chance 0.14 → 0.07`); jeder Tick ist stärker auf das **Fortschreiben bestehender Arbeit** ausgerichtet statt auf Lifecycle-Wechsel (Tool-Call-Band `0.68 → 0.75`, Stop/End entsprechend verschoben).
- **Keine Sprünge:** Werte werden in kleinen Schritten fortgeschrieben (kein Neuwürfeln) — Fundament aus Z-Demo-1/2 (seedbare Snapshots, monotone Ökonomie).

### Tests
- `src/lib/demo.test.ts`: der Live-Evolution-Test prüft jetzt zusätzlich, dass die **Pro-Tick-Deltas** von `totalTokens` (≤ 4000) und `costUsd` (≤ 0.02) eng begrenzt bleiben — ein Tick akkumuliert höchstens einen Tool-Call, also kein ruckartiges Auf/Ab. Determinismus- und Monotonie-/Persistenz-Checks bleiben grün.

### Definition of Done
- [x] Lint ✓
- [x] Unit ✓ (420 passed)
- [x] Build ✓
- [ ] Full E2E — per Test-Kadenz erst gesammelt vor Run 120
- [x] Golden Rule unangetastet (read-only Client-Engine, keine API-Änderung)


---
_Generated by [Claude Code](https://claude.ai/code/session_01UEgRzpHQh5WY2WKZgcscZA)_