### PR TITLE
Fix session-timeline time labels overlapping the bars

### DIFF
--- a/src/plugins/session-timeline/widget.tsx
+++ b/src/plugins/session-timeline/widget.tsx
@@ -89,13 +89,15 @@ export function SessionTimeline() {
         <WidgetState icon={GanttChartSquare} title={t("timeline.empty")} />
       ) : (
         <div className="flex h-full flex-col p-3">
-          <div className="flex pb-1 text-[10px] text-muted">
+          <div className="flex pb-2 text-[10px] text-muted">
             <span className="w-24 shrink-0" />
-            <div className="relative flex-1">
+            {/* h-4 gives the absolutely-positioned tick labels their own band so
+                they sit above the bars instead of overlapping the first row. */}
+            <div className="relative h-4 flex-1">
               {ticks.map((label, i) => (
                 <span
                   key={i}
-                  className="absolute -translate-x-1/2 whitespace-nowrap"
+                  className="absolute top-0 -translate-x-1/2 whitespace-nowrap"
                   style={{ left: `${(i / (TICKS - 1)) * 100}%` }}
                 >
                   {label}


### PR DESCRIPTION
## Fix: Zeit-Labels der Session-Timeline überlappen die Balken

Folge-Fix zur Timeline: die Zeit-Beschriftungen (z. B. `19:24 · 01:24 · …`) lagen direkt auf der ersten Balkenzeile.

### Ursache
Der Tick-Container (`relative flex-1`) enthielt **nur absolut positionierte** `<span>`s → er kollabierte auf **Höhe 0**, sodass die Labels über der ersten Session-Zeile rendern.

### Fix (`src/plugins/session-timeline/widget.tsx`)
- Tick-Band bekommt eine feste Höhe `h-4` und die Labels `top-0` → eigene Zeile **über** den Balken.
- Etwas mehr `pb-2` für Luft zwischen Zeiten und erstem Balken.

### Verifikation (Chromium gegen Demo-Build)
- Zeiten sitzen jetzt klar oberhalb; keine Überlappung mit der ersten Balkenzeile. 24h/7T/30T unverändert korrekt (16/26/34 Balken).
- Lint ✓, Demo-Build ✓.

### Checks
- [x] Lint ✓  [x] Build ✓  [x] reine UI-Layout-Änderung, Golden Rule unangetastet


---
_Generated by [Claude Code](https://claude.ai/code/session_01UEgRzpHQh5WY2WKZgcscZA)_