### PR TITLE
Phase F (FC): project-leaderboard — table↔bars view

### DIFF
--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -66,7 +66,7 @@ export const plugin: Widget = {
 | Tokens & Kosten | `token-chart` | 3/6 | standard | yes | Daily token usage and cost from ccusage. Toggle on the right between tokens (input/output/cache) and cost in € (converted from USD via EUR_PER_USD). |
 | Budget | `budget-gauge` | 2/6 | standard | — | Today's & this month's spend against your budget (USD), with a projection. |
 | Modelle | `model-donut` | 3/6 | standard | yes | Share per model of tokens or cost. |
-| Projekt-Rangliste | `project-leaderboard` | 3/6 | standard | — | Projects by cost, sessions, tools and tokens. Click a column to sort. |
+| Projekt-Rangliste | `project-leaderboard` | 3/6 | standard | yes | Projects by cost, sessions, tools and tokens. Click a column to sort. |
 | Token-Verbrauch je Tool | `token-burn` | 3/6 | standard | — | Where most tokens burn — estimated from tool I/O size (chars ÷ 4). |
 
 ### Activity

--- a/src/plugins/project-leaderboard/widget.tsx
+++ b/src/plugins/project-leaderboard/widget.tsx
@@ -6,6 +6,8 @@ import { Panel } from "@/components/panel";
 import { WidgetState } from "@/components/widget-state";
 import { usePluginQuery } from "@/components/plugin-data";
 import { viewState } from "@/components/widget-view";
+import { useView, ViewSwitch } from "@/components/view-variant";
+import type { ViewOption } from "@/plugins/registry";
 import { useT } from "@/lib/i18n";
 import { formatCompact, formatMoney } from "@/lib/format";
 import type { ProjectUsage } from "@/lib/projects";
@@ -21,9 +23,18 @@ const COLUMNS: { key: SortKey; label: string }[] = [
 
 const MEDAL = ["🥇", "🥈", "🥉"];
 
+// Phase F (F5): table (default, today's look) ↔ bars (ranked by the chosen metric).
+const WIDGET_ID = "project-leaderboard";
+const VIEW_VALUES = ["table", "bars"] as const;
+export const PROJECT_LEADERBOARD_VIEWS: ViewOption[] = [
+  { value: "table", label: "view.table" },
+  { value: "bars", label: "view.bars" },
+];
+
 export function ProjectLeaderboard() {
   const { t } = useT();
   const [sort, setSort] = useState<SortKey>("costUsd");
+  const view = useView(WIDGET_ID, VIEW_VALUES, "table");
   const q = usePluginQuery<{ projects: ProjectUsage[] }>("/api/usage/projects");
 
   const sorted = [...(q.data?.projects ?? [])].sort((a, b) => b[sort] - a[sort]);
@@ -37,13 +48,38 @@ export function ProjectLeaderboard() {
         : String(p[key]);
 
   return (
-    <Panel title={t("leaderboard.title")} icon={<Trophy className="h-4 w-4 text-accent" />} info={t("leaderboard.info")}>
+    <Panel
+      title={t("leaderboard.title")}
+      icon={<Trophy className="h-4 w-4 text-accent" />}
+      info={t("leaderboard.info")}
+      right={
+        <div className="flex items-center gap-1.5">
+          {view === "bars" && (
+            <div className="flex rounded-md border border-panel-border text-xs">
+              {COLUMNS.map((c) => (
+                <button
+                  key={c.key}
+                  onClick={() => setSort(c.key)}
+                  aria-pressed={sort === c.key}
+                  className={`px-2 py-1 ${sort === c.key ? "bg-accent/20 text-accent" : "text-muted hover:text-foreground"}`}
+                >
+                  {t(c.label)}
+                </button>
+              ))}
+            </div>
+          )}
+          <ViewSwitch widgetId={WIDGET_ID} options={PROJECT_LEADERBOARD_VIEWS} value={view} t={t} />
+        </div>
+      }
+    >
       {vs === "error" ? (
         <WidgetState icon={Trophy} title={t("common.loadError")} onRetry={q.refetch} retryLabel={t("common.retry")} />
       ) : vs === "loading" ? (
         <WidgetState icon={Trophy} title={t("common.loading")} loading />
       ) : vs === "empty" ? (
         <WidgetState icon={Trophy} title={t("leaderboard.empty")} />
+      ) : view === "bars" ? (
+        <LeaderboardBars sorted={sorted} sort={sort} cell={cell} />
       ) : (
         <div className="h-full overflow-auto">
           <table className="w-full text-xs">
@@ -90,5 +126,36 @@ export function ProjectLeaderboard() {
         </div>
       )}
     </Panel>
+  );
+}
+
+// Bars view: projects ranked by the selected metric as horizontal bars.
+function LeaderboardBars({
+  sorted,
+  sort,
+  cell,
+}: {
+  sorted: ProjectUsage[];
+  sort: SortKey;
+  cell: (p: ProjectUsage, key: SortKey) => string;
+}) {
+  const max = Math.max(1, ...sorted.map((p) => p[sort]));
+  return (
+    <ul tabIndex={0} className="flex h-full flex-col gap-2 overflow-auto p-4 outline-none">
+      {sorted.map((p, i) => (
+        <li key={p.project}>
+          <div className="mb-1 flex items-center justify-between gap-2 text-xs">
+            <span className="flex min-w-0 items-center gap-1.5">
+              <span className="w-5 shrink-0 text-center tabular-nums text-muted">{MEDAL[i] ?? i + 1}</span>
+              <span className="truncate text-foreground" title={p.project}>{p.project}</span>
+            </span>
+            <span className="shrink-0 tabular-nums text-muted">{cell(p, sort)}</span>
+          </div>
+          <div className="h-2 w-full overflow-hidden rounded-full bg-background/70">
+            <div className="h-full rounded-full bg-accent" style={{ width: `${Math.max(2, (p[sort] / max) * 100)}%` }} />
+          </div>
+        </li>
+      ))}
+    </ul>
   );
 }

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -45,7 +45,7 @@ import { Latency } from "./latency/widget";
 import { ErrorRate } from "./error-rate/widget";
 import { ModelDonut, MODEL_DONUT_VIEWS } from "./model-donut/widget";
 import { SankeyFlow } from "./sankey-flow/widget";
-import { ProjectLeaderboard } from "./project-leaderboard/widget";
+import { ProjectLeaderboard, PROJECT_LEADERBOARD_VIEWS } from "./project-leaderboard/widget";
 import { LiveNow } from "./live-now/widget";
 import { PromptHistory } from "./prompt-history/widget";
 import { Streak } from "./streak/widget";
@@ -127,7 +127,7 @@ export const widgets: Widget[] = [
   { id: "error-rate", title: "Fehlerrate", titleKey: "errors.title", span: "lg:col-span-3", height: H, icon: ShieldAlert, category: "quality", description: "errors.info", component: ErrorRate },
   { id: "model-donut", title: "Modelle", titleKey: "donut.title", span: "lg:col-span-3", height: H, icon: PieChart, category: "economy", description: "donut.info", settings: [viewSetting(MODEL_DONUT_VIEWS)], component: ModelDonut },
   { id: "sankey-flow", title: "Fluss", titleKey: "sankey.title", span: "lg:col-span-3", height: H, icon: Waypoints, category: "tools", description: "sankey.info", component: SankeyFlow },
-  { id: "project-leaderboard", title: "Projekt-Rangliste", titleKey: "leaderboard.title", span: "lg:col-span-3", height: H, icon: Trophy, category: "economy", description: "leaderboard.info", component: ProjectLeaderboard },
+  { id: "project-leaderboard", title: "Projekt-Rangliste", titleKey: "leaderboard.title", span: "lg:col-span-3", height: H, icon: Trophy, category: "economy", description: "leaderboard.info", settings: [viewSetting(PROJECT_LEADERBOARD_VIEWS)], component: ProjectLeaderboard },
   { id: "live-now", title: "Jetzt live", titleKey: "now.title", span: "lg:col-span-3", height: H, icon: Radio, category: "sessions", description: "now.info", component: LiveNow },
   { id: "prompt-history", title: "Prompt-Verlauf", titleKey: "prompts.title", span: "lg:col-span-3", height: H, icon: MessageSquare, category: "sessions", description: "prompts.info", component: PromptHistory },
   { id: "streak", title: "Streak & Produktivität", titleKey: "streak.title", span: "lg:col-span-3", height: H, icon: Flame, category: "activity", description: "streak.info", component: Streak },


### PR DESCRIPTION
FC per-widget view variant: **project-leaderboard** (table↔bars). Default===today's look; light+dark; DE+EN labels; docs/PLUGINS.md regenerated. Still beta. 🤖 [Claude Code](https://claude.com/claude-code)