### PR TITLE
Fix two e2e regressions from the Z-Web-1 footer (a11y contrast + language toggle)

### DIFF
--- a/e2e/global.spec.ts
+++ b/e2e/global.spec.ts
@@ -81,13 +81,15 @@ test("language toggle switches the whole UI (de ↔ en)", async ({ page }) => {
   await prime(page, "dark", "de");
   await gotoDashboard(page);
 
+  // Witness the language switch on the footer tagline: it's unique, language-specific
+  // and always rendered (the header subtitle truncates when the bar is crowded).
   const langGroup = page.getByRole("group", { name: "Language" });
   await expect(langGroup.getByRole("button", { name: "de" })).toHaveAttribute("aria-pressed", "true");
-  await expect(page.getByText("Live-Observability für Claude Code")).toBeVisible();
+  await expect(page.getByText("Lokales, read-only Dashboard für Claude Code.")).toBeVisible();
 
   await langGroup.getByRole("button", { name: "en" }).click();
   await expect(langGroup.getByRole("button", { name: "en" })).toHaveAttribute("aria-pressed", "true");
-  await expect(page.getByText("Live observability for Claude Code")).toBeVisible();
+  await expect(page.getByText("Local, read-only dashboard for Claude Code.")).toBeVisible();
 
   expect(errors, `console errors:\n${errors.join("\n")}`).toEqual([]);
 });

--- a/src/components/site-footer.tsx
+++ b/src/components/site-footer.tsx
@@ -128,7 +128,7 @@ export function SiteFooter() {
           <span>
             © <span suppressHydrationWarning>{year}</span> {CONTACT.name}. {t("footer.rights")}
           </span>
-          <span className="text-muted/80">{t("footer.text")}</span>
+          <span className="text-muted">{t("footer.text")}</span>
         </div>
       </div>
     </footer>

--- a/src/lib/i18n.tsx
+++ b/src/lib/i18n.tsx
@@ -46,7 +46,7 @@ const DE: Record<string, string> = {
   "footer.text": "read-only · Daten aus Hooks → SQLite → UI · die KI rendert dieses Dashboard nie",
 
   // ── Website-Chrome: Footer + eigenständige Seiten (Z-Web) ───────────────────
-  "footer.tagline": "Read-only Live-Observability für Claude Code.",
+  "footer.tagline": "Lokales, read-only Dashboard für Claude Code.",
   "footer.product": "Produkt",
   "footer.resources": "Ressourcen",
   "footer.legal": "Rechtliches",
@@ -573,7 +573,7 @@ const EN: Record<string, string> = {
   "footer.text": "read-only · data from hooks → SQLite → UI · the AI never renders this dashboard",
 
   // ── Website chrome: footer + standalone pages (Z-Web) ───────────────────────
-  "footer.tagline": "Read-only live observability for Claude Code.",
+  "footer.tagline": "Local, read-only dashboard for Claude Code.",
   "footer.product": "Product",
   "footer.resources": "Resources",
   "footer.legal": "Legal",


### PR DESCRIPTION
## Fix: zwei E2E-Regressionen aus dem Z-Web-1-Footer

Die volle E2E-Suite (das Gate vor Run 120) lief mit **342 passed / 2 failed** durch. Beide Fehlschläge stammen vom neuen Footer und sind hier behoben:

### 1. a11y (Light) — `color-contrast` (serious)
Der Hinweistext in der Footer-Unterzeile nutzte `text-muted/80`. Die 80 %-Deckkraft senkte die Light-`--muted`-Farbe auf effektiv `#797f90` auf hellem Panel → **3,82:1** (WCAG AA verlangt 4,5:1). Jetzt volles `text-muted` (~6:1).

### 2. global „language toggle" — Strict-Mode-Verletzung
`footer.tagline` enthielt denselben Text wie der Header-Untertitel → `getByText("Live-Observability …")` matchte **2 Knoten**. Der Footer bekommt eigene Copy (DE „Lokales, read-only Dashboard für Claude Code." / EN „Local, read-only dashboard for Claude Code."); der Test prüft den Sprachwechsel jetzt an diesem **eindeutigen, immer gerenderten** String statt am Header-Untertitel (der bei vollem Header trunkiert).

### Verifikation
- `e2e/global.spec.ts` + `e2e/a11y.spec.ts`: **14 passed** (lokal, Chromium).
- Lint ✓, Build ✓.

> Hintergrund: gefunden durch den vollständigen lokalen E2E-Lauf (344 Tests) als Gate-Check. Damit ist die Suite wieder vollständig grün.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UEgRzpHQh5WY2WKZgcscZA)_