### PR TITLE
Release prep: v1.0.0-beta.2 (beta — no public release yet)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,12 @@
 All notable changes to Claude Mission Control are documented here. This project
 adheres to [Semantic Versioning](https://semver.org/).
 
-## [1.0.0] — Unreleased
+## [1.0.0-beta.2] — 2026-05-25
 
-> 🚧 **In progress (beta → release).** Roll-up of the 100-item release-hardening
-> roadmap (`.team/roadmap.md`); finalised at release sign-off (GATE-E). Sections
-> are filled in as items land.
+> **Still a beta.** Roll-up of the 100-item beta→release hardening roadmap
+> (`.team/roadmap.md`), validated by a full green gate (lint · 528 unit · build ·
+> 348 e2e · 0 vulns). The `1.0.0` release stays deferred — more testing and UI/UX
+> passes first.
 
 ### Fixed
 - Enforced the one-way data contract — read routes no longer write to the DB

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-mission-control",
-  "version": "1.0.0-beta",
+  "version": "1.0.0-beta.2",
   "private": true,
   "description": "A local, read-only observability dashboard for Claude Code — live event stream, session kanban, token/cost charts and a 3D tool-call graph.",
   "license": "PolyForm-Noncommercial-1.0.0",


### PR DESCRIPTION
## Release prep — `1.0.0-beta.2` (stays beta)

Bumps the version after the 100-item beta→release hardening (PR #177) and finalizes the CHANGELOG entry.

**Deliberately still a beta — no public `1.0.0` release/tag yet.** More testing + UI/UX passes come first.

- `package.json`: `1.0.0-beta` → `1.0.0-beta.2`
- `CHANGELOG.md`: `[1.0.0-beta.2]` entry (full green gate: lint · 528 unit · build · 348 e2e · 0 vulns; 100/100 roadmap items, 0 open 🔴/🟠)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
