### PR TITLE
fix(panel): wrap header controls — fixes tool-frequency e2e (main red)

### DIFF
--- a/src/components/panel.tsx
+++ b/src/components/panel.tsx
@@ -24,7 +24,7 @@ export function Panel({
         className,
       )}
     >
-      <header className="flex items-center justify-between border-b border-panel-border px-4 py-2.5">
+      <header className="flex flex-wrap items-center justify-between gap-x-3 gap-y-1.5 border-b border-panel-border px-4 py-2.5">
         <div className="flex items-center gap-2 text-sm font-semibold tracking-wide text-foreground">
           {icon}
           <span>{title}</span>


### PR DESCRIPTION
**Fixes main RED.** The FA `<ViewSwitch>` added to widget headers overflowed the Panel's single-row `flex justify-between` header on narrow widgets (e.g. tool-frequency `col-span-2`), clipping the `30T/7T/Alle` range toggle → e2e `tool-frequency.spec.ts` couldn't click `7T` (not visible/stable). Pattern-level fix: header now `flex-wrap` with gaps, so ViewSwitch + existing controls wrap cleanly instead of clipping — generalises to every FC widget. No logic change. Still beta. 🤖 [Claude Code](https://claude.com/claude-code)