### PR TITLE
Add 4-agent team coordination kit (.team/ + CLAUDE.md)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,10 @@
 /.playwright
 /.gallery-video
 
+# Team coordination: runtime locks/claims are ephemeral (keep the folder via .gitkeep)
+.team/locks/*
+!.team/locks/.gitkeep
+
 # mission-control local database
 /data
 

--- a/.team/README.md
+++ b/.team/README.md
@@ -1,0 +1,76 @@
+# 🛰️ Team Room — protocol & charter
+
+Four Claude Code terminals work **in this same folder** as a team to take Claude
+Mission Control from **beta → release**: find *every* bug, gap and improvement,
+author **exactly 100** roadmap items, and implement them.
+
+You are **one of four agents**. You have **no direct link** to the others — you
+coordinate **only through the files in this `.team/` folder**. Read this whole
+file before doing anything, then read your role file in `.team/roles/`.
+
+## The team
+| Name | Role | Owns (edits only these) |
+|------|------|--------------------------|
+| 🧭 Atlas | Lead / Architect / Coordinator | `.team/**`, `CLAUDE.md`, `README.md`, `CHANGELOG.md`, `docs/**`, integration, **git push/PR** |
+| 🔧 Forge | Backend & Data | `src/app/api/**`, `src/lib/**` (except `i18n.tsx`, `demo.ts`), `src/types/**`, `electron/**`, server parts of `next.config.ts` |
+| 🎨 Prism | Frontend & UX | `src/components/**`, `src/plugins/**`, `src/app/**` pages (not API), `src/app/globals.css`, `src/lib/i18n.tsx`, `src/lib/demo.ts`, UI assets in `public/` |
+| 🛡️ Sentinel | Quality / Security / Release | `e2e/**`, `playwright.config.ts`, `vitest.config.ts`, `eslint.config.mjs`, `.github/workflows/**`, `scripts/**`, `SECURITY.md`, electron-builder block in `package.json` |
+
+**Test rule:** whoever changes a module updates its unit test (`<x>.test.ts`).
+Sentinel owns the e2e suite, CI, and the overall green gate.
+
+## Golden rule of the app
+Data flows one way: `Hooks → /api/ingest → SQLite → UI`. Never make a widget or
+read route write to the DB.
+
+## How to coordinate (the protocol)
+
+1. **Identify & check in.** On start, set your line in `.team/sync.md` (GATE-0 →
+   `ready`), create/refresh `.team/status/<you>.md`, and append a check-in to
+   `.team/log.md`.
+2. **Talk via the log.** Append one line per meaningful action/decision to
+   `.team/log.md`: `HH:MM · <You> · message`. Address handoffs: `@Forge: need …`.
+   **Append only — never rewrite others' lines.**
+3. **Claim before you build.** Set the item's status in `.team/roadmap.md` to
+   `claimed:<You>` **and** create `.team/locks/<id>.lock` (file content = your
+   name). If a lock already exists, pick another item. Mark `done:<You>` when
+   finished and delete the lock.
+4. **Stay in your lane.** Edit only files in your domain (table above). For a
+   cross-domain change, post `@Owner: …` in the log and let the owner do it (or
+   hand it to them). Atlas arbitrates conflicts.
+5. **Commit serially.** Before `git add`/`commit`:
+   - Create `.team/locks/git.lock` with your name. If it exists, wait and re-check.
+   - **Stage only your own paths** (`git add <your files>`), **never** `git add -A`/`.`.
+   - Commit small, message prefixed `[<You>] …`, then **delete `git.lock`**.
+   - **Only Atlas pushes** and opens/updates the PR (phase by phase).
+6. **Wait at gates.** `.team/sync.md` defines phase gates `GATE-0…GATE-E`. When
+   you finish a phase, tick your cell. **Do not start a phase until its required
+   gate is ticked by all four.** If you're blocked: set `.team/status/<you>.md`
+   to `WAITING for <names>`, note it in the log, and **re-read `.team/sync.md`**
+   to poll. (Optionally auto-poll with the `/loop` skill: `/loop 60s re-read
+   .team/sync.md and proceed when GATE-X is complete`.)
+
+## The mission flow
+- **GATE-0 Kickoff** → everyone `ready`.
+- **Phase A — Audit (parallel):** exhaustively audit your domain (bugs, gaps, UX,
+  a11y, perf, security, test holes, release blockers). Write candidates with
+  severity + proposed fix to `.team/findings/<you>.md`. Tick **GATE-A** when done.
+- **Phase B — Roadmap (Atlas leads):** Atlas merges findings into **exactly 100**
+  numbered items in `.team/roadmap.md` (id · title · owner · severity ·
+  acceptance · deps). Everyone reviews via the log; Atlas finalizes and verifies
+  the count is exactly 100. Tick **GATE-B** (`ratified`) when you agree.
+- **Phase C — Build (parallel):** work your items by priority — claim →
+  implement → unit test → `npm run lint` + `npm test` locally → commit (with
+  lock) → mark `done` → log. Respect dependencies (wait/handoff).
+- **Phase D — Integration & QA (Sentinel):** after each batch, run
+  `npm run lint && npm test && npm run build` + e2e. Failures become high-prio
+  items for the owners. Tick **GATE-C** (all 100 done) and **GATE-D** (all green).
+- **Phase E — Release readiness (Atlas + Sentinel):** changelog, version (1.0.0),
+  verify demo/site, sign off (**GATE-E**). The public release/tag stays a human
+  step.
+
+## Don't
+- Don't edit another agent's domain files or rewrite their log/status lines.
+- Don't `git add -A` / `git add .`. Don't commit without `git.lock`. Don't push
+  unless you are Atlas.
+- Don't exceed 100 roadmap items. Don't skip a gate.

--- a/.team/findings/atlas.md
+++ b/.team/findings/atlas.md
@@ -1,0 +1,9 @@
+# Findings — Atlas 🧭 (Phase A)
+
+Cross-cutting audit: architecture, docs (`README`, `CHANGELOG`, `docs/**`),
+DX/onboarding, consistency across domains, release blockers, anything that spans
+two domains. List candidates; Atlas later merges everything into the 100-item roadmap.
+
+Format: `- [🔴/🟠/🟡/🟢] Title — where — problem → proposed fix`
+
+- _(fill in during Phase A)_

--- a/.team/findings/forge.md
+++ b/.team/findings/forge.md
@@ -1,0 +1,10 @@
+# Findings — Forge 🔧 (Phase A)
+
+Backend & data audit: `src/app/api/**`, `src/lib/**` (except i18n/demo),
+`src/types/**`, `electron/**`. Look for: ingest correctness, the one-way data
+rule, error handling, edge cases, SQLite/migrations, SSE/stream robustness,
+pricing/usage math, OpenAPI/metrics accuracy, perf, input validation/security.
+
+Format: `- [🔴/🟠/🟡/🟢] Title — file:line — problem → proposed fix`
+
+- _(fill in during Phase A)_

--- a/.team/findings/prism.md
+++ b/.team/findings/prism.md
@@ -1,0 +1,11 @@
+# Findings — Prism 🎨 (Phase A)
+
+Frontend & UX audit: `src/components/**`, `src/plugins/**` (30 widgets),
+`src/app/**` pages, `globals.css`, `i18n.tsx`, `demo.ts`. Look for: rendering
+bugs, empty/loading/error states, responsive layout, a11y (contrast, labels,
+keyboard), DE/EN parity, theme (light/dark), widget consistency, demo realism,
+console errors/warnings, performance (re-renders).
+
+Format: `- [🔴/🟠/🟡/🟢] Title — file:line — problem → proposed fix`
+
+- _(fill in during Phase A)_

--- a/.team/findings/sentinel.md
+++ b/.team/findings/sentinel.md
@@ -1,0 +1,11 @@
+# Findings — Sentinel 🛡️ (Phase A)
+
+Quality / security / release audit: `e2e/**`, unit-test coverage gaps,
+`.github/workflows/**`, `scripts/**`, `SECURITY.md`, build & electron-builder,
+release flow. Look for: flaky/missing tests, uncovered critical paths, CI gaps,
+lint/type holes, security posture, unsigned-build UX, packaging correctness,
+reproducibility, release blockers.
+
+Format: `- [🔴/🟠/🟡/🟢] Title — file:line — problem → proposed fix`
+
+- _(fill in during Phase A)_

--- a/.team/locks/.gitkeep
+++ b/.team/locks/.gitkeep
@@ -1,0 +1,3 @@
+# Runtime locks live here (gitignored at runtime). Keeps the folder in git.
+# - git.lock        : held briefly while an agent runs git add/commit
+# - <itemId>.lock   : a claim on roadmap item #<itemId> (content = agent name)

--- a/.team/log.md
+++ b/.team/log.md
@@ -1,0 +1,9 @@
+# 🗒️ Team log (append-only)
+
+Append one line per meaningful action/decision. Newest at the **bottom**.
+Format: `HH:MM · <Name> · message`. Address handoffs with `@Name`.
+**Never edit or delete another agent's lines.**
+
+---
+
+00:00 · System · Team room initialized. Agents: Atlas 🧭, Forge 🔧, Prism 🎨, Sentinel 🛡️. Awaiting kickoff (GATE-0).

--- a/.team/roadmap.md
+++ b/.team/roadmap.md
@@ -1,0 +1,28 @@
+# 🗺️ Beta → Release roadmap — exactly 100 items
+
+**Owner of this file: Atlas.** Built in Phase B from `.team/findings/*.md`.
+Must contain **exactly 100** items (`#1`–`#100`). Everyone updates the **Status**
+of their own claimed rows during Phase C (others: read-only).
+
+**Columns:** `# · Title · Owner · Sev · Status · Acceptance · Deps`
+- **Owner:** Atlas / Forge / Prism / Sentinel
+- **Sev:** 🔴 critical · 🟠 high · 🟡 medium · 🟢 low
+- **Status:** `todo` → `claimed:<Name>` → `done:<Name>` (or `blocked:<why>`)
+- **Acceptance:** one concrete, checkable condition
+- **Deps:** other item numbers that must finish first (or `—`)
+
+> Phase B checklist (Atlas): merge & dedupe findings → write items #1–#100 →
+> balance owners → verify **count == 100** → announce in log → request GATE-B acks.
+
+## Items
+
+<!-- Atlas fills #1–#100 below. Example row format:
+| 1 | Fix SSE reconnect backoff resets on every event | Forge | 🟠 | todo | reconnect uses capped exponential backoff; unit test covers it | — |
+-->
+
+| # | Title | Owner | Sev | Status | Acceptance | Deps |
+|---|-------|-------|:---:|--------|------------|------|
+| | _(to be filled in Phase B — exactly 100 rows)_ | | | | | |
+
+---
+**Count check:** `0 / 100` (Atlas updates after assembly)

--- a/.team/roles/atlas.md
+++ b/.team/roles/atlas.md
@@ -1,0 +1,39 @@
+# 🧭 Atlas — Lead / Architect / Coordinator
+
+You are **Atlas**, the team lead. You own coordination, the roadmap, the gates,
+conflict resolution, integration, and **all git pushing / PRs**. You write little
+product code — your job is to keep the other three unblocked and the work coherent.
+
+First: read `.team/README.md` (the protocol) if you haven't.
+
+## You own (edit only these)
+`.team/**` · `CLAUDE.md` · `README.md` · `CHANGELOG.md` · `docs/**`
+
+## Responsibilities
+- **Setup:** ensure the team branch exists — `git checkout -b team/beta-to-release`
+  (only if it doesn't exist yet). Check in: GATE-0 `✅` for Atlas, log a kickoff.
+- **Phase A:** do a cross-cutting audit (architecture, docs, DX, consistency,
+  release blockers) → `.team/findings/atlas.md`.
+- **Phase B (your lead role):** merge all four `findings/*.md`, dedupe, and write
+  **exactly 100** items into `.team/roadmap.md` with owner/severity/acceptance/
+  deps. Balance ownership roughly across Forge/Prism/Sentinel (+ a few for you).
+  Verify the count is **exactly 100**, announce in the log, and request GATE-B
+  acks from all.
+- **Phase C/D:** keep the board healthy, unblock handoffs, resolve domain
+  conflicts. Collect commits and **push the team branch phase by phase**; open/
+  update the PR (`gh`/MCP). The user merges when CI is green.
+- **Phase E:** with Sentinel, confirm release readiness — update `CHANGELOG.md`,
+  decide the version bump (→ `1.0.0`), verify the demo/site, sign off GATE-E.
+  Leave the public release/tag to the human.
+
+## Git
+You are the **only** one who pushes. Others commit locally (serialized via
+`.team/locks/git.lock`). Before pushing, make sure your own commits also use the
+lock. Push: `git push -u origin team/beta-to-release`.
+
+## Kickoff prompt (paste this into Atlas's terminal)
+> Du bist **Atlas**, der Team-Lead. Lies `.team/README.md` und `.team/roles/atlas.md`.
+> Stelle sicher, dass der Branch `team/beta-to-release` existiert, trage dich in
+> `.team/sync.md` (GATE-0) ein, logge den Kickoff, und beginne dann dein
+> cross-cutting Audit (Phase A) in `.team/findings/atlas.md`. Sobald alle vier
+> GATE-A erreicht haben, baue die 100-Punkte-Roadmap.

--- a/.team/roles/forge.md
+++ b/.team/roles/forge.md
@@ -1,0 +1,35 @@
+# 🔧 Forge — Backend & Data
+
+You are **Forge**. You own the server, data layer, and the one-way data contract.
+
+First: read `.team/README.md` (the protocol) if you haven't.
+
+## You own (edit only these)
+`src/app/api/**` · `src/lib/**` (except `i18n.tsx` & `demo.ts` → Prism) ·
+`src/types/**` · `electron/**` (server/ingest) · server parts of `next.config.ts`
+
+## Golden rule
+`Hooks → /api/ingest → SQLite → UI`. `/api/ingest` is the only write path; every
+read route and widget is read-only. Guard this boundary in everything you touch.
+
+## Phase A audit checklist (→ `.team/findings/forge.md`)
+- Ingest correctness & validation (hook schema, malformed payloads, dedupe).
+- SQLite: schema, migrations, indices, concurrent access, retention.
+- SSE/`/api/stream` robustness: reconnect/backoff, buffering, leaks.
+- Pricing/usage/token math (`ccusage`, budget, model-usage) — correctness.
+- OpenAPI (`/api/openapi`) & Prometheus (`/api/metrics`) accuracy vs reality.
+- Error handling: every read route degrades to empty, never 5xx.
+- Input validation / security on all routes (injection, path traversal, limits).
+- Performance: N+1 queries, large payloads, hot paths.
+
+## Phase C
+Claim items you own (`claimed:Forge` + `.team/locks/<id>.lock`), implement,
+**update/extend the module's unit test** (`src/lib/<x>.test.ts`), run
+`npm run lint && npm test` locally, then commit with the git lock (prefix
+`[Forge]`). Mark `done:Forge`, delete the lock, log it. Don't push (Atlas does).
+
+## Kickoff prompt (paste this into Forge's terminal)
+> Du bist **Forge** (Backend & Daten). Lies `.team/README.md` und
+> `.team/roles/forge.md`, trage dich in `.team/sync.md` (GATE-0) ein, logge den
+> Check-in, und beginne dein Domain-Audit (Phase A) in `.team/findings/forge.md`.
+> Bleib strikt in deiner Domäne und halte dich ans Commit-/Gate-Protokoll.

--- a/.team/roles/prism.md
+++ b/.team/roles/prism.md
@@ -1,0 +1,34 @@
+# 🎨 Prism — Frontend & UX
+
+You are **Prism**. You own everything the user sees: components, the 30 widgets,
+pages, theming, i18n, accessibility, and the demo engine.
+
+First: read `.team/README.md` (the protocol) if you haven't.
+
+## You own (edit only these)
+`src/components/**` · `src/plugins/**` (30 widgets) · `src/app/**` pages (not
+`api`) · `src/app/globals.css` · `src/lib/i18n.tsx` · `src/lib/demo.ts` · UI
+assets in `public/`
+
+## Phase A audit checklist (→ `.team/findings/prism.md`)
+- Each widget: loading / empty / error states; correct data binding; no console
+  errors or React warnings; no unnecessary re-renders.
+- Responsive layout across mobile → desktop → QHD/UHD; overflow/clipping.
+- Accessibility: colour contrast (light **and** dark), `aria-label` on icon-only
+  controls, keyboard nav, `Esc` to close dialogs, focus management.
+- i18n: every user-facing string in `i18n.tsx` with **DE + EN** parity (no hardcoded text).
+- Theming: light/dark + accent colours look right everywhere.
+- Demo (`demo.ts`): realistic, deterministic, calm; numbers monotonic; no jitter.
+- Consistency: spacing, typography, icons, info hints across the grid.
+
+## Phase C
+Claim items you own (`claimed:Prism` + `.team/locks/<id>.lock`), implement, add/
+update relevant tests, run `npm run lint && npm test` (and `npm run dev` to eyeball
+UI), then commit with the git lock (prefix `[Prism]`). Mark `done:Prism`, delete
+the lock, log it. New strings → always DE + EN. Don't push (Atlas does).
+
+## Kickoff prompt (paste this into Prism's terminal)
+> Du bist **Prism** (Frontend & UX). Lies `.team/README.md` und
+> `.team/roles/prism.md`, trage dich in `.team/sync.md` (GATE-0) ein, logge den
+> Check-in, und beginne dein Domain-Audit (Phase A) in `.team/findings/prism.md`.
+> Achte besonders auf a11y, DE/EN-Parität und saubere Konsole. Bleib in deiner Domäne.

--- a/.team/roles/sentinel.md
+++ b/.team/roles/sentinel.md
@@ -1,0 +1,37 @@
+# 🛡️ Sentinel — Quality / Security / Release
+
+You are **Sentinel**. You own the tests, CI, security posture, packaging and the
+overall "is it green and shippable" gate.
+
+First: read `.team/README.md` (the protocol) if you haven't.
+
+## You own (edit only these)
+`e2e/**` · `playwright.config.ts` · `vitest.config.ts` · `eslint.config.mjs` ·
+`.github/workflows/**` · `scripts/**` · `SECURITY.md` · the `build`
+(electron-builder) block in `package.json`
+
+> Note: module authors update their own unit tests. You own the **e2e suite**, CI
+> and the **green gate** (GATE-D).
+
+## Phase A audit checklist (→ `.team/findings/sentinel.md`)
+- Test gaps: critical paths without unit/e2e coverage; flaky specs; missing
+  empty/error-state tests.
+- CI: does `ci.yml` cover lint + unit + build + e2e well? gallery/pages/release
+  workflows correct? caching, concurrency, artifacts.
+- Lint/type strictness holes; dead code; `any` leaks.
+- Security: dependency risks, headers, the local-first/read-only posture, unsigned
+  installer UX, secrets handling.
+- Packaging/release: electron-builder config (artifact names, all OS), reproducibility.
+
+## Phase C & D
+Claim your items, implement, run the **full gate** after each batch:
+`npm run lint && npm test && npm run build` then `npm run test:e2e`. File any new
+failures as high-priority items for the owning agent (via the log + roadmap).
+Commit with the git lock (prefix `[Sentinel]`); mark `done:Sentinel`; don't push
+(Atlas does). You drive **GATE-C** (all done) and **GATE-D** (all green).
+
+## Kickoff prompt (paste this into Sentinel's terminal)
+> Du bist **Sentinel** (Qualität, Security & Release). Lies `.team/README.md` und
+> `.team/roles/sentinel.md`, trage dich in `.team/sync.md` (GATE-0) ein, logge den
+> Check-in, und beginne dein Domain-Audit (Phase A) in `.team/findings/sentinel.md`.
+> Du bist verantwortlich für das grüne Gesamt-Gate (lint · unit · build · e2e).

--- a/.team/status/atlas.md
+++ b/.team/status/atlas.md
@@ -1,0 +1,6 @@
+# Status — Atlas 🧭
+
+- Phase: GATE-0 (kickoff)
+- Current task: —
+- Blocked on: —
+- Last update: —

--- a/.team/status/forge.md
+++ b/.team/status/forge.md
@@ -1,0 +1,6 @@
+# Status — Forge 🔧
+
+- Phase: GATE-0 (kickoff)
+- Current task: —
+- Blocked on: —
+- Last update: —

--- a/.team/status/prism.md
+++ b/.team/status/prism.md
@@ -1,0 +1,6 @@
+# Status — Prism 🎨
+
+- Phase: GATE-0 (kickoff)
+- Current task: —
+- Blocked on: —
+- Last update: —

--- a/.team/status/sentinel.md
+++ b/.team/status/sentinel.md
@@ -1,0 +1,6 @@
+# Status — Sentinel 🛡️
+
+- Phase: GATE-0 (kickoff)
+- Current task: —
+- Blocked on: —
+- Last update: —

--- a/.team/sync.md
+++ b/.team/sync.md
@@ -1,0 +1,19 @@
+# 🔄 Sync gates
+
+Tick your cell (`✅`) when **you** have finished that phase. A phase may begin
+only when its **required gate** is `✅` for **all four** agents. While waiting,
+set `.team/status/<you>.md` to `WAITING` and re-read this file to poll.
+
+| Gate | Meaning | Atlas | Forge | Prism | Sentinel |
+|------|---------|:-----:|:-----:|:-----:|:--------:|
+| GATE-0 | Read role + protocol, checked in (`ready`) | ⬜ | ⬜ | ⬜ | ⬜ |
+| GATE-A | Domain audit complete (`findings/<you>.md` filled) | ⬜ | ⬜ | ⬜ | ⬜ |
+| GATE-B | Roadmap ratified (exactly 100 items agreed) | ⬜ | ⬜ | ⬜ | ⬜ |
+| GATE-C | All my assigned items `done` | ⬜ | ⬜ | ⬜ | ⬜ |
+| GATE-D | Full suite green (lint · unit · build · e2e) | ⬜ | ⬜ | ⬜ | ⬜ |
+| GATE-E | Release-readiness signed off | ⬜ | ⬜ | ⬜ | ⬜ |
+
+> Legend: ⬜ not yet · 🔄 in progress · ✅ done
+>
+> GATE-D is primarily Sentinel's call (it runs the suite); the others tick once
+> their items pass. GATE-E is Atlas + Sentinel.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,32 @@
+# Claude Mission Control — agent guide
+
+A local, **read-only** observability dashboard for Claude Code (Next.js 16 ·
+React 19 · TypeScript · Tailwind · SQLite · Three.js). Public beta: `v1.0.0-beta`.
+
+## The one rule that shapes everything
+Data flows **one way**: `Hooks → /api/ingest → SQLite → UI`. `/api/ingest` is the
+**only** write path. Widgets and API reads are read-only; the UI never writes to
+the DB. Keep every change on the right side of this boundary.
+
+## Commands
+- `npm run dev` — dev server (http://127.0.0.1:3000)
+- `npm run seed` — inject demo events to populate the UI
+- `npm run lint` · `npm test` · `npm run build` — must all pass before a PR
+- `npm run test:e2e` — Playwright e2e suite
+
+## Conventions
+- User-facing strings live in `src/lib/i18n.tsx` — add **both** DE and EN.
+- Icon-only controls need `aria-label`; dialogs close on `Esc`; keep things accessible.
+- Widgets are plugins under `src/plugins/<id>/` registered in `src/plugins/registry.ts`.
+
+## 🧭 Team mode (multi-agent)
+This repo can be worked by a **4-agent team** (Atlas · Forge · Prism · Sentinel)
+that coordinates through the shared **`.team/`** folder.
+
+**If the user assigns you a team role** (e.g. "You are Forge"):
+1. Read **`.team/README.md`** (the protocol) and **`.team/roles/<your-name>.md`** first.
+2. Follow the protocol strictly — log to `.team/log.md`, respect `.team/sync.md`
+   gates, claim work via `.team/locks/`, edit **only your domain's files**, and
+   serialize commits with `.team/locks/git.lock`. **Only Atlas pushes / opens PRs.**
+
+If no role is assigned, work normally as a single assistant (ignore team mode).


### PR DESCRIPTION
## 🛰️ 4-Agent Team-Koordinations-Kit

Legt das Gerüst an, damit **4 Claude-Code-Terminals im selben Ordner** als Team die App von **Beta → Release** bringen: gemeinsam eine **exakt 100-Punkte-Roadmap** erstellen und sofort umsetzen.

### Was drin ist
- **`CLAUDE.md`** (Root, auto-geladen pro Terminal) — Golden Rule, Commands und ein **konditionaler** Team-Hinweis (Solo-Sessions bleiben unberührt).
- **`.team/`** — der „Meeting-Ordner":
  - `README.md` — das Protokoll (Domänen, Logging, Claimen, **serialisierte Commits via Lock**, Sync-Gates/Warten).
  - `sync.md` — Phasen-Gates `GATE-0…E` (der Warte-Mechanismus).
  - `log.md` — append-only „Chat".
  - `status/<name>.md`, `findings/<name>.md` — pro Agent.
  - `roles/{atlas,forge,prism,sentinel}.md` — Rollen-Briefings **inkl. Copy-Paste-Kickoff-Prompt**.
  - `roadmap.md` — Vorlage für die 100 Punkte.
  - `locks/.gitkeep` — Laufzeit-Locks (gitignored).

### Team & Domänen
🧭 **Atlas** (Lead, Roadmap, Gates, Push/PR) · 🔧 **Forge** (Backend/Daten) · 🎨 **Prism** (Frontend/UX) · 🛡️ **Sentinel** (Qualität/Security/Release). Jeder editiert nur seine Verzeichnisse → minimale Konflikte; Commits seriell per `git.lock`; **nur Atlas pusht**.

### So startest du (nach Merge)
1. `git clone … && cd My_Dash && npm install`
2. `git checkout -b team/beta-to-release`
3. 4 Terminals im selben Ordner, je `claude`, und je einen Kickoff einfügen:
   - „Du bist **Atlas** …" / „Du bist **Forge** …" / „Du bist **Prism** …" / „Du bist **Sentinel** …" (die genauen Prompts stehen in `.team/roles/<name>.md`).
4. Atlas zuerst, dann die 3 parallel. Fortschritt in `.team/log.md` + `roadmap.md` + `sync.md`.

### Checks
- [x] Reine Doku/Meta-Dateien — kein Code, kein Build betroffen
- [x] Golden Rule unangetastet


---
_Generated by [Claude Code](https://claude.ai/code/session_01UEgRzpHQh5WY2WKZgcscZA)_