### PR TITLE
[Prism] Fix main-red: tool-frequency header controls vs widget toolbar

### DIFF
--- a/src/components/dashboard.tsx
+++ b/src/components/dashboard.tsx
@@ -352,10 +352,13 @@ function WidgetToolbar({
   onHeight: () => void;
   onSettings: () => void;
 }) {
+  // The pill floats over the top-center of the widget (incl. the panel header). Make
+  // the container pass clicks through (pointer-events-none) and re-enable only the
+  // actual icon buttons, so it never blocks a widget's own header controls beneath it.
   const btn =
-    "rounded p-0.5 text-muted transition-colors hover:text-foreground focus-visible:text-foreground";
+    "pointer-events-auto rounded p-0.5 text-muted transition-colors hover:text-foreground focus-visible:text-foreground";
   return (
-    <div className="absolute left-1/2 top-1 z-20 flex -translate-x-1/2 items-center gap-0.5 rounded-md border border-panel-border bg-panel/90 px-1 py-0.5 opacity-0 shadow-md shadow-black/30 backdrop-blur transition-opacity duration-150 focus-within:opacity-100 group-hover:opacity-100">
+    <div className="pointer-events-none absolute left-1/2 top-1 z-20 flex -translate-x-1/2 items-center gap-0.5 rounded-md border border-panel-border bg-panel/90 px-1 py-0.5 opacity-0 shadow-md shadow-black/30 backdrop-blur transition-opacity duration-150 focus-within:opacity-100 group-hover:opacity-100">
       <button
         type="button"
         draggable

--- a/src/plugins/tool-frequency/widget.tsx
+++ b/src/plugins/tool-frequency/widget.tsx
@@ -73,6 +73,7 @@ export function ToolFrequency() {
       info={t("tools.info")}
       right={
         <div className="flex items-center gap-1.5">
+          <ViewSwitch widgetId={WIDGET_ID} options={TOOL_FREQ_VIEWS} value={view} t={t} />
           <div className="flex rounded-md border border-panel-border text-xs">
             {RANGES.map((r) => (
               <button
@@ -85,7 +86,6 @@ export function ToolFrequency() {
               </button>
             ))}
           </div>
-          <ViewSwitch widgetId={WIDGET_ID} options={TOOL_FREQ_VIEWS} value={view} t={t} />
         </div>
       }
     >


### PR DESCRIPTION
The FA ViewSwitch widened tool-frequency's (col-span-2) header so the range group's leftmost '7T' button landed under the hover WidgetToolbar's drag handle (absolute, top-center, z-20) → e2e tool-frequency.spec '7T' click intercepted. Two-part fix:
- WidgetToolbar: the floating pill is now pointer-events-none with pointer-events-auto only on its icon buttons, so it no longer blocks a widget's own header controls beneath it (latent bug for any widget with header controls).
- tool-frequency: order header as [ViewSwitch, range] so the range group is right-most and 7T clears the toolbar. Both specs green (tool-frequency 9/9 + view-variants 48 = 57 e2e), lint + unit green.

<!-- Thanks for contributing to Claude Mission Control! -->

## Summary

<!-- What does this PR do, and why? -->

## Type of change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature / widget
- [ ] ♻️ Refactor
- [ ] 📝 Docs
- [ ] 🧪 Tests / CI

## Checklist

- [ ] `npm run lint` passes
- [ ] `npm test` passes
- [ ] `npm run build` passes
- [ ] New user-facing strings added to **both** DE and EN in `src/lib/i18n.tsx`
- [ ] Respects the golden rule — data flows one way (`Hooks → /api/ingest → SQLite → UI`); no widget writes to the database

## Screenshots / notes

<!-- For UI changes, add before/after screenshots. -->
