### PR TITLE
Harden team protocol: real-100, provable acceptance, severity + release rule

### DIFF
--- a/.team/README.md
+++ b/.team/README.md
@@ -2,7 +2,9 @@
 
 Four Claude Code terminals work **in this same folder** as a team to take Claude
 Mission Control from **beta → release**: find *every* bug, gap and improvement,
-author **exactly 100** roadmap items, and implement them.
+author **exactly 100 release items** (real, deduplicated problems — never filler),
+and implement them. Extra findings are grouped into an item or moved to the
+**post-release backlog**; nothing real is dropped just to hit the number.
 
 You are **one of four agents**. You have **no direct link** to the others — you
 coordinate **only through the files in this `.team/` folder**. Read this whole
@@ -33,8 +35,11 @@ read route write to the DB.
    **Append only — never rewrite others' lines.**
 3. **Claim before you build.** Set the item's status in `.team/roadmap.md` to
    `claimed:<You>` **and** create `.team/locks/<id>.lock` (file content = your
-   name). If a lock already exists, pick another item. Mark `done:<You>` when
-   finished and delete the lock.
+   name). If a lock already exists, pick another item. Mark `done:<You>` **only
+   once its Acceptance is satisfied and provable** (a test, screenshot, CI run,
+   audit-log line, or Sentinel check), then delete the lock. Owners set their own
+   `done`; **Sentinel validates release risk** at GATE-D before it truly counts as
+   release-ready.
 4. **Stay in your lane.** Edit only files in your domain (table above). For a
    cross-domain change, post `@Owner: …` in the log and let the owner do it (or
    hand it to them). Atlas arbitrates conflicts.
@@ -50,21 +55,39 @@ read route write to the DB.
    to poll. (Optionally auto-poll with the `/loop` skill: `/loop 60s re-read
    .team/sync.md and proceed when GATE-X is complete`.)
 
+## Severity (hard meaning — mark consistently)
+- 🔴 **critical** — blocks the release, or causes data loss / a security hole. The app is unusable or a core path fails. No release with an open 🔴.
+- 🟠 **high** — important bug/feature with **no workaround**; release is possible but risky.
+- 🟡 **medium** — quality / UX / test / docs issue that has a workaround; deferrable to a later release.
+- 🟢 **low** — polish, cleanup, nice-to-have.
+
+## Release rule
+- All 🔴 and 🟠 items must be **done or explicitly waived** (a waiver is a logged reason, owned by Atlas).
+- **No item may be marked `done` without satisfying its Acceptance** — provable via test, screenshot, CI, audit-log, or Sentinel check.
+- **Blocked** items must state a concrete reason **and** the next action.
+- **Ownership of truth:** Atlas owns structure + the exact 100-count; row owners own implementation status; **Sentinel validates release risk**.
+- The number is fixed at **100 *release* items** — group related findings into one item, or push extras to the **post-release backlog** (bottom of `roadmap.md`). Never invent filler; never silently drop a real problem.
+
 ## The mission flow
 - **GATE-0 Kickoff** → everyone `ready`.
 - **Phase A — Audit (parallel):** exhaustively audit your domain (bugs, gaps, UX,
   a11y, perf, security, test holes, release blockers). Write candidates with
   severity + proposed fix to `.team/findings/<you>.md`. Tick **GATE-A** when done.
-- **Phase B — Roadmap (Atlas leads):** Atlas merges findings into **exactly 100**
-  numbered items in `.team/roadmap.md` (id · title · owner · severity ·
-  acceptance · deps). Everyone reviews via the log; Atlas finalizes and verifies
+- **Phase B — Roadmap (Atlas leads):** Atlas merges + **deduplicates** findings
+  into **exactly 100 release items** in `.team/roadmap.md` (id · title · owner ·
+  severity · acceptance · deps), sorted **release-critical first**. Related
+  findings are grouped into one item; extras go to the **post-release backlog** —
+  no filler, nothing real dropped. Everyone reviews via the log; Atlas verifies
   the count is exactly 100. Tick **GATE-B** (`ratified`) when you agree.
 - **Phase C — Build (parallel):** work your items by priority — claim →
   implement → unit test → `npm run lint` + `npm test` locally → commit (with
-  lock) → mark `done` → log. Respect dependencies (wait/handoff).
+  lock) → mark `done` **once Acceptance is proven** → log. Respect dependencies
+  (wait/handoff).
 - **Phase D — Integration & QA (Sentinel):** after each batch, run
-  `npm run lint && npm test && npm run build` + e2e. Failures become high-prio
-  items for the owners. Tick **GATE-C** (all 100 done) and **GATE-D** (all green).
+  `npm run lint && npm test && npm run build` + e2e, **and validate each item's
+  Acceptance** (is the proof there?). Items without proof bounce back to their
+  owner; failures become high-prio items. Tick **GATE-C** (all 100 done **and
+  verified**) and **GATE-D** (all green; every 🔴/🟠 done or waived).
 - **Phase E — Release readiness (Atlas + Sentinel):** changelog, version (1.0.0),
   verify demo/site, sign off (**GATE-E**). The public release/tag stays a human
   step.
@@ -73,4 +96,5 @@ read route write to the DB.
 - Don't edit another agent's domain files or rewrite their log/status lines.
 - Don't `git add -A` / `git add .`. Don't commit without `git.lock`. Don't push
   unless you are Atlas.
-- Don't exceed 100 roadmap items. Don't skip a gate.
+- Don't pad to 100 with filler or drop real problems — group them or defer to the backlog.
+- Don't mark an item `done` without satisfying its Acceptance. Don't skip a gate.

--- a/.team/roadmap.md
+++ b/.team/roadmap.md
@@ -1,18 +1,32 @@
-# 🗺️ Beta → Release roadmap — exactly 100 items
+# 🗺️ Beta → Release roadmap — exactly 100 release items
 
-**Owner of this file: Atlas.** Built in Phase B from `.team/findings/*.md`.
-Must contain **exactly 100** items (`#1`–`#100`). Everyone updates the **Status**
-of their own claimed rows during Phase C (others: read-only).
+**Owner of this file: Atlas.** Built in Phase B from `.team/findings/*.md` —
+**deduplicated, release-critical-first**. Must contain **exactly 100** items
+(`#1`–`#100`) that are *real* problems: group related findings into one item and
+push extras to the **Post-release backlog** below — never pad with filler, never
+drop a real problem. Everyone updates the **Status** of their own claimed rows
+during Phase C (others: read-only).
 
 **Columns:** `# · Title · Owner · Sev · Status · Acceptance · Deps`
 - **Owner:** Atlas / Forge / Prism / Sentinel
-- **Sev:** 🔴 critical · 🟠 high · 🟡 medium · 🟢 low
-- **Status:** `todo` → `claimed:<Name>` → `done:<Name>` (or `blocked:<why>`)
-- **Acceptance:** one concrete, checkable condition
+- **Sev (hard meaning):**
+  - 🔴 **critical** — blocks release / data loss / security hole (no release with open 🔴)
+  - 🟠 **high** — important, **no workaround**; release possible but risky
+  - 🟡 **medium** — quality/UX/test/docs with a workaround; deferrable
+  - 🟢 **low** — polish / cleanup / nice-to-have
+- **Status:** `todo` → `claimed:<Name>` → `done:<Name>` (or `blocked:<why> · next:<action>`)
+- **Acceptance:** one concrete condition **provable by test / screenshot / CI / audit-log / Sentinel check**. An item is not `done` until its Acceptance is met.
 - **Deps:** other item numbers that must finish first (or `—`)
 
-> Phase B checklist (Atlas): merge & dedupe findings → write items #1–#100 →
-> balance owners → verify **count == 100** → announce in log → request GATE-B acks.
+### Release rule
+- All 🔴 and 🟠 must be **done or explicitly waived** (waiver = logged reason, owned by Atlas).
+- No row is `done` without its Acceptance satisfied; **Sentinel validates** release risk at GATE-D.
+- `blocked` rows need a concrete reason **and** a next action.
+- Atlas owns structure + the 100-count · row owners own status · Sentinel owns release-risk validation.
+
+> Phase B checklist (Atlas): merge & **dedupe** findings → write items #1–#100,
+> release-critical first → balance owners → verify **count == 100** → park extras
+> in the backlog → announce in log → request GATE-B acks.
 
 ## Items
 
@@ -25,4 +39,13 @@ of their own claimed rows during Phase C (others: read-only).
 | | _(to be filled in Phase B — exactly 100 rows)_ | | | | | |
 
 ---
-**Count check:** `0 / 100` (Atlas updates after assembly)
+**Count check:** `0 / 100` (Atlas updates after assembly) ·
+**Release-blockers (🔴/🟠) done:** `0 / 0`
+
+## Post-release backlog (not counted in the 100)
+Real findings that are valid but **not release-critical** land here instead of
+being forced into the 100 or dropped. Same columns; revisit after release.
+
+| Title | Owner | Sev | Acceptance | Notes |
+|-------|-------|:---:|------------|-------|
+| _(deferred findings go here)_ | | | | |

--- a/.team/roles/atlas.md
+++ b/.team/roles/atlas.md
@@ -14,11 +14,14 @@ First: read `.team/README.md` (the protocol) if you haven't.
   (only if it doesn't exist yet). Check in: GATE-0 `✅` for Atlas, log a kickoff.
 - **Phase A:** do a cross-cutting audit (architecture, docs, DX, consistency,
   release blockers) → `.team/findings/atlas.md`.
-- **Phase B (your lead role):** merge all four `findings/*.md`, dedupe, and write
-  **exactly 100** items into `.team/roadmap.md` with owner/severity/acceptance/
-  deps. Balance ownership roughly across Forge/Prism/Sentinel (+ a few for you).
-  Verify the count is **exactly 100**, announce in the log, and request GATE-B
-  acks from all.
+- **Phase B (your lead role):** merge all four `findings/*.md`, **deduplicate**,
+  and write **exactly 100 release items** into `.team/roadmap.md` (owner / severity
+  / **provable acceptance** / deps), sorted **release-critical first**. Group
+  related findings into one item; park non-release-critical extras in the
+  **Post-release backlog** — never pad with filler, never drop a real problem.
+  Balance ownership across Forge/Prism/Sentinel (+ a few for you). Verify the count
+  is **exactly 100**, announce in the log, and request GATE-B acks. You own a
+  **waiver** decision when a 🔴/🟠 is deferred (log the reason).
 - **Phase C/D:** keep the board healthy, unblock handoffs, resolve domain
   conflicts. Collect commits and **push the team branch phase by phase**; open/
   update the PR (`gh`/MCP). The user merges when CI is green.

--- a/.team/roles/sentinel.md
+++ b/.team/roles/sentinel.md
@@ -23,12 +23,20 @@ First: read `.team/README.md` (the protocol) if you haven't.
   installer UX, secrets handling.
 - Packaging/release: electron-builder config (artifact names, all OS), reproducibility.
 
-## Phase C & D
+## Phase C & D — you are the release-risk validator
 Claim your items, implement, run the **full gate** after each batch:
 `npm run lint && npm test && npm run build` then `npm run test:e2e`. File any new
 failures as high-priority items for the owning agent (via the log + roadmap).
+
+**Validate acceptance, not just green:** for every row marked `done`, confirm its
+**Acceptance** is actually proven (a test, screenshot, CI run, audit-log line, or
+your own check). If the proof is missing, bounce it back — set the row to
+`blocked:no proof · next:<owner> add evidence` and ping the owner in the log.
+
+Enforce the **Release rule**: no GATE-D while any 🔴/🟠 is open and unwaived.
 Commit with the git lock (prefix `[Sentinel]`); mark `done:Sentinel`; don't push
-(Atlas does). You drive **GATE-C** (all done) and **GATE-D** (all green).
+(Atlas does). You drive **GATE-C** (all done **and verified**) and **GATE-D**
+(all green; every 🔴/🟠 done or waived).
 
 ## Kickoff prompt (paste this into Sentinel's terminal)
 > Du bist **Sentinel** (Qualität, Security & Release). Lies `.team/README.md` und

--- a/.team/sync.md
+++ b/.team/sync.md
@@ -9,8 +9,8 @@ set `.team/status/<you>.md` to `WAITING` and re-read this file to poll.
 | GATE-0 | Read role + protocol, checked in (`ready`) | ⬜ | ⬜ | ⬜ | ⬜ |
 | GATE-A | Domain audit complete (`findings/<you>.md` filled) | ⬜ | ⬜ | ⬜ | ⬜ |
 | GATE-B | Roadmap ratified (exactly 100 items agreed) | ⬜ | ⬜ | ⬜ | ⬜ |
-| GATE-C | All my assigned items `done` | ⬜ | ⬜ | ⬜ | ⬜ |
-| GATE-D | Full suite green (lint · unit · build · e2e) | ⬜ | ⬜ | ⬜ | ⬜ |
+| GATE-C | All my items `done` **with Acceptance proven** | ⬜ | ⬜ | ⬜ | ⬜ |
+| GATE-D | Suite green + every 🔴/🟠 done-or-waived (Sentinel-validated) | ⬜ | ⬜ | ⬜ | ⬜ |
 | GATE-E | Release-readiness signed off | ⬜ | ⬜ | ⬜ | ⬜ |
 
 > Legend: ⬜ not yet · 🔄 in progress · ✅ done


### PR DESCRIPTION
## Team-Protokoll härten (nur `.team/`)

Setzt dein Review-Feedback (8/10 → schärfer) um. **Nur `.team/`** geändert, kein Produktcode. Online-Recherche bestätigte die Severity-Definitionen (Industriestandard: critical = Datenverlust/Crash/unbenutzbar, high = ohne Workaround, medium = mit Workaround/deferrable, low = Polish).

### Übernommene Punkte
1. **„exactly 100" entschärft** → *100 Release-Items*. Verwandte Findings werden **gruppiert**, nicht-release-kritische in einen neuen **Post-Release-Backlog** (unten in `roadmap.md`) verschoben — kein Füllmaterial, kein stilles Verlieren echter Probleme.
2. **Acceptance muss belegbar sein** (Test / Screenshot / CI / Audit-Log / Sentinel-Check). Ein Item ist erst `done`, wenn die Acceptance erfüllt ist. Owner setzt `done`, **Sentinel validiert** das Release-Risiko (GATE-D).
3. **Harte Severity-Bedeutung** (🔴/🟠/🟡/🟢) in `README.md` + `roadmap.md`.
4. **Release rule** ergänzt:
   - Alle 🔴/🟠 müssen `done` oder **explizit gewaived** sein (Waiver = geloggter Grund, Atlas).
   - Kein `done` ohne erfüllte Acceptance.
   - `blocked` braucht Grund **und** nächste Aktion.
   - Ownership of truth: Atlas = Struktur/Count · Row-Owner = Status · Sentinel = Release-Risiko.

### Geänderte Dateien
`.team/README.md`, `.team/roadmap.md` (+ Backlog-Sektion & Count-/Blocker-Check), `.team/roles/atlas.md`, `.team/roles/sentinel.md`, `.team/sync.md` (GATE-C „verified", GATE-D „🔴/🟠 cleared").

### Checks
- [x] Nur `.team/` berührt (verifiziert) · reine Governance-Doku
- [x] Kein Produktcode, Golden Rule unangetastet


---
_Generated by [Claude Code](https://claude.ai/code/session_01UEgRzpHQh5WY2WKZgcscZA)_