### PR TITLE
security: override postcss to clear the last Dependabot alert

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6925,6 +6925,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -8875,34 +8876,6 @@
         "sass": {
           "optional": true
         }
-      }
-    },
-    "node_modules/next/node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/ngraph.events": {

--- a/package.json
+++ b/package.json
@@ -73,6 +73,9 @@
     "typescript": "^5",
     "vitest": "^3.2.4"
   },
+  "overrides": {
+    "postcss": "^8.5.15"
+  },
   "build": {
     "appId": "com.belkisaslani.claude-mission-control",
     "productName": "Claude Mission Control",


### PR DESCRIPTION
## Security: letzte Dependabot-Schwachstelle beheben (PostCSS XSS)

Dependabot-PR **#175** ist bereits in `main` und hat **electron → 39.8.5** (minimale sichere Version), **electron-builder → 26.8.1** und **@electron/rebuild → 4.0.4** gebumpt — damit waren die **electron-** und **node-tar**-Advisories erledigt.

Übrig blieb nur noch **PostCSS XSS** (moderate), weil Next.js eine verwundbare postcss-Version bündelt.

### Änderung (minimal, auf aktuellem `main` rebased)
- `overrides: { "postcss": "^8.5.15" }` — erzwingt die gepatchte postcss-Version.
- Bewusst **kein** `npm audit fix --force` (hätte Next.js auf 9.3.3 herabgestuft) und **kein** electron-42-Sprung (mains 39.8.5 reicht und ist weniger riskant).

### Ergebnis
- `npm audit` → **0 vulnerabilities**.
- Lint ✓ · Unit-Tests ✓ · Standard-Build ✓ · Demo-Build ✓.

> @coderabbitai full review
