### PR TITLE
Z-Demo-4: epic auto-rotation for the 3D tool-graph

### DIFF
--- a/src/plugins/tool-graph/auto-rotate.test.ts
+++ b/src/plugins/tool-graph/auto-rotate.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import { autoRotateSpeed, AUTO_ROTATE_SPEED, RESUME_DELAY_MS, RAMP_MS } from "./auto-rotate";
+
+describe("tool-graph auto-rotate timing", () => {
+  it("idles at full epic speed until first touched", () => {
+    expect(autoRotateSpeed(null)).toBe(AUTO_ROTATE_SPEED);
+  });
+
+  it("stays paused for the full 15s after interaction ends", () => {
+    expect(autoRotateSpeed(0)).toBe(0);
+    expect(autoRotateSpeed(RESUME_DELAY_MS - 1)).toBe(0);
+    expect(autoRotateSpeed(RESUME_DELAY_MS)).toBe(0); // ramp k=0
+  });
+
+  it("eases gently back to full speed over the ramp window (never snaps)", () => {
+    expect(autoRotateSpeed(RESUME_DELAY_MS + RAMP_MS / 2)).toBeCloseTo(AUTO_ROTATE_SPEED / 2, 5);
+    expect(autoRotateSpeed(RESUME_DELAY_MS + RAMP_MS)).toBe(AUTO_ROTATE_SPEED);
+  });
+
+  it("never exceeds full speed once resumed", () => {
+    expect(autoRotateSpeed(RESUME_DELAY_MS + RAMP_MS * 10)).toBe(AUTO_ROTATE_SPEED);
+  });
+
+  it("is monotonic non-decreasing across the resume ramp", () => {
+    let prev = -1;
+    for (let ms = RESUME_DELAY_MS; ms <= RESUME_DELAY_MS + RAMP_MS + 500; ms += 50) {
+      const s = autoRotateSpeed(ms);
+      expect(s).toBeGreaterThanOrEqual(prev);
+      prev = s;
+    }
+    expect(prev).toBe(AUTO_ROTATE_SPEED);
+  });
+});

--- a/src/plugins/tool-graph/auto-rotate.ts
+++ b/src/plugins/tool-graph/auto-rotate.ts
@@ -1,0 +1,22 @@
+// Z-Demo-4 — epic auto-rotation timing for the 3D tool-graph.
+//
+// The graph idles with a slow, steady (epic) auto-rotation. When the user grabs
+// it, rotation stops; once they let go we wait RESUME_DELAY_MS, then ease the
+// speed back up over RAMP_MS so it resumes gently (never snaps back to full).
+// This module is the pure timing core so it can be unit-tested without WebGL.
+
+export const RESUME_DELAY_MS = 15_000;
+export const RAMP_MS = 1_500;
+// OrbitControls.autoRotateSpeed: ~75s per orbit — slow and majestic.
+export const AUTO_ROTATE_SPEED = 0.8;
+
+// Target auto-rotate speed given how long ago the last manual interaction ended.
+// `null` means the user has never touched the graph → idle epic spin. During the
+// interaction and the RESUME_DELAY_MS pause the speed is 0; afterwards it eases
+// linearly from 0 to full over RAMP_MS.
+export function autoRotateSpeed(msSinceInteractionEnd: number | null): number {
+  if (msSinceInteractionEnd === null) return AUTO_ROTATE_SPEED;
+  if (msSinceInteractionEnd < RESUME_DELAY_MS) return 0;
+  const k = Math.min(1, (msSinceInteractionEnd - RESUME_DELAY_MS) / RAMP_MS);
+  return +(AUTO_ROTATE_SPEED * k).toFixed(4);
+}

--- a/src/plugins/tool-graph/widget.tsx
+++ b/src/plugins/tool-graph/widget.tsx
@@ -9,6 +9,7 @@ import { WidgetState } from "@/components/widget-state";
 import { useLive } from "@/components/live-provider";
 import { useT } from "@/lib/i18n";
 import { relativeTime, STATUS_META } from "@/lib/format";
+import { autoRotateSpeed, AUTO_ROTATE_SPEED } from "./auto-rotate";
 
 // Wrapper preserves the imperative ref through next/dynamic (camera + bloom composer).
 const ForceGraph3D = dynamic(() => import("./force-graph"), { ssr: false });
@@ -343,6 +344,56 @@ export function ToolGraph() {
     return () => cancelAnimationFrame(raf);
   }, []);
 
+  // Z-Demo-4: slow, steady auto-rotation. Manual interaction pauses it; 15s after
+  // the user lets go it eases back up to full speed (never snaps). OrbitControls
+  // does the actual orbiting (autoRotate); we just gate speed by interaction time.
+  useEffect(() => {
+    if (!threeReady) return;
+    let raf = 0;
+    let tries = 0;
+    let interacting = false;
+    let lastEnd: number | null = null; // null until the user first grabs the graph
+    let detach = () => {};
+    const setup = () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const controls = fgRef.current?.controls?.() as any;
+      if (!controls?.addEventListener) {
+        if (tries++ < 60) raf = requestAnimationFrame(setup);
+        return;
+      }
+      const onStart = () => {
+        interacting = true;
+      };
+      const onEnd = () => {
+        interacting = false;
+        lastEnd = performance.now();
+      };
+      controls.addEventListener("start", onStart);
+      controls.addEventListener("end", onEnd);
+      detach = () => {
+        controls.removeEventListener("start", onStart);
+        controls.removeEventListener("end", onEnd);
+        controls.autoRotate = false;
+      };
+      const loop = () => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const c = fgRef.current?.controls?.() as any;
+        if (c) {
+          const speed = interacting ? 0 : autoRotateSpeed(lastEnd === null ? null : performance.now() - lastEnd);
+          c.autoRotate = speed > 0;
+          c.autoRotateSpeed = speed > 0 ? speed : AUTO_ROTATE_SPEED;
+        }
+        raf = requestAnimationFrame(loop);
+      };
+      raf = requestAnimationFrame(loop);
+    };
+    setup();
+    return () => {
+      cancelAnimationFrame(raf);
+      detach();
+    };
+  }, [threeReady]);
+
   const focusNode = useCallback((node: GraphNode) => {
     const fg = fgRef.current;
     if (!fg?.cameraPosition || typeof node.x !== "number") return;
@@ -419,6 +470,7 @@ export function ToolGraph() {
                 height={dims.h}
                 graphData={data}
                 backgroundColor="#06070b"
+                controlType="orbit"
                 showNavInfo={false}
                 nodeLabel={(n: object) => {
                   const g = n as GraphNode;


### PR DESCRIPTION
## Z-Demo-4 — Epischer 3D-Graph

> **Gestackt auf #153 → #152 → #151.** Solange die Vorgänger nicht in `main` sind, zeigt dieser Diff auch deren Änderungen. **Bitte der Reihe nach mergen (#151 → #152 → #153 → #154)**, dann kollabiert der Diff hier auf reine Z-Demo-4-Änderungen.

Macht die 3D-Tool-Graph-Rotation episch — **Optik bleibt unverändert** (Nodes, Bloom, Farben), nur das Rotationsverhalten ist neu.

### Änderungen (`src/plugins/tool-graph/`)
- **`controlType="orbit"`** → three.js `OrbitControls` mit eingebautem `autoRotate`.
- **Langsame, gleichmäßige Auto-Rotation** (~75s pro Umdrehung, `AUTO_ROTATE_SPEED = 0.8`) — majestätisch statt hektisch, kein Springen.
- **Manuelle Bewegung pausiert** die Rotation sofort; **15 s** nach dem Loslassen wird sie über eine kurze Rampe (1,5 s) **sanft wieder aufgenommen** — kein harter Sprung zurück auf volle Geschwindigkeit.
- Pause/Resume/Ramp-Timing ist in `auto-rotate.ts` als **reine Funktion** ausgelagert (WebGL-frei → unit-testbar).

### Tests
- `auto-rotate.test.ts` (5 Tests): Idle = volle Speed bis zur ersten Berührung; 0 während der 15-s-Pause; lineare Ease-in-Rampe (kein Snap); Deckelung bei voller Speed; Monotonie über die Rampe.
- Die eigentliche Rotation ist WebGL-/Browser-Verhalten — die Library-API (`controlType='orbit'`, `controls()`-Accessor, `autoRotate`, `controls.update()` pro Frame) wurde gegen `3d-force-graph`/`three` verifiziert; die visuelle Bestätigung erfolgt im Demo-Build / per Screenshot.

### Definition of Done
- [x] Lint ✓
- [x] Unit ✓ (425 passed, +5)
- [x] Build ✓
- [ ] Full E2E — per Test-Kadenz erst gesammelt **vor Run 120** (jetzt komplette Z-Demo-Serie fertig → als Nächstes die volle Suite + Run 120)
- [x] Golden Rule unangetastet (nur Client-seitiges Rendering-Verhalten, keine API-Änderung)


---
_Generated by [Claude Code](https://claude.ai/code/session_01UEgRzpHQh5WY2WKZgcscZA)_