### PR TITLE
Z-Web-1: professional site footer + standalone pages

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -433,24 +433,41 @@ Die öffentliche Demo (läuft idealerweise **nur** auf der Website) wirkt aktuel
 das Aushängeschild. Deshalb **aufgefächert** in mehrere PR-große Teil-Runs (der
 Reihe nach abzuarbeiten, jeder mit De/En × Light/Dark-Screenshots der Demo):
 
-- **Z-Demo-1 — Seedbare, konsistente Demo-Daten.** Fundament: die In-Browser-
-  Engine (`src/lib/demo.ts`) deterministisch/seedbar machen, sodass über Reloads
-  hinweg ein stimmiges, kuratiertes Bild entsteht und Screenshots/GIFs
-  reproduzierbar sind. → Voraussetzung für Z-Demo-2…4.
-- **Z-Demo-2 — Persistente Sessions & monotone Ökonomie.** Eine **beendete
-  Session verschwindet nie wieder** (bleibt in „Beendet", kein Wegrotieren der
-  Historie); **Kosten/Tokens steigen monoton** — nur aufwärts, in kleinen,
-  plausiblen Schritten, **kein Hoch-/Runter-Springen**.
-- **Z-Demo-3 — Ruhigerer Takt.** Ereignis-Takt entschleunigen, keine sprunghaften
-  Zahlensprünge; Werte sanft fortschreiben statt neu zu würfeln.
-- **Z-Demo-4 — Epischer 3D-Graph.** Optik bleibt, aber **nicht springen**: eine
-  **langsame, gleichmäßige (epische) Auto-Rotation**. Bei **manueller** Bewegung
-  nicht sofort weiterdrehen, sondern **15 s warten**, dann sanft wieder aufnehmen.
+- ✅ **Z-Demo-1 — Seedbare, konsistente Demo-Daten** *(erledigt, #151)*. Fundament:
+  die In-Browser-Engine (`src/lib/demo.ts`) deterministisch/seedbar (mulberry32),
+  sodass über Reloads hinweg ein stimmiges, kuratiertes Bild entsteht und
+  Screenshots/GIFs reproduzierbar sind. → Voraussetzung für Z-Demo-2…4.
+- ✅ **Z-Demo-2 — Persistente Sessions & monotone Ökonomie** *(erledigt, #152)*. Eine
+  **beendete Session verschwindet nie wieder** (Live-Set begrenzt, Historie bleibt);
+  **Kosten/Tokens steigen monoton** — nur aufwärts, in kleinen Schritten, **kein
+  Hoch-/Runter-Springen**.
+- ✅ **Z-Demo-3 — Ruhigerer Takt** *(erledigt, #153)*. Ereignis-Takt entschleunigt
+  (1100 → 2400 ms), seltener neue Sessions; Werte sanft fortschreiben statt neu zu
+  würfeln (Pro-Tick-Deltas eng begrenzt).
+- ✅ **Z-Demo-4 — Epischer 3D-Graph** *(erledigt, #154)*. Optik bleibt; **langsame,
+  gleichmäßige Auto-Rotation** (~75 s/Umdrehung). Bei **manueller** Bewegung
+  pausiert sie und nimmt **15 s** später über eine Rampe sanft wieder auf.
 
-### Z-Shots. 📸 Automatische Widget-Galerie (Playwright, **vor dem Beta-Release**)
+### Z-Web. 🪪 Professionelle Website-Seiten + Footer (Aushängeschild)
+
+> Die Demo soll so professionell wirken wie Obsidian & Co.: vollständige Seiten,
+> ein kompakter, technisch/animatorisch hochwertiger Footer, und überall Bilder
+> vom Programm. **Release-relevant** (erster Eindruck).
+
+- **Z-Web-1 — Footer & Seiten** *(in Arbeit)*. Kompakter, animierter `SiteFooter`
+  (Sheen-Hairline, Hover-Underlines, Open-to-work-Badge, Foto-Platzhalter) auf
+  Dashboard **und** allen Seiten. Vier eigenständige, statisch exportierte Seiten
+  über ein gemeinsames `PageShell`: **Über mich** (Portfolio/Status arbeitssuchend),
+  **Funktionen**, **Kontakt**, **Impressum & Datenschutz** (DE-konform, Hinweis:
+  Demo rein clientseitig, keine Datenerhebung). Voll i18n (DE/EN). Kontaktdaten:
+  Name, Ort (Freiberg am Neckar), Telefon, E-Mail, GitHub — **ohne Straße**.
+- **Z-Web-2 — Foto.** Echtes Profilbild unter `public/profile.jpg` einsetzen
+  (der `Avatar` zeigt es automatisch statt des Platzhalters).
+
+### Z-Shots. 📸 Automatische Bild-Galerie + GIFs (Playwright, **vor dem Beta-Release**)
 
 Die alten Platzhalter-Bilder wurden in Run 99 entfernt. **Direkt vor dem
-Beta-Release** wird eine frische, vollständige Bild-Galerie automatisch erzeugt:
+Beta-Release** wird eine frische, vollständige Galerie automatisch erzeugt:
 
 - **Jedes Widget einzeln** (alle Einträge der Registry) als eigener Screenshot.
 - **Beide Themes** (Light **und** Dark) **× jede Akzentfarbe** der Palette
@@ -459,8 +476,10 @@ Beta-Release** wird eine frische, vollständige Bild-Galerie automatisch erzeugt
 - **Mit Playwright** erzeugt (eigener Spec/Script über dem Seed-/Demo-Backend),
   deterministisch und reproduzierbar; Ausgabe nach `assets/widgets/<widget>/
   <mode>-<accent>.png` und als CI-Artefakt gesammelt.
-- README/Doku-Galerie + Demo-Sektion werden mit den neuen Bildern bestückt
-  (ersetzt die in Run 99 entfernten Platzhalter).
+- **GIFs** (Live-Stream, 3D-Graph-Rotation) per Playwright-Video → ffmpeg/gifski
+  **in CI** (lokal fehlt das Tooling), professionell und schlank.
+- **README-Galerie + Funktionen-Seite + Demo-Sektion** werden mit den neuen
+  Bildern bestückt (ersetzt die in Run 99 entfernten Platzhalter).
 
 ## Phase Ω — Beta-Release (Run 120, **letzter Schritt**)
 

--- a/public/README.md
+++ b/public/README.md
@@ -1,0 +1,7 @@
+# Public assets
+
+Drop a profile photo here as **`profile.jpg`** (square works best, e.g. 512×512).
+
+It is picked up automatically by the `Avatar` component and shown in the site
+footer and on the **About** and **Contact** pages. Until a file exists, a styled
+placeholder is shown instead — no code change needed when you add the photo.

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import Link from "next/link";
+import { ArrowRight } from "lucide-react";
+import { PageShell } from "@/components/page-shell";
+import { GithubMark } from "@/components/github-mark";
+import { Avatar } from "@/components/avatar";
+import { useT } from "@/lib/i18n";
+import { CONTACT } from "@/lib/contact";
+
+const SKILLS = [
+  "TypeScript",
+  "React",
+  "Next.js",
+  "Node.js",
+  "Tailwind CSS",
+  "Three.js",
+  "SQLite",
+  "Playwright",
+  "Vitest",
+  "CI/CD",
+  "REST APIs",
+  "UI/UX",
+];
+
+export default function AboutPage() {
+  const { t } = useT();
+  return (
+    <PageShell active="/about">
+      <div className="mc-fade-up flex flex-col gap-10">
+        {/* Hero */}
+        <section className="flex flex-col items-start gap-6 sm:flex-row sm:items-center">
+          <Avatar size={120} className="ring-2" />
+          <div className="min-w-0">
+            <span className="inline-flex items-center gap-1.5 rounded-full border border-emerald-500/30 bg-emerald-500/10 px-2.5 py-1 text-[11px] font-medium text-emerald-400">
+              <span className="mc-live-dot h-1.5 w-1.5 rounded-full bg-emerald-400" />
+              {t("footer.openToWork")}
+            </span>
+            <h1 className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl">{CONTACT.name}</h1>
+            <p className="mt-3 max-w-2xl text-sm leading-relaxed text-muted sm:text-base">{t("about.lead")}</p>
+          </div>
+        </section>
+
+        {/* Skills */}
+        <section>
+          <h2 className="mb-3 text-sm font-semibold uppercase tracking-wider text-foreground/80">{t("about.skillsTitle")}</h2>
+          <ul className="flex flex-wrap gap-2">
+            {SKILLS.map((s) => (
+              <li
+                key={s}
+                className="rounded-full border border-panel-border bg-panel/60 px-3 py-1 text-[12px] text-muted transition-colors hover:border-accent/40 hover:text-foreground"
+              >
+                {s}
+              </li>
+            ))}
+          </ul>
+        </section>
+
+        {/* Background + project */}
+        <section className="grid gap-4 sm:grid-cols-2">
+          <article className="rounded-xl border border-panel-border bg-panel/40 p-5">
+            <h2 className="mb-2 text-base font-semibold text-foreground">{t("about.backgroundTitle")}</h2>
+            <p className="text-sm leading-relaxed text-muted">{t("about.backgroundBody")}</p>
+          </article>
+          <article className="rounded-xl border border-panel-border bg-panel/40 p-5">
+            <h2 className="mb-2 text-base font-semibold text-foreground">{t("about.projectTitle")}</h2>
+            <p className="text-sm leading-relaxed text-muted">{t("about.projectBody")}</p>
+          </article>
+        </section>
+
+        {/* CTAs */}
+        <section className="flex flex-wrap gap-3">
+          <Link
+            href="/contact"
+            className="inline-flex items-center gap-1.5 rounded-lg bg-accent px-4 py-2 text-sm font-medium text-white transition-opacity hover:opacity-90"
+          >
+            {t("about.ctaContact")}
+            <ArrowRight className="h-4 w-4" />
+          </Link>
+          <a
+            href={CONTACT.repo}
+            target="_blank"
+            rel="noreferrer noopener"
+            className="inline-flex items-center gap-1.5 rounded-lg border border-panel-border px-4 py-2 text-sm font-medium text-foreground transition-colors hover:border-accent/50"
+          >
+            <GithubMark className="h-4 w-4" />
+            {t("about.ctaProject")}
+          </a>
+        </section>
+      </div>
+    </PageShell>
+  );
+}

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { Mail, Phone, MapPin, BadgeCheck } from "lucide-react";
+import { PageShell } from "@/components/page-shell";
+import { GithubMark } from "@/components/github-mark";
+import { Avatar } from "@/components/avatar";
+import { useT } from "@/lib/i18n";
+import { CONTACT } from "@/lib/contact";
+
+function ContactRow({
+  icon: Icon,
+  label,
+  value,
+  href,
+}: {
+  icon: React.ComponentType<{ className?: string }>;
+  label: string;
+  value: string;
+  href?: string;
+}) {
+  const body = (
+    <div className="flex items-center gap-3 rounded-xl border border-panel-border bg-panel/40 p-4 transition-colors hover:border-accent/40">
+      <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-accent/10 text-accent">
+        <Icon className="h-5 w-5" />
+      </span>
+      <div className="min-w-0">
+        <p className="text-[11px] uppercase tracking-wide text-muted">{label}</p>
+        <p className="truncate text-sm text-foreground">{value}</p>
+      </div>
+    </div>
+  );
+  return href ? (
+    <a href={href} target={href.startsWith("http") ? "_blank" : undefined} rel="noreferrer noopener" className="block">
+      {body}
+    </a>
+  ) : (
+    body
+  );
+}
+
+export default function ContactPage() {
+  const { t } = useT();
+  return (
+    <PageShell active="/contact">
+      <div className="mc-fade-up flex flex-col gap-8">
+        <header className="flex flex-col items-start gap-4 sm:flex-row sm:items-center">
+          <Avatar size={84} />
+          <div>
+            <h1 className="text-3xl font-bold tracking-tight text-foreground sm:text-4xl">{t("contact.title")}</h1>
+            <p className="mt-2 max-w-xl text-sm leading-relaxed text-muted">{t("contact.lead")}</p>
+          </div>
+        </header>
+
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+          <ContactRow icon={Mail} label={t("contact.emailLabel")} value={CONTACT.email} href={`mailto:${CONTACT.email}`} />
+          <ContactRow icon={Phone} label={t("contact.phoneLabel")} value={CONTACT.phone} href={CONTACT.phoneHref} />
+          <ContactRow icon={MapPin} label={t("contact.locationLabel")} value={`${CONTACT.city}, ${CONTACT.country}`} />
+          <ContactRow icon={GithubMark} label={t("contact.githubLabel")} value="BEKO2210" href={CONTACT.github} />
+        </div>
+
+        <div className="flex flex-wrap items-center gap-3 rounded-xl border border-emerald-500/25 bg-emerald-500/[0.06] p-4">
+          <BadgeCheck className="h-5 w-5 text-emerald-400" />
+          <div>
+            <p className="text-[11px] uppercase tracking-wide text-emerald-400/90">{t("contact.statusLabel")}</p>
+            <p className="text-sm text-foreground">{t("about.status")}</p>
+          </div>
+        </div>
+
+        <p className="text-xs text-muted">{t("contact.note")}</p>
+      </div>
+    </PageShell>
+  );
+}

--- a/src/app/features/page.tsx
+++ b/src/app/features/page.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { Activity, KanbanSquare, Coins, Boxes, Timer, AlertTriangle, ImageIcon, ArrowRight, type LucideIcon } from "lucide-react";
+import { PageShell } from "@/components/page-shell";
+import { useT } from "@/lib/i18n";
+import { CONTACT } from "@/lib/contact";
+
+type Feat = { icon: LucideIcon; t: string; d: string };
+
+export default function FeaturesPage() {
+  const { t } = useT();
+  const features: Feat[] = [
+    { icon: Activity, t: t("landing.f1t"), d: t("landing.f1d") },
+    { icon: KanbanSquare, t: t("landing.f2t"), d: t("landing.f2d") },
+    { icon: Coins, t: t("landing.f3t"), d: t("landing.f3d") },
+    { icon: Boxes, t: t("landing.f4t"), d: t("landing.f4d") },
+    { icon: Timer, t: t("features.f5t"), d: t("features.f5d") },
+    { icon: AlertTriangle, t: t("features.f6t"), d: t("features.f6d") },
+  ];
+
+  return (
+    <PageShell active="/features">
+      <div className="mc-fade-up flex flex-col gap-12">
+        <header className="max-w-2xl">
+          <h1 className="text-3xl font-bold tracking-tight text-foreground sm:text-4xl">{t("features.title")}</h1>
+          <p className="mt-3 text-sm leading-relaxed text-muted sm:text-base">{t("features.lead")}</p>
+        </header>
+
+        <section className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          {features.map((f) => (
+            <article
+              key={f.t}
+              className="group rounded-xl border border-panel-border bg-panel/50 p-5 transition-colors hover:border-accent/30"
+            >
+              <span className="inline-flex h-9 w-9 items-center justify-center rounded-lg bg-accent/10 text-accent transition-transform group-hover:scale-110">
+                <f.icon className="h-5 w-5" />
+              </span>
+              <h3 className="mt-3 text-sm font-semibold text-foreground">{f.t}</h3>
+              <p className="mt-1 text-xs leading-relaxed text-muted">{f.d}</p>
+            </article>
+          ))}
+        </section>
+
+        {/* Gallery — placeholders now; the CI gallery pipeline (Z-Shots) fills these. */}
+        <section>
+          <h2 className="text-lg font-semibold text-foreground">{t("features.galleryTitle")}</h2>
+          <p className="mt-1 text-sm text-muted">{t("features.galleryLead")}</p>
+          <div className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2">
+            {[0, 1, 2, 3].map((i) => (
+              <div
+                key={i}
+                className="flex aspect-video items-center justify-center rounded-xl border border-dashed border-panel-border bg-panel/30 text-muted"
+              >
+                <span className="flex flex-col items-center gap-2 text-xs">
+                  <ImageIcon className="h-6 w-6 opacity-60" />
+                  {t("features.shotComing")}
+                </span>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section className="rounded-2xl border border-panel-border bg-gradient-to-br from-panel/60 to-background p-8 text-center">
+          <p className="text-base font-medium text-foreground">{t("landing.tagline")}</p>
+          <a
+            href={CONTACT.demo}
+            target="_blank"
+            rel="noreferrer noopener"
+            className="mt-4 inline-flex items-center gap-1.5 rounded-lg bg-accent px-5 py-2.5 text-sm font-medium text-white transition-opacity hover:opacity-90"
+          >
+            {t("features.ctaDemo")}
+            <ArrowRight className="h-4 w-4" />
+          </a>
+        </section>
+      </div>
+    </PageShell>
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -180,6 +180,27 @@ body {
   animation: mc-stream-in 0.35s ease both;
 }
 
+/* Footer: a slow accent sheen sweeping across the top hairline. */
+@keyframes mc-sheen {
+  0% {
+    background-position: -150% 0;
+  }
+  100% {
+    background-position: 250% 0;
+  }
+}
+.mc-footer-sheen {
+  background-image: linear-gradient(
+    90deg,
+    transparent 0%,
+    color-mix(in srgb, var(--accent) 70%, transparent) 50%,
+    transparent 100%
+  );
+  background-size: 40% 100%;
+  background-repeat: no-repeat;
+  animation: mc-sheen 7s linear infinite;
+}
+
 /* Respect users who prefer less motion. */
 @media (prefers-reduced-motion: reduce) {
   *,

--- a/src/app/legal/page.tsx
+++ b/src/app/legal/page.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { useT } from "@/lib/i18n";
+import { PageShell } from "@/components/page-shell";
+import { CONTACT } from "@/lib/contact";
+
+function Section({ id, title, children }: { id: string; title: string; children: React.ReactNode }) {
+  return (
+    <section id={id} className="scroll-mt-24 rounded-xl border border-panel-border bg-panel/40 p-6">
+      <h2 className="text-lg font-semibold text-foreground">{title}</h2>
+      <div className="mt-3 space-y-2 text-sm leading-relaxed text-muted">{children}</div>
+    </section>
+  );
+}
+
+export default function LegalPage() {
+  const { t } = useT();
+  return (
+    <PageShell>
+      <div className="mc-fade-up flex flex-col gap-6">
+        <h1 className="text-3xl font-bold tracking-tight text-foreground sm:text-4xl">{t("legal.title")}</h1>
+
+        <Section id="impressum" title={t("legal.impressumTitle")}>
+          <p className="text-xs uppercase tracking-wide text-muted/80">{t("legal.impressumIntro")}</p>
+          <p className="pt-1 font-medium text-foreground">{t("legal.responsible")}</p>
+          <p>{CONTACT.name}</p>
+          <p>
+            {CONTACT.city}, {CONTACT.country}
+          </p>
+          <p className="pt-2 font-medium text-foreground">{t("legal.contactTitle")}</p>
+          <p>
+            <a href={`mailto:${CONTACT.email}`} className="hover:text-foreground">
+              {CONTACT.email}
+            </a>
+          </p>
+          <p>
+            <a href={CONTACT.phoneHref} className="hover:text-foreground">
+              {CONTACT.phone}
+            </a>
+          </p>
+        </Section>
+
+        <Section id="datenschutz" title={t("legal.privacyTitle")}>
+          <p>{t("legal.privacyIntro")}</p>
+          <p>{t("legal.privacyClient")}</p>
+          <p>{t("legal.privacyHosting")}</p>
+        </Section>
+
+        <Section id="haftung" title={t("legal.disclaimerTitle")}>
+          <p>{t("legal.disclaimerBody")}</p>
+        </Section>
+      </div>
+    </PageShell>
+  );
+}

--- a/src/components/avatar.tsx
+++ b/src/components/avatar.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { useState } from "react";
+import { User } from "lucide-react";
+import { asset } from "@/lib/asset";
+
+// Profile photo with a graceful placeholder. Drop a file at `public/profile.jpg`
+// and it appears automatically — no code change. Until then (or on load error)
+// a styled placeholder is shown, so the layout never breaks.
+export function Avatar({
+  size = 96,
+  src = "/profile.jpg",
+  alt = "Belkis Aslani",
+  className = "",
+}: {
+  size?: number;
+  src?: string;
+  alt?: string;
+  className?: string;
+}) {
+  const [ok, setOk] = useState(true);
+  const dim = { width: size, height: size };
+  return (
+    <span
+      className={`relative inline-flex shrink-0 items-center justify-center overflow-hidden rounded-full ring-1 ring-accent/30 bg-gradient-to-br from-panel to-background ${className}`}
+      style={dim}
+    >
+      {ok ? (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img
+          src={asset(src)}
+          alt={alt}
+          width={size}
+          height={size}
+          className="h-full w-full object-cover"
+          onError={() => setOk(false)}
+        />
+      ) : (
+        <User className="text-muted" style={{ width: size * 0.42, height: size * 0.42 }} aria-hidden />
+      )}
+    </span>
+  );
+}

--- a/src/components/dashboard.tsx
+++ b/src/components/dashboard.tsx
@@ -29,6 +29,7 @@ import { LangToggle } from "@/components/lang-toggle";
 import { InfoHint } from "@/components/info-hint";
 import { WidgetErrorBoundary } from "@/components/error-boundary";
 import { Landing } from "@/components/landing";
+import { SiteFooter } from "@/components/site-footer";
 import { SearchProvider, useSearch } from "@/components/search";
 import { TimeRangeProvider, useTimeRange } from "@/components/time-range";
 import { FacetProvider, useFacets } from "@/components/facets";
@@ -303,10 +304,8 @@ export function Dashboard() {
               );
             })}
           </div>
-          <footer className="pt-2 text-center text-[11px] text-muted">
-            {t("footer.text")} · <span className="text-muted">by Belkis Aslani</span>
-          </footer>
         </div>
+        <SiteFooter />
         {galleryOpen && (
           <WidgetGallery
             order={order}

--- a/src/components/github-mark.tsx
+++ b/src/components/github-mark.tsx
@@ -1,0 +1,9 @@
+// GitHub glyph as a local SVG — lucide-react dropped its brand icons, so we ship
+// our own (same mark used on the landing hero). Accepts a className like an icon.
+export function GithubMark({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 16 16" className={className} fill="currentColor" aria-hidden="true">
+      <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 2-.27c.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8z" />
+    </svg>
+  );
+}

--- a/src/components/page-shell.tsx
+++ b/src/components/page-shell.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
+import { RadarLogo } from "@/components/radar-logo";
+import { LangToggle } from "@/components/lang-toggle";
+import { SiteFooter } from "@/components/site-footer";
+import { useT } from "@/lib/i18n";
+
+const NAV = [
+  { href: "/features", key: "nav.features" },
+  { href: "/about", key: "nav.about" },
+  { href: "/contact", key: "nav.contact" },
+] as const;
+
+// Chrome for the standalone marketing/legal pages: a sticky top bar with brand +
+// nav + language toggle, the page content, and the shared site footer.
+export function PageShell({ active, children }: { active?: string; children: React.ReactNode }) {
+  const { t } = useT();
+  return (
+    <div className="flex min-h-screen flex-col bg-background">
+      <header className="sticky top-0 z-40 border-b border-panel-border bg-background/80 backdrop-blur">
+        <div className="mx-auto flex max-w-[1100px] items-center justify-between gap-3 px-5 py-3 sm:px-6">
+          <Link href="/" className="group flex items-center gap-2 text-foreground">
+            <RadarLogo className="h-6 w-6 transition-transform group-hover:scale-110" />
+            <span className="text-sm font-semibold tracking-tight">Claude Mission Control</span>
+          </Link>
+          <nav className="flex items-center gap-1">
+            {NAV.map((n) => (
+              <Link
+                key={n.href}
+                href={n.href}
+                className={`rounded-md px-2.5 py-1 text-[12px] transition-colors hover:text-foreground ${
+                  active === n.href ? "text-foreground" : "text-muted"
+                }`}
+              >
+                {t(n.key)}
+              </Link>
+            ))}
+            <span className="mx-1 hidden h-4 w-px bg-panel-border sm:block" />
+            <LangToggle />
+          </nav>
+        </div>
+      </header>
+
+      <main className="mx-auto w-full max-w-[1100px] flex-1 px-5 py-10 sm:px-6 sm:py-14">
+        <Link
+          href="/"
+          className="mb-6 inline-flex items-center gap-1.5 text-xs text-muted transition-colors hover:text-foreground"
+        >
+          <ArrowLeft className="h-3.5 w-3.5" />
+          {t("nav.backHome")}
+        </Link>
+        {children}
+      </main>
+
+      <SiteFooter />
+    </div>
+  );
+}

--- a/src/components/site-footer.tsx
+++ b/src/components/site-footer.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import Link from "next/link";
+import { Mail, Phone, MapPin, ArrowUpRight } from "lucide-react";
+import { RadarLogo } from "@/components/radar-logo";
+import { GithubMark } from "@/components/github-mark";
+import { Avatar } from "@/components/avatar";
+import { useT } from "@/lib/i18n";
+import { CONTACT } from "@/lib/contact";
+
+function FootLink({ href, children, external }: { href: string; children: React.ReactNode; external?: boolean }) {
+  const cls =
+    "group/link inline-flex w-fit items-center gap-1 text-[12px] text-muted transition-colors hover:text-foreground";
+  const inner = (
+    <>
+      <span className="relative">
+        {children}
+        <span className="absolute -bottom-0.5 left-0 h-px w-0 bg-accent transition-all duration-300 group-hover/link:w-full" />
+      </span>
+      {external && <ArrowUpRight className="h-3 w-3 opacity-0 transition-opacity group-hover/link:opacity-100" />}
+    </>
+  );
+  return external ? (
+    <a href={href} target="_blank" rel="noreferrer noopener" className={cls}>
+      {inner}
+    </a>
+  ) : (
+    <Link href={href} className={cls}>
+      {inner}
+    </Link>
+  );
+}
+
+function Column({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="flex flex-col gap-2">
+      <h3 className="text-[11px] font-semibold uppercase tracking-wider text-foreground/80">{title}</h3>
+      {children}
+    </div>
+  );
+}
+
+// Compact, animated site footer. Shared by the dashboard and the standalone pages.
+export function SiteFooter() {
+  const { t } = useT();
+  const year = new Date().getFullYear();
+
+  return (
+    <footer className="relative mt-6 border-t border-panel-border bg-panel/40">
+      {/* animated accent sheen on the top hairline */}
+      <div aria-hidden className="mc-footer-sheen pointer-events-none absolute inset-x-0 -top-px h-px" />
+
+      <div className="mx-auto grid max-w-[1600px] grid-cols-2 gap-x-6 gap-y-7 px-5 py-7 sm:px-6 md:grid-cols-4 lg:grid-cols-[1.6fr_1fr_1fr_1.4fr]">
+        {/* Brand */}
+        <div className="col-span-2 flex flex-col gap-3 md:col-span-1">
+          <Link href="/" className="group flex items-center gap-2 text-foreground">
+            <RadarLogo className="h-6 w-6 transition-transform group-hover:scale-110" />
+            <span className="text-sm font-semibold tracking-tight">Claude Mission Control</span>
+          </Link>
+          <p className="max-w-xs text-[12px] leading-relaxed text-muted">{t("footer.tagline")}</p>
+          <div className="mt-1 flex items-center gap-2">
+            <a
+              href={CONTACT.repo}
+              target="_blank"
+              rel="noreferrer noopener"
+              aria-label="GitHub"
+              className="flex h-8 w-8 items-center justify-center rounded-full border border-panel-border text-muted transition-colors hover:border-accent/50 hover:text-foreground"
+            >
+              <GithubMark className="h-4 w-4" />
+            </a>
+            <a
+              href={`mailto:${CONTACT.email}`}
+              aria-label={t("contact.emailLabel")}
+              className="flex h-8 w-8 items-center justify-center rounded-full border border-panel-border text-muted transition-colors hover:border-accent/50 hover:text-foreground"
+            >
+              <Mail className="h-4 w-4" />
+            </a>
+          </div>
+        </div>
+
+        {/* Product */}
+        <Column title={t("footer.product")}>
+          <FootLink href="/">{t("nav.dashboard")}</FootLink>
+          <FootLink href="/features">{t("nav.features")}</FootLink>
+          <FootLink href={CONTACT.demo} external>
+            {t("nav.demo")}
+          </FootLink>
+          <FootLink href={CONTACT.repo} external>
+            {t("nav.github")}
+          </FootLink>
+        </Column>
+
+        {/* Resources / Legal */}
+        <Column title={t("footer.legal")}>
+          <FootLink href="/about">{t("nav.about")}</FootLink>
+          <FootLink href="/contact">{t("nav.contact")}</FootLink>
+          <FootLink href="/legal#impressum">{t("nav.impressum")}</FootLink>
+          <FootLink href="/legal#datenschutz">{t("nav.privacy")}</FootLink>
+        </Column>
+
+        {/* Author card */}
+        <div className="col-span-2 flex items-start gap-3 rounded-xl border border-panel-border bg-background/40 p-3 md:col-span-1">
+          <Avatar size={52} />
+          <div className="min-w-0">
+            <p className="text-sm font-semibold text-foreground">{CONTACT.name}</p>
+            <span className="mt-0.5 inline-flex items-center gap-1.5 rounded-full border border-emerald-500/30 bg-emerald-500/10 px-2 py-0.5 text-[10px] font-medium text-emerald-400">
+              <span className="mc-live-dot h-1.5 w-1.5 rounded-full bg-emerald-400" />
+              {t("footer.openToWork")}
+            </span>
+            <div className="mt-2 flex flex-col gap-1 text-[11px] text-muted">
+              <a href={`mailto:${CONTACT.email}`} className="inline-flex items-center gap-1.5 hover:text-foreground">
+                <Mail className="h-3 w-3" /> {CONTACT.email}
+              </a>
+              <a href={CONTACT.phoneHref} className="inline-flex items-center gap-1.5 hover:text-foreground">
+                <Phone className="h-3 w-3" /> {CONTACT.phone}
+              </a>
+              <span className="inline-flex items-center gap-1.5">
+                <MapPin className="h-3 w-3" /> {CONTACT.city}
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Bottom bar */}
+      <div className="border-t border-panel-border/60">
+        <div className="mx-auto flex max-w-[1600px] flex-col items-center justify-between gap-1.5 px-5 py-3 text-center text-[11px] text-muted sm:flex-row sm:px-6 sm:text-left">
+          <span>
+            © {year} {CONTACT.name}. {t("footer.rights")}
+          </span>
+          <span className="text-muted/80">{t("footer.text")}</span>
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/src/lib/asset.ts
+++ b/src/lib/asset.ts
@@ -1,0 +1,8 @@
+// Public-asset URL helper. On the static GitHub-Pages demo the app is served
+// under a basePath (/My_Dash), so raw "/foo.png" would 404. Mirror next.config's
+// basePath logic here so <img src> to files in /public resolves in both builds.
+export const ASSET_BASE = process.env.NEXT_PUBLIC_MC_DEMO === "1" ? "/My_Dash" : "";
+
+export function asset(path: string): string {
+  return ASSET_BASE + (path.startsWith("/") ? path : "/" + path);
+}

--- a/src/lib/contact.ts
+++ b/src/lib/contact.ts
@@ -1,0 +1,14 @@
+// Single source of truth for public contact details (no street address — kept
+// private by choice). Used by the footer and the About/Contact/Legal pages.
+export const CONTACT = {
+  name: "Belkis Aslani",
+  role: "Developer",
+  email: "belkis.aslani@gmail.com",
+  phone: "+49 176 81462526",
+  phoneHref: "tel:+4917681462526",
+  city: "Freiberg am Neckar",
+  country: "Deutschland",
+  github: "https://github.com/BEKO2210",
+  repo: "https://github.com/BEKO2210/My_Dash",
+  demo: "https://beko2210.github.io/My_Dash/",
+} as const;

--- a/src/lib/i18n.tsx
+++ b/src/lib/i18n.tsx
@@ -45,6 +45,77 @@ const DE: Record<string, string> = {
     "Events im Live-Puffer dieses Browsers (zuletzt empfangene, max. 300) — kein Gesamtzähler. Die Zahl wächst mit neuen Events und startet beim Neuladen frisch aus den letzten ~100.",
   "footer.text": "read-only · Daten aus Hooks → SQLite → UI · die KI rendert dieses Dashboard nie",
 
+  // ── Website-Chrome: Footer + eigenständige Seiten (Z-Web) ───────────────────
+  "footer.tagline": "Read-only Live-Observability für Claude Code.",
+  "footer.product": "Produkt",
+  "footer.resources": "Ressourcen",
+  "footer.legal": "Rechtliches",
+  "footer.openToWork": "Offen für Angebote",
+  "footer.builtBy": "Entwickelt von",
+  "footer.rights": "Alle Rechte vorbehalten.",
+
+  "nav.dashboard": "Dashboard",
+  "nav.features": "Funktionen",
+  "nav.about": "Über mich",
+  "nav.contact": "Kontakt",
+  "nav.impressum": "Impressum",
+  "nav.privacy": "Datenschutz",
+  "nav.download": "Download",
+  "nav.github": "GitHub",
+  "nav.demo": "Live-Demo",
+  "nav.backHome": "Zurück zum Dashboard",
+
+  "about.title": "Über mich",
+  "about.lead":
+    "Hi, ich bin Belkis Aslani – Entwickler aus Freiberg am Neckar. Ich baue durchdachte, performante Web-Anwendungen mit Fokus auf saubere Architektur, gutes Design und Liebe zum Detail.",
+  "about.statusTitle": "Status",
+  "about.status": "Aktuell arbeitssuchend – offen für neue Herausforderungen und Angebote.",
+  "about.skillsTitle": "Skills & Technologien",
+  "about.backgroundTitle": "Hintergrund",
+  "about.backgroundBody":
+    "Am liebsten arbeite ich an Produkten, die echte Probleme lösen – von der Datenschicht bis zur letzten Animation. Claude Mission Control ist mein aktuelles Schaufenster: ein lokales, read-only Observability-Dashboard für Claude Code mit Live-Event-Stream, Session-Kanban, Token-/Kosten-Charts und einem animierten 3D-Tool-Graph.",
+  "about.projectTitle": "Dieses Projekt",
+  "about.projectBody":
+    "Gebaut mit Next.js 16, React 19, TypeScript, Tailwind CSS 4 und Three.js, vollständig getestet (Vitest + Playwright) und über eine Plugin-Registry erweiterbar. Die Demo läuft komplett im Browser – ohne Server.",
+  "about.ctaContact": "Kontakt aufnehmen",
+  "about.ctaProject": "Projekt ansehen",
+
+  "features.title": "Funktionen",
+  "features.lead":
+    "Alles, um jede Aktion von Claude Code in Echtzeit zu verstehen – in einem kuratierten, schnellen Dashboard.",
+  "features.shotComing": "Screenshot folgt",
+  "features.galleryTitle": "Einblicke",
+  "features.galleryLead": "Ein paar Eindrücke aus dem Dashboard. Die Bilder werden automatisch erzeugt.",
+  "features.f5t": "Latenz & Performance",
+  "features.f5d": "Antwort- und Tool-Laufzeiten als Verteilung – Ausreißer sofort sichtbar.",
+  "features.f6t": "Fehler & Anomalien",
+  "features.f6d": "Fehlerraten, Incidents und automatische Anomalie-Erkennung.",
+  "features.ctaDemo": "Live-Demo öffnen",
+
+  "contact.title": "Kontakt",
+  "contact.lead": "Du möchtest zusammenarbeiten oder hast eine Frage? Ich freue mich, von dir zu hören.",
+  "contact.emailLabel": "E-Mail",
+  "contact.phoneLabel": "Telefon",
+  "contact.locationLabel": "Standort",
+  "contact.githubLabel": "GitHub",
+  "contact.statusLabel": "Status",
+  "contact.note": "Antwort meist innerhalb von 24 Stunden.",
+
+  "legal.title": "Impressum & Datenschutz",
+  "legal.impressumTitle": "Impressum",
+  "legal.impressumIntro": "Angaben gemäß § 5 DDG.",
+  "legal.responsible": "Verantwortlich für den Inhalt",
+  "legal.contactTitle": "Kontakt",
+  "legal.privacyTitle": "Datenschutz",
+  "legal.privacyIntro": "Der Schutz deiner Daten ist mir wichtig. Diese Website ist bewusst minimal gehalten.",
+  "legal.privacyClient":
+    "Die Demo läuft vollständig in deinem Browser. Es werden keine personenbezogenen Daten erhoben, keine Cookies gesetzt und kein Tracking eingesetzt. Alle angezeigten Daten sind synthetisch und werden lokal erzeugt.",
+  "legal.privacyHosting":
+    "Gehostet über GitHub Pages (GitHub Inc.). Beim Aufruf kann der Anbieter technisch notwendige Server-Logs (z. B. IP-Adresse) verarbeiten – siehe GitHub-Datenschutzerklärung.",
+  "legal.disclaimerTitle": "Haftungsausschluss",
+  "legal.disclaimerBody":
+    "Inhalte wurden mit größter Sorgfalt erstellt. Für Richtigkeit, Vollständigkeit und Aktualität wird keine Gewähr übernommen. Für Inhalte externer Links sind ausschließlich deren Betreiber verantwortlich.",
+
   "landing.badge": "Live-Demo",
   "landing.tagline": "Live-Observability für Claude Code",
   "landing.lead":
@@ -500,6 +571,77 @@ const EN: Record<string, string> = {
   "header.eventsInfo":
     "Events in this browser's live buffer (most recent, max 300) — not a total counter. It grows with new events and re-seeds from the latest ~100 on reload.",
   "footer.text": "read-only · data from hooks → SQLite → UI · the AI never renders this dashboard",
+
+  // ── Website chrome: footer + standalone pages (Z-Web) ───────────────────────
+  "footer.tagline": "Read-only live observability for Claude Code.",
+  "footer.product": "Product",
+  "footer.resources": "Resources",
+  "footer.legal": "Legal",
+  "footer.openToWork": "Open to work",
+  "footer.builtBy": "Built by",
+  "footer.rights": "All rights reserved.",
+
+  "nav.dashboard": "Dashboard",
+  "nav.features": "Features",
+  "nav.about": "About",
+  "nav.contact": "Contact",
+  "nav.impressum": "Imprint",
+  "nav.privacy": "Privacy",
+  "nav.download": "Download",
+  "nav.github": "GitHub",
+  "nav.demo": "Live demo",
+  "nav.backHome": "Back to dashboard",
+
+  "about.title": "About me",
+  "about.lead":
+    "Hi, I'm Belkis Aslani – a developer based in Freiberg am Neckar, Germany. I build thoughtful, performant web apps with a focus on clean architecture, good design and attention to detail.",
+  "about.statusTitle": "Status",
+  "about.status": "Currently open to work – available for new challenges and opportunities.",
+  "about.skillsTitle": "Skills & tech",
+  "about.backgroundTitle": "Background",
+  "about.backgroundBody":
+    "I love working on products that solve real problems – from the data layer to the last animation. Claude Mission Control is my current showcase: a local, read-only observability dashboard for Claude Code with a live event stream, session kanban, token/cost charts and an animated 3D tool-call graph.",
+  "about.projectTitle": "This project",
+  "about.projectBody":
+    "Built with Next.js 16, React 19, TypeScript, Tailwind CSS 4 and Three.js, fully tested (Vitest + Playwright) and extensible via a plugin registry. The demo runs entirely in the browser – no server.",
+  "about.ctaContact": "Get in touch",
+  "about.ctaProject": "View the project",
+
+  "features.title": "Features",
+  "features.lead":
+    "Everything you need to understand every Claude Code action in real time – in one curated, fast dashboard.",
+  "features.shotComing": "Screenshot coming",
+  "features.galleryTitle": "A look inside",
+  "features.galleryLead": "A few impressions from the dashboard. Images are generated automatically.",
+  "features.f5t": "Latency & performance",
+  "features.f5d": "Response and tool runtimes as a distribution – outliers visible at a glance.",
+  "features.f6t": "Errors & anomalies",
+  "features.f6d": "Error rates, incidents and automatic anomaly detection.",
+  "features.ctaDemo": "Open the live demo",
+
+  "contact.title": "Contact",
+  "contact.lead": "Want to work together or have a question? I'd love to hear from you.",
+  "contact.emailLabel": "Email",
+  "contact.phoneLabel": "Phone",
+  "contact.locationLabel": "Location",
+  "contact.githubLabel": "GitHub",
+  "contact.statusLabel": "Status",
+  "contact.note": "Usually replies within 24 hours.",
+
+  "legal.title": "Imprint & Privacy",
+  "legal.impressumTitle": "Imprint",
+  "legal.impressumIntro": "Information pursuant to § 5 DDG (German law).",
+  "legal.responsible": "Responsible for content",
+  "legal.contactTitle": "Contact",
+  "legal.privacyTitle": "Privacy",
+  "legal.privacyIntro": "Your privacy matters. This site is intentionally kept minimal.",
+  "legal.privacyClient":
+    "The demo runs entirely in your browser. No personal data is collected, no cookies are set and no tracking is used. All displayed data is synthetic and generated locally.",
+  "legal.privacyHosting":
+    "Hosted via GitHub Pages (GitHub Inc.). On access, the provider may process technically necessary server logs (e.g. IP address) – see GitHub's privacy statement.",
+  "legal.disclaimerTitle": "Disclaimer",
+  "legal.disclaimerBody":
+    "Content has been created with the greatest care. No guarantee is given for accuracy, completeness or timeliness. The operators of external links are solely responsible for their content.",
 
   "landing.badge": "Live demo",
   "landing.tagline": "Live observability for Claude Code",


### PR DESCRIPTION
## Z-Web-1 — Professioneller Footer + eigenständige Seiten

Macht die öffentliche Website (GitHub-Pages-Demo) so professionell wie z. B. Obsidian: vollständige Seiten + ein kompakter, animierter Footer. Alles **statisch exportierbar** (verifiziert mit `MC_DEMO=1`) und voll **i18n** (DE/EN).

### Footer (`SiteFooter`)
- Kompakt, aber technisch/animatorisch hochwertig: animierte Accent-Sheen-Hairline, Hover-Underlines, Marken-Block, Navigationsspalten und eine **Autoren-Karte** (Foto-Avatar, „Offen für Angebote"-Badge mit Live-Dot, E-Mail/Telefon/Ort).
- Ersetzt den alten Mini-Footer im Dashboard und erscheint auf allen Seiten.

### Vier neue Seiten (gemeinsames `PageShell` mit Topbar + Footer)
- **Über mich** (`/about`) — Portfolio-Stil, Skills, Status *arbeitssuchend / offen für Angebote*, Foto-Platzhalter, CTAs.
- **Funktionen** (`/features`) — Feature-Karten + **Screenshot-Galerie-Platzhalter** (werden in Z-Shots automatisch befüllt).
- **Kontakt** (`/contact`) — Kontaktkarten + Status-Badge.
- **Impressum & Datenschutz** (`/legal`) — DE-konform (§ 5 DDG), Datenschutzhinweis: die Demo läuft **rein clientseitig**, keine Datenerhebung/Cookies/Tracking.

### Foto-Platzhalter
- `Avatar` zeigt automatisch `public/profile.jpg`, sobald die Datei existiert — sonst ein gestylter Platzhalter (kein Code-Change nötig). Anleitung in `public/README.md`.

### Kontaktdaten (wie abgestimmt: **ohne Straße**)
Name, Ort (Freiberg am Neckar), Telefon, E-Mail, GitHub — zentral in `src/lib/contact.ts`.

### Roadmap
Neuer Abschnitt **Z-Web** ergänzt; Z-Demo-1…4 als erledigt markiert; **Z-Shots** um GIFs + README-/Funktionen-Galerie erweitert.

### Definition of Done
- [x] Lint ✓
- [x] Unit ✓ (420)
- [x] Build ✓ (Standard **und** statischer Demo-Export `out/` mit basePath `/My_Dash`)
- [x] Neue Routen statisch generiert: `/about`, `/features`, `/contact`, `/legal`
- [x] Golden Rule unangetastet (statische Seiten, keine API-Änderung)

### Folge-Runs
- **Z-Web-2:** echtes Profilfoto.
- **Z-Shots:** echte Screenshots jetzt + CI-Galerie/GIF-Pipeline → README & Funktionen-Seite.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UEgRzpHQh5WY2WKZgcscZA)_