### PR TITLE
fix: WidgetToolbar pointer-events so it doesn't block widget header controls (main-red)

### DIFF
--- a/src/components/dashboard.tsx
+++ b/src/components/dashboard.tsx
@@ -352,10 +352,13 @@ function WidgetToolbar({
   onHeight: () => void;
   onSettings: () => void;
 }) {
+  // The pill floats over the top-center of the widget (incl. the panel header). Make
+  // the container pass clicks through (pointer-events-none) and re-enable only the
+  // actual icon buttons, so it never blocks a widget's own header controls beneath it.
   const btn =
-    "rounded p-0.5 text-muted transition-colors hover:text-foreground focus-visible:text-foreground";
+    "pointer-events-auto rounded p-0.5 text-muted transition-colors hover:text-foreground focus-visible:text-foreground";
   return (
-    <div className="absolute left-1/2 top-1 z-20 flex -translate-x-1/2 items-center gap-0.5 rounded-md border border-panel-border bg-panel/90 px-1 py-0.5 opacity-0 shadow-md shadow-black/30 backdrop-blur transition-opacity duration-150 focus-within:opacity-100 group-hover:opacity-100">
+    <div className="pointer-events-none absolute left-1/2 top-1 z-20 flex -translate-x-1/2 items-center gap-0.5 rounded-md border border-panel-border bg-panel/90 px-1 py-0.5 opacity-0 shadow-md shadow-black/30 backdrop-blur transition-opacity duration-150 focus-within:opacity-100 group-hover:opacity-100">
       <button
         type="button"
         draggable

--- a/src/plugins/tool-frequency/widget.tsx
+++ b/src/plugins/tool-frequency/widget.tsx
@@ -73,6 +73,7 @@ export function ToolFrequency() {
       info={t("tools.info")}
       right={
         <div className="flex items-center gap-1.5">
+          <ViewSwitch widgetId={WIDGET_ID} options={TOOL_FREQ_VIEWS} value={view} t={t} />
           <div className="flex rounded-md border border-panel-border text-xs">
             {RANGES.map((r) => (
               <button
@@ -85,7 +86,6 @@ export function ToolFrequency() {
               </button>
             ))}
           </div>
-          <ViewSwitch widgetId={WIDGET_ID} options={TOOL_FREQ_VIEWS} value={view} t={t} />
         </div>
       }
     >


### PR DESCRIPTION
Real root-cause fix for the tool-frequency e2e (main red): the hover WidgetToolbar pill (absolute, z-20, top-center) intercepted clicks on widgets' own header controls (e.g. tool-frequency '7T' → aria-pressed never updated). Fix (Prism, 1e667e7): toolbar pill `pointer-events-none`, icon buttons `pointer-events-auto`; tool-frequency header reordered. General fix for any widget with header controls. Complements panel flex-wrap #195. Beta. 🤖 [Claude Code](https://claude.com/claude-code)