### PR TITLE
Z-Shots: address code-review findings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 /test-results
 /playwright-report
 /.playwright
+/.gallery-video
 
 # mission-control local database
 /data

--- a/next.config.ts
+++ b/next.config.ts
@@ -25,7 +25,7 @@ const nextConfig: NextConfig = isDemo
       assetPrefix: basePath,
       trailingSlash: true,
       images: { unoptimized: true },
-      env: { NEXT_PUBLIC_MC_DEMO: "1" },
+      env: { NEXT_PUBLIC_MC_DEMO: "1", NEXT_PUBLIC_MC_BASE_PATH: basePath ?? "" },
     }
   : {
       // Standalone output bundles a minimal server (.next/standalone/server.js) so the

--- a/scripts/gallery.mjs
+++ b/scripts/gallery.mjs
@@ -42,7 +42,15 @@ function serve() {
     .createServer((req, res) => {
       let url = req.url.split("?")[0];
       if (BASE && url.startsWith(BASE)) url = url.slice(BASE.length);
-      let fp = path.join(ROOT, decodeURIComponent(url));
+      let decoded;
+      try {
+        decoded = decodeURIComponent(url);
+      } catch {
+        res.writeHead(400);
+        res.end("400");
+        return;
+      }
+      let fp = path.join(ROOT, decoded);
       try {
         if (fp.endsWith("/") || fs.statSync(fp).isDirectory()) fp = path.join(fp, "index.html");
       } catch {
@@ -109,23 +117,26 @@ async function captureGif(browser) {
     recordVideo: { dir: tmp, size: { width: 1280, height: 720 } },
   });
   const page = await ctx.newPage();
-  await page.addInitScript(prime("dark"));
-  await gotoDashboard(page);
-  await page.locator("#mc-widget-live-stream").first().scrollIntoViewIfNeeded().catch(() => {});
-  await page.waitForTimeout(8000); // record ~8s of live updates
-  await ctx.close(); // flush the video
-  const webm = fs.readdirSync(tmp).find((f) => f.endsWith(".webm"));
-  if (!webm) return console.log("gif: no video recorded");
-  const out = path.join(SHOTS, "dashboard-live.gif");
-  // Palette filtergraph uses split → must be -filter_complex (not -vf).
-  const fc =
-    "fps=10,scale=860:-1:flags=lanczos,split[s0][s1];[s0]palettegen=max_colors=160[p];[s1][p]paletteuse=dither=bayer:bayer_scale=3";
-  const r = spawnSync(FFMPEG, ["-y", "-i", path.join(tmp, webm), "-filter_complex", fc, "-loop", "0", out], {
-    encoding: "utf8",
-  });
-  if (r.status === 0) console.log(`gif: wrote ${out} (${(fs.statSync(out).size / 1024).toFixed(0)} KB)`);
-  else console.log("gif: ffmpeg failed:\n" + (r.stderr || "").split("\n").slice(-4).join("\n"));
-  fs.rmSync(tmp, { recursive: true, force: true });
+  try {
+    await page.addInitScript(prime("dark"));
+    await gotoDashboard(page);
+    await page.locator("#mc-widget-live-stream").first().scrollIntoViewIfNeeded().catch(() => {});
+    await page.waitForTimeout(8000); // record ~8s of live updates
+    await ctx.close(); // flush the video
+    const webm = fs.readdirSync(tmp).find((f) => f.endsWith(".webm"));
+    if (!webm) return console.log("gif: no video recorded");
+    const out = path.join(SHOTS, "dashboard-live.gif");
+    // Palette filtergraph uses split → must be -filter_complex (not -vf).
+    const fc =
+      "fps=10,scale=860:-1:flags=lanczos,split[s0][s1];[s0]palettegen=max_colors=160[p];[s1][p]paletteuse=dither=bayer:bayer_scale=3";
+    const r = spawnSync(FFMPEG, ["-y", "-i", path.join(tmp, webm), "-filter_complex", fc, "-loop", "0", out], {
+      encoding: "utf8",
+    });
+    if (r.status === 0) console.log(`gif: wrote ${out} (${(fs.statSync(out).size / 1024).toFixed(0)} KB)`);
+    else console.log("gif: ffmpeg failed:\n" + (r.stderr || "").split("\n").slice(-4).join("\n"));
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true }); // always clean up the temp video dir
+  }
 }
 
 (async () => {

--- a/src/components/site-footer.tsx
+++ b/src/components/site-footer.tsx
@@ -126,7 +126,7 @@ export function SiteFooter() {
       <div className="border-t border-panel-border/60">
         <div className="mx-auto flex max-w-[1600px] flex-col items-center justify-between gap-1.5 px-5 py-3 text-center text-[11px] text-muted sm:flex-row sm:px-6 sm:text-left">
           <span>
-            © {year} {CONTACT.name}. {t("footer.rights")}
+            © <span suppressHydrationWarning>{year}</span> {CONTACT.name}. {t("footer.rights")}
           </span>
           <span className="text-muted/80">{t("footer.text")}</span>
         </div>

--- a/src/lib/asset.ts
+++ b/src/lib/asset.ts
@@ -1,7 +1,8 @@
 // Public-asset URL helper. On the static GitHub-Pages demo the app is served
-// under a basePath (/My_Dash), so raw "/foo.png" would 404. Mirror next.config's
-// basePath logic here so <img src> to files in /public resolves in both builds.
-export const ASSET_BASE = process.env.NEXT_PUBLIC_MC_DEMO === "1" ? "/My_Dash" : "";
+// under a basePath (e.g. /My_Dash), so raw "/foo.png" would 404. next.config
+// exposes the active basePath as NEXT_PUBLIC_MC_BASE_PATH; use it so <img src>
+// to files in /public resolves under any basePath (and is "" in the normal build).
+export const ASSET_BASE = process.env.NEXT_PUBLIC_MC_BASE_PATH ?? "";
 
 export function asset(path: string): string {
   return ASSET_BASE + (path.startsWith("/") ? path : "/" + path);


### PR DESCRIPTION
- Footer copyright year: suppressHydrationWarning so the build-time prerender year can't trigger a hydration mismatch at a year boundary.
- asset(): drive ASSET_BASE from NEXT_PUBLIC_MC_BASE_PATH (exposed by next.config) instead of hardcoding /My_Dash, so public assets resolve under any basePath.
- gallery.mjs: always clean up the temp video dir (try/finally) and guard decodeURIComponent against malformed URLs; gitignore .gallery-video.

https://claude.ai/code/session_01UEgRzpHQh5WY2WKZgcscZA