### PR TITLE
fix(gallery): re-validate resolved paths before every fs access

### DIFF
--- a/scripts/gallery.mjs
+++ b/scripts/gallery.mjs
@@ -37,6 +37,16 @@ const TYPES = {
   ".txt": "text/plain", ".ico": "image/x-icon", ".webmanifest": "application/manifest+json",
 };
 
+// Resolve a candidate path and confine it to ROOT. Returns the normalized
+// absolute path only when it stays inside the served directory, otherwise
+// null. Every filesystem access below must go through this so the value
+// reaching each `fs.*` sink has been re-validated against the root.
+function confineToRoot(candidate) {
+  const resolved = path.resolve(candidate);
+  if (resolved !== ROOT && !resolved.startsWith(ROOT + path.sep)) return null;
+  return resolved;
+}
+
 function serve() {
   return http
     .createServer((req, res) => {
@@ -50,20 +60,33 @@ function serve() {
         res.end("400");
         return;
       }
-      let fp = path.join(ROOT, decoded);
-      // Path-traversal guard: the resolved target must stay inside ROOT.
-      if (fp !== ROOT && !fp.startsWith(ROOT + path.sep)) {
+      const endsWithSep = decoded.endsWith("/");
+      let fp = confineToRoot(path.join(ROOT, decoded));
+      if (!fp) {
         res.writeHead(403);
         res.end("403");
         return;
       }
       try {
-        if (fp.endsWith("/") || fs.statSync(fp).isDirectory()) fp = path.join(fp, "index.html");
+        if (endsWithSep || fs.statSync(fp).isDirectory()) fp = confineToRoot(path.join(fp, "index.html"));
       } catch {
         /* fall through */
       }
+      if (!fp) {
+        res.writeHead(403);
+        res.end("403");
+        return;
+      }
       try {
-        if (!fs.existsSync(fp) && fs.existsSync(fp + ".html")) fp += ".html";
+        if (!fs.existsSync(fp)) {
+          const withHtml = confineToRoot(fp + ".html");
+          if (!withHtml || !fs.existsSync(withHtml)) {
+            res.writeHead(404);
+            res.end("404");
+            return;
+          }
+          fp = withHtml;
+        }
         const buf = fs.readFileSync(fp);
         res.writeHead(200, { "content-type": TYPES[path.extname(fp)] || "application/octet-stream" });
         res.end(buf);


### PR DESCRIPTION
## Summary

Resolves the four CodeQL **"Uncontrolled data used in path expression"** (High) alerts (#1–#4) in `scripts/gallery.mjs`.

The script runs a small static-file server for the screenshot gallery. The request URL flows into `fs.statSync` (:61), `fs.existsSync` (:66) and `fs.readFileSync` (:67). A traversal guard existed, but it ran *before* `fp` was reassigned — first via `path.join(fp, "index.html")` for directories, then via `fp += ".html"` — so the paths that actually reached the `fs.*` sinks were never re-validated against the served root. CodeQL therefore (correctly) did not treat the guard as a barrier for those sinks.

## Change

- Add a `confineToRoot(candidate)` helper that `path.resolve()`s the candidate and returns it only when it stays inside `ROOT`, otherwise `null`.
- Route **every** filesystem access through it, so each `fs.*` call receives a freshly contained path:
  - initial request path → 403 if it escapes
  - directory `index.html` join → re-validated → 403 if it escapes
  - `.html` fallback → re-validated → 404 if missing or escaping
- Directory detection now also honors a trailing-slash request (`endsWithSep`) computed from the decoded URL.

Serving behavior is unchanged for legitimate requests; traversal attempts (`/../../etc/passwd`, encoded `..%2f..%2f…`) are blocked. Verified the containment logic against both legitimate and malicious inputs, and `node --check` passes.

https://claude.ai/code/session_01VHfyBQhS7TFw8drzdT7oPb

---
_Generated by [Claude Code](https://claude.ai/code/session_01VHfyBQhS7TFw8drzdT7oPb)_