### PR TITLE
Fix 11 CodeQL high-severity security alerts

### DIFF
--- a/scripts/gallery.mjs
+++ b/scripts/gallery.mjs
@@ -51,6 +51,12 @@ function serve() {
         return;
       }
       let fp = path.join(ROOT, decoded);
+      // Path-traversal guard: the resolved target must stay inside ROOT.
+      if (fp !== ROOT && !fp.startsWith(ROOT + path.sep)) {
+        res.writeHead(403);
+        res.end("403");
+        return;
+      }
       try {
         if (fp.endsWith("/") || fs.statSync(fp).isDirectory()) fp = path.join(fp, "index.html");
       } catch {

--- a/scripts/seed-demo.mjs
+++ b/scripts/seed-demo.mjs
@@ -4,6 +4,8 @@
 //
 //   npm run seed
 
+import { randomBytes } from "node:crypto";
+
 const PORT = process.env.MC_PORT || 3000;
 const TOKEN = process.env.MC_HOOK_TOKEN || "";
 const BASE = `http://127.0.0.1:${PORT}/api/ingest`;
@@ -22,7 +24,7 @@ async function post(event, payload) {
 }
 
 function id() {
-  return "demo-" + Math.random().toString(36).slice(2, 10);
+  return "demo-" + randomBytes(6).toString("hex");
 }
 
 async function runSession({ cwd, prompt, tools, end }) {

--- a/scripts/wire-hooks.mjs
+++ b/scripts/wire-hooks.mjs
@@ -7,7 +7,7 @@
 // stdin via `--data-binary @-`; it's fire-and-forget (short timeout) so a stopped
 // dashboard never blocks Claude Code.
 
-import { readFileSync, writeFileSync, existsSync, copyFileSync, mkdirSync } from "node:fs";
+import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
 import path from "node:path";
 import os from "node:os";
 
@@ -76,14 +76,22 @@ export function wireHooks({ port = "3000", token = "", claudeDir } = {}) {
 
   let settings = {};
   let backup = null;
-  if (existsSync(settingsPath)) {
+  // Read directly and handle "missing" via ENOENT instead of an existsSync
+  // check, so there's no check-then-use race on the settings file.
+  let existing = null;
+  try {
+    existing = readFileSync(settingsPath);
+  } catch (err) {
+    if (err.code !== "ENOENT") throw err;
+  }
+  if (existing != null) {
     try {
-      settings = JSON.parse(readFileSync(settingsPath, "utf8"));
+      settings = JSON.parse(existing.toString("utf8"));
     } catch {
       throw new Error(`Could not parse ${settingsPath} — aborting to avoid clobbering it.`);
     }
     backup = settingsPath + ".bak";
-    copyFileSync(settingsPath, backup);
+    writeFileSync(backup, existing);
   }
 
   settings.hooks = settings.hooks || {};

--- a/src/lib/transcript.ts
+++ b/src/lib/transcript.ts
@@ -1,4 +1,4 @@
-import { open, readFile, stat } from "node:fs/promises";
+import { open } from "node:fs/promises";
 import { redactSecrets, redactValue } from "./prompt";
 
 // Reads Claude Code's per-session JSONL transcript and rolls up the billable token
@@ -177,11 +177,13 @@ const DEFAULT_MAX_BYTES = 8 * 1024 * 1024;
 // Read the transcript, capping at maxBytes by reading only the tail of very large
 // files (a cut first line just fails to parse and is skipped).
 export async function readTranscriptText(path: string, maxBytes = DEFAULT_MAX_BYTES): Promise<string> {
-  const st = await stat(path);
-  if (st.size <= maxBytes) return readFile(path, "utf8");
-
+  // Open once and operate on the file handle (fstat + read on the same fd) so
+  // there's no check-then-use window between sizing and reading the file.
   const fh = await open(path, "r");
   try {
+    const st = await fh.stat();
+    if (st.size <= maxBytes) return await fh.readFile("utf8");
+
     const buf = Buffer.alloc(maxBytes);
     await fh.read(buf, 0, maxBytes, st.size - maxBytes);
     return buf.toString("utf8");

--- a/src/lib/webhook.test.ts
+++ b/src/lib/webhook.test.ts
@@ -12,6 +12,13 @@ describe("webhookPayload", () => {
   it("uses Discord's content field for discord URLs", () => {
     expect(webhookPayload("https://discord.com/api/webhooks/x", "hi")).toEqual({ content: "hi" });
     expect(webhookPayload("https://discordapp.com/api/webhooks/x", "hi")).toEqual({ content: "hi" });
+    expect(webhookPayload("https://canary.discord.com/api/webhooks/x", "hi")).toEqual({ content: "hi" });
+  });
+
+  it("does not treat look-alike hosts as Discord (anchored host match)", () => {
+    expect(webhookPayload("https://discord.com.evil.example/x", "hi")).toEqual({ text: "hi" });
+    expect(webhookPayload("https://evil.example/discord.com", "hi")).toEqual({ text: "hi" });
+    expect(webhookPayload("not-a-url", "hi")).toEqual({ text: "hi" });
   });
 });
 

--- a/src/lib/webhook.ts
+++ b/src/lib/webhook.ts
@@ -13,7 +13,16 @@ export interface WebhookConfig {
 // Slack expects { text }, Discord expects { content }. Pick by URL host so a
 // single config field works for either.
 export function webhookPayload(url: string, message: string): Record<string, string> {
-  return /discord(app)?\.com/i.test(url) ? { content: message } : { text: message };
+  let host = "";
+  try {
+    host = new URL(url).hostname.toLowerCase();
+  } catch {
+    /* not a parseable URL — fall back to the Slack shape */
+  }
+  // Anchored on the host so e.g. "discord.com.evil.example" can't masquerade as
+  // Discord; still allows subdomains like canary.discord.com.
+  const isDiscord = /^(.+\.)?discord(app)?\.com$/.test(host);
+  return isDiscord ? { content: message } : { text: message };
 }
 
 // Loopback / link-local / private-range hosts. We refuse to POST alerts to these


### PR DESCRIPTION
## Summary

Resolves all 11 open CodeQL **High** findings from the Security tab.

| # | Alert | File | Fix |
|---|-------|------|-----|
| 5, 6 | Insecure randomness | `scripts/seed-demo.mjs` | Demo session ids now come from `crypto.randomBytes` instead of `Math.random()` |
| 1–4 | Uncontrolled data used in path expression | `scripts/gallery.mjs` | Added a path-traversal guard: the resolved target must stay inside `ROOT`, otherwise `403` |
| 10 | Missing regular expression anchor | `src/lib/webhook.ts` | Discord detection now parses the URL and matches an **anchored** hostname (`^(.+\.)?discord(app)?\.com$`), so `discord.com.evil.example` can't masquerade. Subdomains like `canary.discord.com` still match |
| 7–9 | Potential file system race condition | `src/lib/transcript.ts`, `scripts/wire-hooks.mjs` | `transcript.ts`: `stat`+`read` now operate on a single open file handle (fstat on the fd) — no path-based check-then-use. `wire-hooks.mjs`: read with ENOENT handling instead of `existsSync`, back up from the already-read bytes |

No behavioural change for valid inputs — only the unsafe code paths are tightened.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm test` — 543 tests pass (added 2 cases for the anchored Discord-host match, incl. look-alike + non-URL inputs)
- [x] `npm run build` — succeeds

https://claude.ai/code/session_01KVncw7hFMGnB7fuZPqQ2N9

---
_Generated by [Claude Code](https://claude.ai/code/session_01KVncw7hFMGnB7fuZPqQ2N9)_